### PR TITLE
Fix bug: False positive repeated JS calls.

### DIFF
--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -149,7 +149,7 @@ class Api {
     if (!allowRepeat) {
       for (String i in _msgCompleters.keys) {
         String call = code.split('(')[0];
-        if (i.contains(call)) {
+        if (i.compareTo(call) == 0) {
           print('request $call loading');
           return _msgCompleters[i].future;
         }


### PR DESCRIPTION
Was due to erroneous String comparison, which gave repeated == true if the call to be dispatched contained a substring of the already registered call in the msgCompleter.

e.g. repeated == true for `account.gen` if `account.genIcons` has been registered before.

This is the underlying issue of #90. Fixes #90 