### PR TITLE
Bugfix/89 97

### DIFF
--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -50,6 +50,8 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
       derivePath: _derivePath,
     );
 
+    Navigator.of(context).pop();
+
     /// check if account duplicate
     if (acc != null) {
       if (acc['error'] != null) {
@@ -67,6 +69,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
                     onPressed: () {
                       setState(() {
                         _step = 0;
+                        _submitting = false;
                       });
                       Navigator.of(context).pop();
                     },
@@ -79,6 +82,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
           UI.alertWASM(context, () {
             setState(() {
               _step = 0;
+              _submitting = false;
             });
           });
         }
@@ -88,6 +92,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
       return;
     }
 
+    // account == null
     showCupertinoDialog(
       context: context,
       builder: (BuildContext context) {
@@ -98,17 +103,17 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
           actions: <Widget>[
             CupertinoButton(
               child: Text(I18n.of(context).home['cancel']),
-              onPressed: () => Navigator.of(context).pop(),
+              onPressed: () {
+                setState(() {
+                  _submitting = false;
+                });
+                Navigator.of(context).pop();
+              },
             ),
           ],
         );
       },
     );
-
-    Navigator.of(context).pop();
-    setState(() {
-      _submitting = false;
-    });
   }
 
   Future<void> _checkAccountDuplicate(Map<String, dynamic> acc) async {
@@ -126,7 +131,12 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
               actions: <Widget>[
                 CupertinoButton(
                   child: Text(I18n.of(context).home['cancel']),
-                  onPressed: () => Navigator.of(context).pop(),
+                  onPressed: () {
+                    setState(() {
+                      _submitting = false;
+                    });
+                    Navigator.of(context).pop();
+                  },
                 ),
                 CupertinoButton(
                   child: Text(I18n.of(context).home['ok']),

--- a/lib/page/profile/account/changePasswordPage.dart
+++ b/lib/page/profile/account/changePasswordPage.dart
@@ -69,7 +69,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
         // use local name, not webApi returned name
         Map<String, dynamic> localAcc = AccountData.toJson(store.currentAccount);
 
-        // make metadata the same from the polkadot-js/api
+        // make metadata the same as the polkadot-js/api's
         acc['meta']['name'] = localAcc['name'];
         store.updateAccount(acc);
         // update encrypted seed after password updated

--- a/lib/page/profile/account/changePasswordPage.dart
+++ b/lib/page/profile/account/changePasswordPage.dart
@@ -68,7 +68,9 @@ class _ChangePassword extends State<ChangePasswordPage> {
             .evalJavascript('account.changePassword("${store.currentAccount.pubKey}", "$passOld", "$passNew")');
         // use local name, not webApi returned name
         Map<String, dynamic> localAcc = AccountData.toJson(store.currentAccount);
-        acc['meta']['name'] = localAcc['meta']['name'];
+
+        // make metadata the same from the polkadot-js/api
+        acc['meta']['name'] = localAcc['name'];
         store.updateAccount(acc);
         // update encrypted seed after password updated
         store.updateSeed(store.currentAccount.pubKey, _passOldCtrl.text, _passCtrl.text);


### PR DESCRIPTION
* Fix #89 
* Fix #97 : Tested scenarios with account import:
** wrong mnemonic -> goes back to first page where the seed is entered
** duplicate account  -> goes back to page where the pin is entered if the user chose to not overwrite the existing account.
** duplicate account  ->  goes to encointerHomePage without intermediately falling back to the AccountCreate/Import page if the user decided to overwrite the existing account.
** everything correct -> goes to encointerHomePage without intermediately falling back to the AccountCreate/Import page.