### PR TITLE
Ux refinements

### DIFF
--- a/lib/js_service_encointer/src/service/encointer.js
+++ b/lib/js_service_encointer/src/service/encointer.js
@@ -1,4 +1,4 @@
-import { assert, u8aToHex } from '@polkadot/util';
+import { assert, u8aToHex, hexToU8a} from '@polkadot/util';
 import BN from 'bn.js';
 import { cryptoWaitReady, encodeAddress } from '@polkadot/util-crypto';
 import { createType } from '@polkadot/types';
@@ -51,7 +51,8 @@ export async function subscribeCurrentPhase (msgChannel) {
 
 export async function getCurrencyIdentifiers () {
   const cids = await api.query.encointerCurrencies.currencyIdentifiers();
-  // cids.map((cid) => bs58.decode(cid));
+  send('log', `Got Cids Raw: ${cids}`);
+  // const cidsBase58 = cids.map((cid) => bs58.encode(hexToU8a(cid.toString())));
   return {
     cids
   };

--- a/lib/store/settings.dart
+++ b/lib/store/settings.dart
@@ -1,6 +1,5 @@
-import 'package:mobx/mobx.dart';
-
 import 'package:json_annotation/json_annotation.dart';
+import 'package:mobx/mobx.dart';
 import 'package:polka_wallet/common/consts/settings.dart';
 import 'package:polka_wallet/page/profile/settings/ss58PrefixListPage.dart';
 import 'package:polka_wallet/store/account/types/accountData.dart';
@@ -178,7 +177,7 @@ abstract class _SettingsStore with Store {
     Map<String, dynamic> value =
         await rootStore.localStorage.getObject(localStorageEndpointKey);
     if (value == null) {
-      endpoint = networkEndpointKusama;
+      endpoint = networkEndpointEncointerGesell;
     } else {
       endpoint = EndpointData.fromJson(value);
     }

--- a/lib/utils/format.dart
+++ b/lib/utils/format.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
 import 'dart:math';
+import 'dart:typed_data';
 
+import 'package:base58check/base58.dart';
+import 'package:base58check/base58check.dart';
 import 'package:convert/convert.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
@@ -26,7 +29,10 @@ class Fmt {
   }
 
   static String currencyIdentifier(String cid, {int pad = 8}) {
-    return address(cid, pad: pad);
+    List<int> cidBytes = hexToBytes(cid);
+    Base58Codec codec = Base58Codec(Base58CheckCodec.BITCOIN_ALPHABET);
+    var cidBase58 = codec.encode(cidBytes);
+    return address(cidBase58, pad: pad);
   }
 
   /// number transform 1:
@@ -314,5 +320,22 @@ class Fmt {
 
   static String accountName(BuildContext context, AccountData acc) {
     return '${acc.name ?? ''}${(acc.observation ?? false) ? ' (${I18n.of(context).account['observe']})' : ''}';
+  }
+
+  static List<int> hexToBytes(String hex) {
+    const String _BYTE_ALPHABET = "0123456789abcdef";
+
+    hex = hex.replaceAll(" ", "");
+    hex = hex.replaceAll("0x", "");
+    hex = hex.toLowerCase();
+    if (hex.length % 2 != 0) hex = "0" + hex;
+    Uint8List result = new Uint8List(hex.length ~/ 2);
+    for (int i = 0; i < result.length; i++) {
+      int value = (_BYTE_ALPHABET.indexOf(hex[i * 2]) << 4) //= byte[0] * 16
+          +
+          _BYTE_ALPHABET.indexOf(hex[i * 2 + 1]);
+      result[i] = value;
+    }
+    return result;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.2"
+  base58check:
+    dependency: "direct main"
+    description:
+      name: base58check
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_downloader: ^1.4.4
   path_provider:
   device_info: ^0.4.2
+  base58check: ^1.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/test/utils/format_test.dart
+++ b/test/utils/format_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:polka_wallet/utils/format.dart';
+
+void main() {
+  group('Fmt', () {
+    test('formats cid properly', () {
+      expect(
+          'HKKAHQhLbLy8b84u1UjnHX9Pqk4FXebzKgtqSt8EKsES',
+          Fmt.currencyIdentifier(
+              '0xf26bfaa0feee0968ec0637e1933e64cd1947294d3b667d43b76b3915fc330b53',
+              pad: 46));
+    });
+  });
+}


### PR DESCRIPTION
* Change default network: To Encointer Testnet Gesell. Closes #43. Note you can clear the App cache with: adb shell pm clear org.encointer.wallet
* Display currency identifier as base58. I chose to handle the Cid in the background still as hex. Only the formatting method was adjusted. Closes #19 