### PR TITLE
Remove hardcode password in meetup

### DIFF
--- a/lib/page-encointer/meetup/MeetupPage.dart
+++ b/lib/page-encointer/meetup/MeetupPage.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:encointer_wallet/common/components/passwordInputDialog.dart';
 import 'package:encointer_wallet/common/components/roundedButton.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/attestationState.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 import 'attestation/attestationCard.dart';
 
@@ -24,7 +25,32 @@ class _MeetupPageState extends State<MeetupPage> {
 
   final AppStore store;
   var _amountAttendees;
+  String pwd;
   bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _showPasswordDialog(context);
+    });
+  }
+
+  Future<void> _showPasswordDialog(BuildContext context) async {
+    showCupertinoDialog(
+      context: context,
+      builder: (_) {
+        return PasswordInputDialog(
+          title: Text(I18n.of(context).home['unlock']),
+          account: store.account.currentAccount,
+          onOk: (password) {
+            pwd = password;
+            // Navigator.of(context).pop();
+          },
+        );
+      },
+    );
+  }
 
   List<Widget> _buildAttestationCardList(String claim) {
     return store.encointer.attestations
@@ -39,12 +65,11 @@ class _MeetupPageState extends State<MeetupPage> {
         .toList();
   }
 
-
   void _initMeetup() async {
     print("creating my claim with vote $_amountAttendees");
     webApi.encointer.createClaimOfAttendance(_amountAttendees);
     var claimHex = await webApi.encointer.encodeClaimOfAttendance();
-    if ((store.encointer.attestations == null)|(store.encointer.attestations.isEmpty)) {
+    if ((store.encointer.attestations == null) || (store.encointer.attestations.isEmpty)) {
       store.encointer.attestations = _buildAttestationStateMap(store.encointer.meetupRegistry);
     }
     setState(() {
@@ -74,15 +99,16 @@ class _MeetupPageState extends State<MeetupPage> {
     final Map dic = I18n.of(context).encointer;
 
     return Scaffold(
-        appBar: AppBar(
-          title: Text(dic['ceremony']),
-          centerTitle: true,
-        ),
-        backgroundColor: Theme.of(context).canvasColor,
-        body: SafeArea(
-          child: _isLoading
-              ? Center(child: CupertinoActivityIndicator())
-              : Column(children: <Widget>[
+      appBar: AppBar(
+        title: Text(dic['ceremony']),
+        centerTitle: true,
+      ),
+      backgroundColor: Theme.of(context).canvasColor,
+      body: SafeArea(
+        child: _isLoading
+            ? Center(child: CupertinoActivityIndicator())
+            : Column(
+                children: <Widget>[
                   Padding(
                     padding: EdgeInsets.all(16),
                     child: Row(
@@ -122,7 +148,9 @@ class _MeetupPageState extends State<MeetupPage> {
                   RoundedButton(
                       text: dic['meetup.complete'],
                       onPressed: () => Navigator.popUntil(context, ModalRoute.withName('/')))
-                ]),
-        ));
+                ],
+              ),
+      ),
+    );
   }
 }

--- a/lib/page-encointer/meetup/attestation/attestationCard.dart
+++ b/lib/page-encointer/meetup/attestation/attestationCard.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:encointer_wallet/common/components/roundedButton.dart';
 import 'package:encointer_wallet/common/components/roundedCard.dart';
 import 'package:encointer_wallet/page-encointer/meetup/attestation/components/stateMachinePartyA.dart';
@@ -9,12 +6,16 @@ import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/attestationState.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 
 class AttestationCard extends StatefulWidget {
   AttestationCard(
     this.store, {
     this.myMeetupRegistryIndex,
     this.otherMeetupRegistryIndex,
+    this.accountPassword,
   });
 
   static const String route = '/encointer/meetup/';
@@ -22,6 +23,7 @@ class AttestationCard extends StatefulWidget {
 
   final int myMeetupRegistryIndex;
   final int otherMeetupRegistryIndex;
+  final String accountPassword;
 
   @override
   _AttestationCardState createState() => _AttestationCardState(store);
@@ -46,6 +48,7 @@ class _AttestationCardState extends State<AttestationCard> {
             store,
             otherMeetupRegistryIndex: widget.otherMeetupRegistryIndex,
             myMeetupRegistryIndex: widget.myMeetupRegistryIndex,
+            accountPassword: widget.accountPassword,
           ),
         ),
       );
@@ -56,6 +59,7 @@ class _AttestationCardState extends State<AttestationCard> {
             store,
             otherMeetupRegistryIndex: widget.otherMeetupRegistryIndex,
             myMeetupRegistryIndex: widget.myMeetupRegistryIndex,
+            accountPassword: widget.accountPassword,
           ),
         ),
       );

--- a/lib/page-encointer/meetup/attestation/components/stateMachinePartyA.dart
+++ b/lib/page-encointer/meetup/attestation/components/stateMachinePartyA.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:encointer_wallet/common/components/activityIndicator.dart';
 import 'package:encointer_wallet/page-encointer/meetup/attestation/components/qrCode.dart';
 import 'package:encointer_wallet/page-encointer/meetup/attestation/components/scanQrCode.dart';
@@ -9,17 +7,22 @@ import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/attestation.dart';
 import 'package:encointer_wallet/store/encointer/types/attestationState.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 
 class StateMachinePartyA extends StatefulWidget {
   StateMachinePartyA(
     this.store, {
     this.otherMeetupRegistryIndex,
     this.myMeetupRegistryIndex,
+    this.accountPassword,
   }) : super();
 
   final AppStore store;
   final int otherMeetupRegistryIndex;
   final int myMeetupRegistryIndex;
+  final String accountPassword;
+
   @override
   _StateMachinePartyAState createState() {
     return _StateMachinePartyAState(store);
@@ -92,7 +95,7 @@ class _StateMachinePartyAState extends State<StateMachinePartyA> {
         opaque: false,
         pageBuilder: (BuildContext context, _, __) => ActivityIndicator(
           title: "Attesting ClaimB",
-          future: webApi.encointer.attestClaimOfAttendance(claimBhex, "123qwe"),
+          future: webApi.encointer.attestClaimOfAttendance(claimBhex, widget.accountPassword),
         ),
       ),
     );

--- a/lib/page-encointer/meetup/attestation/components/stateMachinePartyB.dart
+++ b/lib/page-encointer/meetup/attestation/components/stateMachinePartyB.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:encointer_wallet/common/components/activityIndicator.dart';
 import 'package:encointer_wallet/page-encointer/meetup/attestation/components/qrCode.dart';
 import 'package:encointer_wallet/page-encointer/meetup/attestation/components/scanQrCode.dart';
@@ -10,6 +7,9 @@ import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/attestation.dart';
 import 'package:encointer_wallet/store/encointer/types/attestationState.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 
 class StateMachinePartyB extends StatefulWidget {
   StateMachinePartyB(
@@ -17,12 +17,14 @@ class StateMachinePartyB extends StatefulWidget {
     this.otherMeetupRegistryIndex,
     this.myMeetupRegistryIndex,
     this.initialAttestationStep,
+    this.accountPassword,
   }) : super();
 
   final AppStore store;
   final int otherMeetupRegistryIndex;
   final int myMeetupRegistryIndex;
   final CurrentAttestationStep initialAttestationStep;
+  final String accountPassword;
 
   @override
   _StateMachinePartyBState createState() {
@@ -71,7 +73,7 @@ class _StateMachinePartyBState extends State<StateMachinePartyB> {
         pageBuilder: (BuildContext context, _, __) {
           return ActivityIndicator(
             title: "Attesting ClaimA",
-            future: webApi.encointer.attestClaimOfAttendance(claimAhex, "123qwe"),
+            future: webApi.encointer.attestClaimOfAttendance(claimAhex, widget.accountPassword),
           );
         },
       ),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -384,7 +384,7 @@ class _AssetsState extends State<Assets> {
             ],
           );
         }),
-        Expanded(child: _communityCurrencyAssets(context, store)),
+        _communityCurrencyAssets(context, store),
       ],
     );
   }


### PR DESCRIPTION
MeetupPage: Remove hardcoded password. Show PasswordInputDialog at the start of the meetup (after amount of attendees has been confirmed) and cache it for the time of the meetup. Fixes: #68 

Tested with a successful meetup.