### PR TITLE
Fix warnings and hints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12'
+    - run: dartanalyzer --fatal-warnings .
     - run: |
         pushd ./lib/js_service_encointer
         yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - run: flutter analyze  --fatal-warnings
     - run: |
         pushd ./lib/js_service_encointer
         yarn install
         yarn run build
         popd
+    - run: flutter analyze  --fatal-warnings
     - run: flutter pub get
     - run: flutter test
     - run: flutter build apk --flavor fdroid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12'
-    - run: dartanalyzer --fatal-warnings .
+    - run: flutter analyze  --fatal-warnings
     - run: |
         pushd ./lib/js_service_encointer
         yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 os: osx
 osx_image: xcode12
 language: generic
-dart_task:
-  # fatal warnings, only analyze the lib directory
-  - dartanalyzer: --fatal-warnings lib
 before_script:
 - brew update
 - brew install --HEAD usbmuxd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os: osx
 osx_image: xcode12
 language: generic
+dart_task:
+  # fatal warnings, only analyze the lib directory
+  - dartanalyzer: --fatal-warnings lib
 before_script:
 - brew update
 - brew install --HEAD usbmuxd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,48 @@
 os: osx
 osx_image: xcode12
 language: generic
-
-jobs:
-  include:
-    - stage: analyze
-      script:
-        - dartanalyzer --fatal-warnings .
-    - stage: setup
-      script:
-        - brew update
-        - brew install --HEAD usbmuxd
-        - brew unlink usbmuxd
-        - brew link usbmuxd
-        - brew install ideviceinstaller
-        - brew install ios-deploy
-        - git clone https://github.com/flutter/flutter.git -b beta --depth 1
-        - curl -Lo node.tar.xz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz
-        - echo "b8dc634798ee783482c2ae1755bd7dff09d83fa7bb037cdc370b601d0a5e5cbb node.tar.xz"
-          | sha256sum -c -
-        - tar -vxf node.tar.xz
-        - curl -Lo yarn.tar.gz https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz
-        - echo "bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58  yarn.tar.gz"
-          | sha256sum -c -
-        - tar zvxf yarn.tar.gz
-        - export PATH=$PATH:$PWD/node-v12.18.2-linux-x64/bin:$PWD/yarn-v1.22.4/bin
-        - pushd ./lib/js_service_encointer
-        - yarn install
-        - yarn run build
-        - popd
-    - stage: build_ios
-        - flutter/bin/flutter build ios --debug --no-codesign
-    - stage: deploy
-      before_deploy:
-        - pushd build/ios/iphoneos
-        - mkdir Payload
-        - cd Payload
-        - ln -s ../Runner.app
-        - cd ..
-        - zip -r app.ipa Payload
-        - popd
-      deploy:
-        provider: releases
-        api_key:
-          secure: Iz2UqvsL8efZNLRZvLnQj8TwZNq0KYY5lrWhsZBboOORQ4y+tjtTiHo5OSHrJh2YsDZ+FUWfx1MQLlR5KjDd1fs14gEIVvkGTfurmiys3QSWXcn7VWphJlWDXanOCZxArITXV35iVrrNSCdnuFKzWgkfsXzFHKM8tEUHU3Vz2Po2VEM20VfjkBAWxBKAPjvVDQ4SrDpDCcW4hbUhZ932AixS1qaHs+aDn+no/HlkjwAF/Fj9GrlK9U/Mfdaym/ZzChCWluOWiHvN1G9PkG/MvlrJzEp5/zFIaxUwzNLynbDgPDd/8mRBq02RIW1KS3KoNN8kK2xyHI+wdl5BLY5OQkMZ56vJaApltIASa7LrYMSktQSLPaJhcvf78thlh3vN1BpfDPr8EEfcoDA8guV9ZrJqNZO+GCy/i1Fh/5xkIkcZVvy3C1KoKvdU5J2AE9+hqz53Rkx55vWD2ipWiv3+cd9APO+OtCuZiVonGPDqLLyJoRdPQVw7vsVivxL2iTMOFLIwyBZViQyibunZFsxfKs00PwimHYcSbFwkszWttxbMnqj32yNbG2Wu5rIkwvQSSvpxXWC2orDj867IX7VOYystYn9hb46dLkZc18nRPXVlM8/+CFMRm58+QXP/LeFvbS9MdncQ9H278TZr/9i4cji8k9zYenNHeh7Wvu2DpIM=
-        file: build/ios/iphoneos/app.ipa
-        on:
-          repo: encointer/encointer-wallet-flutter
-        skip_cleanup: true
-
-# specify the ordering of stages
-stages:
-  - analyze
-  - setup
-  - deploy
-
+dart_task:
+  # fatal warnings, only analyze the lib directory
+  - dartanalyzer: --fatal-warnings lib
+before_script:
+- brew update
+- brew install --HEAD usbmuxd
+- brew unlink usbmuxd
+- brew link usbmuxd
+- brew install ideviceinstaller
+- brew install ios-deploy
+- git clone https://github.com/flutter/flutter.git -b beta --depth 1
+- curl -Lo node.tar.xz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz
+- echo "b8dc634798ee783482c2ae1755bd7dff09d83fa7bb037cdc370b601d0a5e5cbb node.tar.xz"
+ | sha256sum -c -
+- tar -vxf node.tar.xz
+- curl -Lo yarn.tar.gz https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz
+- echo "bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58  yarn.tar.gz"
+ | sha256sum -c -
+- tar zvxf yarn.tar.gz
+- export PATH=$PATH:$PWD/node-v12.18.2-linux-x64/bin:$PWD/yarn-v1.22.4/bin
+- pushd ./lib/js_service_encointer
+- yarn install
+- yarn run build
+- popd
+script:
+- flutter/bin/flutter build ios --debug --no-codesign
 cache:
   directories:
   - "$HOME/.pub-cache"
+before_deploy:
+- pushd build/ios/iphoneos
+- mkdir Payload
+- cd Payload
+- ln -s ../Runner.app
+- cd ..
+- zip -r app.ipa Payload
+- popd
+deploy:
+  provider: releases
+  api_key:
+    secure: Iz2UqvsL8efZNLRZvLnQj8TwZNq0KYY5lrWhsZBboOORQ4y+tjtTiHo5OSHrJh2YsDZ+FUWfx1MQLlR5KjDd1fs14gEIVvkGTfurmiys3QSWXcn7VWphJlWDXanOCZxArITXV35iVrrNSCdnuFKzWgkfsXzFHKM8tEUHU3Vz2Po2VEM20VfjkBAWxBKAPjvVDQ4SrDpDCcW4hbUhZ932AixS1qaHs+aDn+no/HlkjwAF/Fj9GrlK9U/Mfdaym/ZzChCWluOWiHvN1G9PkG/MvlrJzEp5/zFIaxUwzNLynbDgPDd/8mRBq02RIW1KS3KoNN8kK2xyHI+wdl5BLY5OQkMZ56vJaApltIASa7LrYMSktQSLPaJhcvf78thlh3vN1BpfDPr8EEfcoDA8guV9ZrJqNZO+GCy/i1Fh/5xkIkcZVvy3C1KoKvdU5J2AE9+hqz53Rkx55vWD2ipWiv3+cd9APO+OtCuZiVonGPDqLLyJoRdPQVw7vsVivxL2iTMOFLIwyBZViQyibunZFsxfKs00PwimHYcSbFwkszWttxbMnqj32yNbG2Wu5rIkwvQSSvpxXWC2orDj867IX7VOYystYn9hb46dLkZc18nRPXVlM8/+CFMRm58+QXP/LeFvbS9MdncQ9H278TZr/9i4cji8k9zYenNHeh7Wvu2DpIM=
+  file: build/ios/iphoneos/app.ipa
+  on:
+    repo: encointer/encointer-wallet-flutter
+  skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,60 @@
 os: osx
 osx_image: xcode12
 language: generic
-dart_task:
-  # fatal warnings, only analyze the lib directory
-  - dartanalyzer: --fatal-warnings lib
-before_script:
-- brew update
-- brew install --HEAD usbmuxd
-- brew unlink usbmuxd
-- brew link usbmuxd
-- brew install ideviceinstaller
-- brew install ios-deploy
-- git clone https://github.com/flutter/flutter.git -b beta --depth 1
-- curl -Lo node.tar.xz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz
-- echo "b8dc634798ee783482c2ae1755bd7dff09d83fa7bb037cdc370b601d0a5e5cbb node.tar.xz"
- | sha256sum -c -
-- tar -vxf node.tar.xz
-- curl -Lo yarn.tar.gz https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz
-- echo "bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58  yarn.tar.gz"
- | sha256sum -c -
-- tar zvxf yarn.tar.gz
-- export PATH=$PATH:$PWD/node-v12.18.2-linux-x64/bin:$PWD/yarn-v1.22.4/bin
-- pushd ./lib/js_service_encointer
-- yarn install
-- yarn run build
-- popd
-script:
-- flutter/bin/flutter build ios --debug --no-codesign
+
+jobs:
+  include:
+    - stage: analyze
+      script:
+        - dartanalyzer --fatal-warnings .
+    - stage: setup
+      script:
+        - brew update
+        - brew install --HEAD usbmuxd
+        - brew unlink usbmuxd
+        - brew link usbmuxd
+        - brew install ideviceinstaller
+        - brew install ios-deploy
+        - git clone https://github.com/flutter/flutter.git -b beta --depth 1
+        - curl -Lo node.tar.xz https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-x64.tar.xz
+        - echo "b8dc634798ee783482c2ae1755bd7dff09d83fa7bb037cdc370b601d0a5e5cbb node.tar.xz"
+          | sha256sum -c -
+        - tar -vxf node.tar.xz
+        - curl -Lo yarn.tar.gz https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz
+        - echo "bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58  yarn.tar.gz"
+          | sha256sum -c -
+        - tar zvxf yarn.tar.gz
+        - export PATH=$PATH:$PWD/node-v12.18.2-linux-x64/bin:$PWD/yarn-v1.22.4/bin
+        - pushd ./lib/js_service_encointer
+        - yarn install
+        - yarn run build
+        - popd
+    - stage: build_ios
+        - flutter/bin/flutter build ios --debug --no-codesign
+    - stage: deploy
+      before_deploy:
+        - pushd build/ios/iphoneos
+        - mkdir Payload
+        - cd Payload
+        - ln -s ../Runner.app
+        - cd ..
+        - zip -r app.ipa Payload
+        - popd
+      deploy:
+        provider: releases
+        api_key:
+          secure: Iz2UqvsL8efZNLRZvLnQj8TwZNq0KYY5lrWhsZBboOORQ4y+tjtTiHo5OSHrJh2YsDZ+FUWfx1MQLlR5KjDd1fs14gEIVvkGTfurmiys3QSWXcn7VWphJlWDXanOCZxArITXV35iVrrNSCdnuFKzWgkfsXzFHKM8tEUHU3Vz2Po2VEM20VfjkBAWxBKAPjvVDQ4SrDpDCcW4hbUhZ932AixS1qaHs+aDn+no/HlkjwAF/Fj9GrlK9U/Mfdaym/ZzChCWluOWiHvN1G9PkG/MvlrJzEp5/zFIaxUwzNLynbDgPDd/8mRBq02RIW1KS3KoNN8kK2xyHI+wdl5BLY5OQkMZ56vJaApltIASa7LrYMSktQSLPaJhcvf78thlh3vN1BpfDPr8EEfcoDA8guV9ZrJqNZO+GCy/i1Fh/5xkIkcZVvy3C1KoKvdU5J2AE9+hqz53Rkx55vWD2ipWiv3+cd9APO+OtCuZiVonGPDqLLyJoRdPQVw7vsVivxL2iTMOFLIwyBZViQyibunZFsxfKs00PwimHYcSbFwkszWttxbMnqj32yNbG2Wu5rIkwvQSSvpxXWC2orDj867IX7VOYystYn9hb46dLkZc18nRPXVlM8/+CFMRm58+QXP/LeFvbS9MdncQ9H278TZr/9i4cji8k9zYenNHeh7Wvu2DpIM=
+        file: build/ios/iphoneos/app.ipa
+        on:
+          repo: encointer/encointer-wallet-flutter
+        skip_cleanup: true
+
+# specify the ordering of stages
+stages:
+  - analyze
+  - setup
+  - deploy
+
 cache:
   directories:
   - "$HOME/.pub-cache"
-before_deploy:
-- pushd build/ios/iphoneos
-- mkdir Payload
-- cd Payload
-- ln -s ../Runner.app
-- cd ..
-- zip -r app.ipa Payload
-- popd
-deploy:
-  provider: releases
-  api_key:
-    secure: Iz2UqvsL8efZNLRZvLnQj8TwZNq0KYY5lrWhsZBboOORQ4y+tjtTiHo5OSHrJh2YsDZ+FUWfx1MQLlR5KjDd1fs14gEIVvkGTfurmiys3QSWXcn7VWphJlWDXanOCZxArITXV35iVrrNSCdnuFKzWgkfsXzFHKM8tEUHU3Vz2Po2VEM20VfjkBAWxBKAPjvVDQ4SrDpDCcW4hbUhZ932AixS1qaHs+aDn+no/HlkjwAF/Fj9GrlK9U/Mfdaym/ZzChCWluOWiHvN1G9PkG/MvlrJzEp5/zFIaxUwzNLynbDgPDd/8mRBq02RIW1KS3KoNN8kK2xyHI+wdl5BLY5OQkMZ56vJaApltIASa7LrYMSktQSLPaJhcvf78thlh3vN1BpfDPr8EEfcoDA8guV9ZrJqNZO+GCy/i1Fh/5xkIkcZVvy3C1KoKvdU5J2AE9+hqz53Rkx55vWD2ipWiv3+cd9APO+OtCuZiVonGPDqLLyJoRdPQVw7vsVivxL2iTMOFLIwyBZViQyibunZFsxfKs00PwimHYcSbFwkszWttxbMnqj32yNbG2Wu5rIkwvQSSvpxXWC2orDj867IX7VOYystYn9hb46dLkZc18nRPXVlM8/+CFMRm58+QXP/LeFvbS9MdncQ9H278TZr/9i4cji8k9zYenNHeh7Wvu2DpIM=
-  file: build/ios/iphoneos/app.ipa
-  on:
-    repo: encointer/encointer-wallet-flutter
-  skip_cleanup: 'true'

--- a/lib/common/components/accountAdvanceOption.dart
+++ b/lib/common/components/accountAdvanceOption.dart
@@ -131,7 +131,7 @@ class _AccountAdvanceOption extends State<AccountAdvanceOption> {
                 padding: EdgeInsets.fromLTRB(16, 0, 16, 0),
                 child: Form(
                   key: _formKey,
-                  autovalidate: true,
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
                   child: TextFormField(
                     decoration: InputDecoration(
                       hintText: '//hard/soft///password',

--- a/lib/common/components/currencyWithIcon.dart
+++ b/lib/common/components/currencyWithIcon.dart
@@ -1,8 +1,6 @@
+import 'package:encointer_wallet/utils/format.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:encointer_wallet/config/consts.dart';
-import 'package:encointer_wallet/store/app.dart';
-import 'package:encointer_wallet/utils/format.dart';
 
 class CurrencyWithIcon extends StatelessWidget {
   CurrencyWithIcon(
@@ -19,9 +17,6 @@ class CurrencyWithIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String networkToken =
-        globalAppStore.settings.networkState.tokenSymbol;
-    final int decimals = globalAppStore.settings.networkState.tokenDecimals;
     bool hasIcon = true;
     return Row(
       mainAxisAlignment: mainAxisAlignment ?? MainAxisAlignment.start,

--- a/lib/common/components/roundedButton.dart
+++ b/lib/common/components/roundedButton.dart
@@ -34,10 +34,12 @@ class RoundedButton extends StatelessWidget {
       text ?? '',
       style: Theme.of(context).textTheme.button,
     ));
-    return RaisedButton(
-      padding: EdgeInsets.only(top: 12, bottom: 12),
-      color: color ?? Theme.of(context).primaryColor,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+    return ElevatedButton(
+      style: TextButton.styleFrom(
+        padding: EdgeInsets.only(top: 12, bottom: 12),
+        backgroundColor: color ?? Theme.of(context).primaryColor,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: row,

--- a/lib/common/components/txData.dart
+++ b/lib/common/components/txData.dart
@@ -5,6 +5,7 @@ part 'txData.g.dart';
 @JsonSerializable()
 class TxData extends _TxData {
   static TxData fromJson(Map<String, dynamic> json) => _$TxDataFromJson(json);
+  Map<String, dynamic> toJson() => _$TxDataToJson(this);
 }
 
 abstract class _TxData {

--- a/lib/page-encointer/bazaar/article/articleCard.dart
+++ b/lib/page-encointer/bazaar/article/articleCard.dart
@@ -1,22 +1,20 @@
 import 'package:flutter/material.dart';
 
 class ArticleCard extends StatelessWidget {
-  double _width;
-  double _height;
-  String title;
-  String price;
-  String dateAdded;
-  String category;
-  String description;
-  String image;
-  String location;
+  final String title;
+  final String price;
+  final String dateAdded;
+  final String category;
+  final String description;
+  final String image;
+  final String location;
 
   ArticleCard({this.title, this.price, this.dateAdded, this.category, this.description, this.image, this.location});
 
   @override
   Widget build(BuildContext context) {
-    _width = MediaQuery.of(context).size.width;
-    _height = MediaQuery.of(context).size.height;
+    double width = MediaQuery.of(context).size.width;
+    double height = MediaQuery.of(context).size.height;
     return Card(
       elevation: 3,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
@@ -31,10 +29,10 @@ class ArticleCard extends StatelessWidget {
               children: <Widget>[
                 Text(
                   title,
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: _height / 40),
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: height / 40),
                 ),
                 Container(
-                  width: _width / 3,
+                  width: width / 3,
                   padding: EdgeInsets.only(top: 5),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -66,11 +64,11 @@ class ArticleCard extends StatelessWidget {
                 ),
                 Flexible(
                   child: Container(
-                      width: _width / 2.5,
+                      width: width / 2.5,
                       child: Text(
                         description,
                         style: TextStyle(
-                          fontSize: _height / 70,
+                          fontSize: height / 70,
                         ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
@@ -82,7 +80,7 @@ class ArticleCard extends StatelessWidget {
                 ),
                 Flexible(
                   child: Container(
-                    width: _width / 2.75,
+                    width: width / 2.75,
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: <Widget>[
@@ -90,7 +88,7 @@ class ArticleCard extends StatelessWidget {
                           child: GestureDetector(
                             child: Icon(
                               Icons.favorite_border,
-                              size: _height / 30,
+                              size: height / 30,
                             ),
                             onTap: () {
                               print('Fav');
@@ -102,18 +100,18 @@ class ArticleCard extends StatelessWidget {
                           children: <Widget>[
                             Text(
                               dateAdded,
-                              style: TextStyle(fontSize: _height / 65),
+                              style: TextStyle(fontSize: height / 65),
                             ),
                             Row(
                               mainAxisSize: MainAxisSize.min,
                               children: <Widget>[
                                 Icon(
                                   Icons.location_on,
-                                  size: _height / 65,
+                                  size: height / 65,
                                 ),
                                 Text(
                                   location,
-                                  style: TextStyle(fontSize: _height / 65),
+                                  style: TextStyle(fontSize: height / 65),
                                 )
                               ],
                             ),
@@ -129,7 +127,7 @@ class ArticleCard extends StatelessWidget {
               width: 10,
             ),
             Container(
-              width: _width / 2.5,
+              width: width / 2.5,
               decoration: BoxDecoration(
                 shape: BoxShape.rectangle,
                 color: Colors.white,
@@ -139,8 +137,8 @@ class ArticleCard extends StatelessWidget {
               child: Image.asset(
                 image,
                 fit: BoxFit.cover,
-                height: _height / 4.5,
-                width: _width / 4.5,
+                height: height / 4.5,
+                width: width / 4.5,
               ),
             ),
           ],

--- a/lib/page-encointer/bazaar/bazaarEntry.dart
+++ b/lib/page-encointer/bazaar/bazaarEntry.dart
@@ -273,17 +273,8 @@ class _BazaarEntryState extends State<BazaarEntry> {
     );
   }
 
-  List<String> reverse(List<String> list) {
-    int end = list.length - 1;
-    var reversedList = new List(list.length);
-    for (int i = 0; i <= end; i++) {
-      reversedList[end - i] = list[i];
-    }
-    return reversedList.cast<String>();
-  }
-
   Widget _buildShopEntries(BuildContext context, int index, AppStore store) {
-    List<String> reversedList = reverse(store.encointer.shopRegistry);
+    List<String> reversedList = new List.from(store.encointer.shopRegistry.reversed);
     return GestureDetector(
       onTap: () {
         //TODO make clickable

--- a/lib/page-encointer/bazaar/bazaarEntry.dart
+++ b/lib/page-encointer/bazaar/bazaarEntry.dart
@@ -1,18 +1,16 @@
 import 'package:encointer_wallet/common/components/BorderedTitle.dart';
 import 'package:encointer_wallet/common/components/roundedCard.dart';
-import 'package:encointer_wallet/page-encointer/bazaar/article/articleClass.dart';
-import 'package:encointer_wallet/page-encointer/bazaar/article/articleCard.dart';
+import 'package:encointer_wallet/page-encointer/bazaar/common/communityChooserHandler.dart';
+import 'package:encointer_wallet/page-encointer/bazaar/common/menuHandler.dart';
 import 'package:encointer_wallet/page-encointer/bazaar/shop/shopCard.dart';
 import 'package:encointer_wallet/page-encointer/bazaar/shop/shopClass.dart';
 import 'package:encointer_wallet/page-encointer/bazaar/shop/shopOverviewPanel.dart';
-import 'package:encointer_wallet/page-encointer/bazaar/common/communityChooserHandler.dart';
-import 'package:encointer_wallet/page-encointer/bazaar/common/menuHandler.dart';
 import 'package:encointer_wallet/store/app.dart';
+import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:encointer_wallet/utils/format.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mobx/mobx.dart';
 
@@ -56,11 +54,10 @@ class _BazaarEntryState extends State<BazaarEntry> {
   @override
   Widget build(BuildContext context) {
     final Map<String, String> dic = I18n.of(context).bazaar;
-    Color primaryColor = Theme.of(context).primaryColor;
     Color secondaryColor = Theme.of(context).secondaryHeaderColor;
 
     // reaction necessary because shops is not an observable list (view should not change without user doing anything)
-    final refreshPageOnCidChange = reaction((_) => store.encointer.chosenCid, (_) => refreshPage());
+    //final refreshPageOnCidChange = reaction((_) => store.encointer.chosenCid, (_) => refreshPage());
 
     final List<Widget> _widgetList = <Widget>[
       homeView(context, store),
@@ -239,16 +236,14 @@ class _BazaarEntryState extends State<BazaarEntry> {
                         children: <Widget>[
                           // TODO: how to refresh automatically?
                           !reload
-                              ? FlatButton(
+                              ? TextButton(
                                   child: Text("Refresh"),
                                   onPressed: () {
                                     refreshPage();
                                   })
                               : Container(
                                   alignment: Alignment.topCenter,
-                                  child: FlatButton(
-                                    child: Text(""),
-                                  ),
+                                  child: Text(""),
                                 ),
                           Container(
                             alignment: Alignment.center,

--- a/lib/page-encointer/bazaar/common/imagePickerHandler.dart
+++ b/lib/page-encointer/bazaar/common/imagePickerHandler.dart
@@ -2,64 +2,54 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
-import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter/cupertino.dart';
 
 class ImagePickerHandler extends StatelessWidget {
-  BuildContext context;
-  File _imageFile;
-
   static final String route = '/encointer/imagePickerHandler';
 
-  Future<void> _openCamera() async {
+  Future<void> _openCamera(BuildContext context) async {
     try {
       var image = await ImagePicker().getImage(source: ImageSource.camera);
       File imageFile = File(image.path);
       // TODO: app crashes when image cropper is opened
       // File croppedImage = await _cropImage(image);
-      _setStateAndReturn(imageFile);
+      _setStateAndReturn(context, imageFile);
     } catch (e) {
       print("Image picker error " + e);
     }
   }
 
-  Future<void> _openGallery() async {
+  Future<void> _openGallery(BuildContext context) async {
     try {
       var image = await ImagePicker().getImage(source: ImageSource.gallery);
       File imageFile = File(image.path);
       // TODO: app crashes when image cropper is opened
       // File croppedImage = await _cropImage(imageFile);
-      _setStateAndReturn(imageFile);
+      _setStateAndReturn(context, imageFile);
     } catch (e) {
       print("Image picker error " + e);
     }
   }
 
-  Future<File> _cropImage(File image) async {
-    File croppedFile = await ImageCropper.cropImage(
-      sourcePath: image.path,
-      //ratioX: 1.0,
-      //ratioY: 1.0,
-      // TODO: set reasonable picture size
-      maxWidth: 512,
-      maxHeight: 512,
-    );
-    return croppedFile;
-  }
+  // Future<File> _cropImage(File image) async {
+  //   File croppedFile = await ImageCropper.cropImage(
+  //     sourcePath: image.path,
+  //     //ratioX: 1.0,
+  //     //ratioY: 1.0,
+  //     // TODO: set reasonable picture size
+  //     maxWidth: 512,
+  //     maxHeight: 512,
+  //   );
+  //   return croppedFile;
+  // }
 
-  void _setStateAndReturn(File image) {
-    _imageFile = image;
-    Navigator.pop(context, _imageFile);
-  }
-
-  void _dismiss() {
-    Navigator.pop(context, null);
+  void _setStateAndReturn(BuildContext context, File image) {
+    Navigator.pop(context, image);
   }
 
   @override
   Widget build(BuildContext context) {
-    this.context = context;
     final Map<String, String> dic = I18n.of(context).bazaar;
 
     return Scaffold(
@@ -74,17 +64,17 @@ class ImagePickerHandler extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 GestureDetector(
-                  onTap: () => _openCamera(),
+                  onTap: () => _openCamera(context),
                   child: roundedButton(dic['camera.default'], EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 0.0),
                       const Color(0xFF167F67), const Color(0xFFFFFFFF)),
                 ),
                 GestureDetector(
-                  onTap: () => _openGallery(),
+                  onTap: () => _openGallery(context),
                   child: roundedButton(dic['gallery.default'], EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 0.0),
                       const Color(0xFF167F67), const Color(0xFFFFFFFF)),
                 ),
                 GestureDetector(
-                  onTap: () => _dismiss(),
+                  onTap: () => Navigator.pop(context, null),
                   child: roundedButton(dic['cancel.default'], EdgeInsets.fromLTRB(0.0, 10.0, 0.0, 0.0),
                       const Color(0xFF167F67), const Color(0xFFFFFFFF)),
                 ),

--- a/lib/page-encointer/bazaar/shop/createShopForm.dart
+++ b/lib/page-encointer/bazaar/shop/createShopForm.dart
@@ -1,14 +1,15 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:encointer_wallet/common/components/roundedButton.dart';
+import 'package:encointer_wallet/page-encointer/bazaar/common/imagePickerHandler.dart';
+import 'package:encointer_wallet/page-encointer/bazaar/shop/shopClass.dart';
+import 'package:encointer_wallet/page/account/txConfirmPage.dart';
+import 'package:encointer_wallet/service/ipfsApi/httpApi.dart';
+import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'dart:convert';
-import 'package:encointer_wallet/page/account/txConfirmPage.dart';
-import 'package:encointer_wallet/store/app.dart';
-import 'package:encointer_wallet/service/ipfsApi/httpApi.dart';
-import 'dart:io';
-import 'package:encointer_wallet/page-encointer/bazaar/shop/shopClass.dart';
-import 'package:encointer_wallet/page-encointer/bazaar/common/imagePickerHandler.dart';
 
 class CreateShopForm extends StatefulWidget {
   CreateShopForm(this.store);
@@ -24,8 +25,6 @@ class _CreateShopForm extends State<CreateShopForm> {
   _CreateShopForm(this.store);
 
   final AppStore store;
-  static final String route = '/encointer/bazaar/createShopForm';
-
   final _formKey = GlobalKey<FormState>();
 
   final TextEditingController _nameCtrl = new TextEditingController();

--- a/lib/page-encointer/bazaar/shop/shopCard.dart
+++ b/lib/page-encointer/bazaar/shop/shopCard.dart
@@ -1,16 +1,14 @@
-import 'package:flutter/material.dart';
 import 'package:encointer_wallet/config/consts.dart';
+import 'package:flutter/material.dart';
 
 class ShopCard extends StatelessWidget {
-  double _width;
-  double _height;
-  String title;
-  String description;
-  String imageHash;
+  final String title;
+  final String description;
+  final String imageHash;
   // TODO
-  String dateAdded;
-  String category;
-  String location;
+  final String dateAdded;
+  final String category;
+  final String location;
 
   ShopCard({this.title, this.dateAdded, this.category, this.description, this.imageHash, this.location});
 
@@ -20,8 +18,8 @@ class ShopCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _width = MediaQuery.of(context).size.width;
-    _height = MediaQuery.of(context).size.height;
+    double width = MediaQuery.of(context).size.width;
+    double height = MediaQuery.of(context).size.height;
     return Card(
       elevation: 3,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
@@ -36,10 +34,10 @@ class ShopCard extends StatelessWidget {
               children: <Widget>[
                 Text(
                   title,
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: _height / 40),
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: height / 40),
                 ),
                 Container(
-                  width: _width / 3,
+                  width: width / 3,
                   padding: EdgeInsets.only(top: 5),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -63,11 +61,11 @@ class ShopCard extends StatelessWidget {
                 ),
                 Flexible(
                   child: Container(
-                      width: _width / 2.5,
+                      width: width / 2.5,
                       child: Text(
                         description,
                         style: TextStyle(
-                          fontSize: _height / 70,
+                          fontSize: height / 70,
                         ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
@@ -79,7 +77,7 @@ class ShopCard extends StatelessWidget {
                 ),
                 Flexible(
                   child: Container(
-                    width: _width / 2.75,
+                    width: width / 2.75,
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: <Widget>[
@@ -87,7 +85,7 @@ class ShopCard extends StatelessWidget {
                           child: GestureDetector(
                             child: Icon(
                               Icons.favorite_border,
-                              size: _height / 30,
+                              size: height / 30,
                             ),
                             onTap: () {
                               print('Fav');
@@ -99,18 +97,18 @@ class ShopCard extends StatelessWidget {
                           children: <Widget>[
                             Text(
                               dateAdded,
-                              style: TextStyle(fontSize: _height / 65),
+                              style: TextStyle(fontSize: height / 65),
                             ),
                             Row(
                               mainAxisSize: MainAxisSize.min,
                               children: <Widget>[
                                 Icon(
                                   Icons.location_on,
-                                  size: _height / 65,
+                                  size: height / 65,
                                 ),
                                 Text(
                                   location,
-                                  style: TextStyle(fontSize: _height / 65),
+                                  style: TextStyle(fontSize: height / 65),
                                 )
                               ],
                             ),
@@ -126,7 +124,7 @@ class ShopCard extends StatelessWidget {
               width: 10,
             ),
             Container(
-              width: _width / 2.5,
+              width: width / 2.5,
               decoration: BoxDecoration(
                 shape: BoxShape.rectangle,
                 color: Colors.white,
@@ -136,8 +134,8 @@ class ShopCard extends StatelessWidget {
               child: Image.network(
                 getImageAdress(this.imageHash),
                 fit: BoxFit.cover,
-                height: _height / 4.5,
-                width: _width / 4.5,
+                height: height / 4.5,
+                width: width / 4.5,
               ),
             ),
           ],

--- a/lib/page-encointer/bazaar/shop/shopOverviewPage.dart
+++ b/lib/page-encointer/bazaar/shop/shopOverviewPage.dart
@@ -90,13 +90,4 @@ class _ShopObserverState extends State<ShopObserver> with SingleTickerProviderSt
       ),
     );
   }
-
-  Widget _getShopViewOffline() {
-    return SafeArea(
-      child: Container(
-        padding: EdgeInsets.fromLTRB(16, 32, 16, 32),
-        child: ShopOverviewPanel(store),
-      ),
-    );
-  }
 }

--- a/lib/page-encointer/encointerEntry.dart
+++ b/lib/page-encointer/encointerEntry.dart
@@ -117,6 +117,8 @@ class _PhaseAwareBoxState extends State<PhaseAwareBox> with SingleTickerProvider
         return AssigningPage(store);
       case CeremonyPhase.ATTESTING:
         return AttestingPage(store);
+      default:
+        return RegisteringPage(store);
     }
   }
 

--- a/lib/page-encointer/homePage.dart
+++ b/lib/page-encointer/homePage.dart
@@ -1,4 +1,3 @@
-import 'package:encointer_wallet/page-encointer/bazaar/bazaarEntry.dart';
 import 'package:encointer_wallet/page-encointer/encointerEntry.dart';
 import 'package:encointer_wallet/page/assets/index.dart';
 import 'package:encointer_wallet/page/profile/index.dart';
@@ -35,11 +34,11 @@ class _EncointerHomePageState extends State<EncointerHomePage> {
     Map<String, String> tabs = I18n.of(context).home;
     return _tabList
         .map((i) => BottomNavigationBarItem(
-              icon: Image.asset(_tabList[activeItem] == i
-                  ? 'assets/images/public/${i}_indigo.png'
-                  : 'assets/images/public/${i}_dark.png',
-                  key: Key('tab-${i.toLowerCase()}')
-              ),
+              icon: Image.asset(
+                  _tabList[activeItem] == i
+                      ? 'assets/images/public/${i}_indigo.png'
+                      : 'assets/images/public/${i}_dark.png',
+                  key: Key('tab-${i.toLowerCase()}')),
               label: tabs[i.toLowerCase()],
             ))
         .toList();

--- a/lib/page-encointer/meetup/MeetupPage.dart
+++ b/lib/page-encointer/meetup/MeetupPage.dart
@@ -47,7 +47,6 @@ class _MeetupPageState extends State<MeetupPage> {
   void _initMeetup() async {
     print("creating my claim with vote $_amountAttendees");
     webApi.encointer.createClaimOfAttendance(_amountAttendees);
-    var claimHex = await webApi.encointer.encodeClaimOfAttendance();
     if ((store.encointer.attestations == null) || (store.encointer.attestations.isEmpty)) {
       store.encointer.attestations = _buildAttestationStateMap(store.encointer.meetupRegistry);
     }

--- a/lib/page-encointer/meetup/attestation/attestationCard.dart
+++ b/lib/page-encointer/meetup/attestation/attestationCard.dart
@@ -62,9 +62,9 @@ class _AttestationCardState extends State<AttestationCard> {
     }
   }
 
-  _revertAttestation() {
-    print("reverting attestation");
-  }
+  // _revertAttestation() {
+  //   print("reverting attestation");
+  // }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page-encointer/meetup/attestation/attestationCard.dart
+++ b/lib/page-encointer/meetup/attestation/attestationCard.dart
@@ -62,17 +62,13 @@ class _AttestationCardState extends State<AttestationCard> {
     }
   }
 
-  // _revertAttestation() {
-  //   print("reverting attestation");
-  // }
-
   @override
   Widget build(BuildContext context) {
     final Map dic = I18n.of(context).encointer;
 
     int otherIndex = widget.otherMeetupRegistryIndex;
     AttestationState attestation = store.encointer.attestations[otherIndex];
-    print("Attestationcard for " + attestation.pubKey);
+    print("Attestation card for " + attestation.pubKey);
 
     return RoundedCard(
       border: Border.all(color: Theme.of(context).cardColor),

--- a/lib/page-encointer/meetup/confirmAttendeesDialog.dart
+++ b/lib/page-encointer/meetup/confirmAttendeesDialog.dart
@@ -1,13 +1,11 @@
-import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:encointer_wallet/common/components/roundedCard.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
-
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class ConfirmAttendeesDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final title = 'Grid List';
     final Map dic = I18n.of(context).encointer;
 
     return Scaffold(
@@ -15,50 +13,45 @@ class ConfirmAttendeesDialog extends StatelessWidget {
           title: Text(dic['ceremony']),
           centerTitle: true,
         ),
-        backgroundColor:Theme.of(context).canvasColor,
+        backgroundColor: Theme.of(context).canvasColor,
         body: SafeArea(
-          child: Column(
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.all(16),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      Text(
-                        'How many attendees are present?',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      )
-                    ],
-                  ),
-                ),
-                Flexible(
-                  child: RoundedCard(
-                    margin: EdgeInsets.fromLTRB(16, 12, 16, 24),
-                    padding: EdgeInsets.only(top: 8, bottom: 8),
-                    child: GridView.count(
-                      // Create a grid with 2 columns.
-                      crossAxisCount: 2,
-                      childAspectRatio: 4/2,
-                      children: List.generate(10, (index) {
-                        var value = index +3;
-                        return Center(
-                            child: CupertinoButton(
-                                child: Text(value.toString()),
-                                onPressed: () {
-                                  Navigator.of(context).pop(value);
-                                }
-                            )
-                        );
-                      }),
+          child: Column(children: <Widget>[
+            Padding(
+              padding: EdgeInsets.all(16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    'How many attendees are present?',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
                     ),
-                  ),
+                  )
+                ],
+              ),
+            ),
+            Flexible(
+              child: RoundedCard(
+                margin: EdgeInsets.fromLTRB(16, 12, 16, 24),
+                padding: EdgeInsets.only(top: 8, bottom: 8),
+                child: GridView.count(
+                  // Create a grid with 2 columns.
+                  crossAxisCount: 2,
+                  childAspectRatio: 4 / 2,
+                  children: List.generate(10, (index) {
+                    var value = index + 3;
+                    return Center(
+                        child: CupertinoButton(
+                            child: Text(value.toString()),
+                            onPressed: () {
+                              Navigator.of(context).pop(value);
+                            }));
+                  }),
                 ),
-              ]
-          ),
-        )
-    );
+              ),
+            ),
+          ]),
+        ));
   }
 }

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -28,8 +28,6 @@ class _AttestingPageState extends State<AttestingPage> {
 
   final AppStore store;
 
-  String _tab = 'DOT';
-
   Future<void> _startMeetup(BuildContext context) async {
     var amount = await Navigator.of(context).push(MaterialPageRoute(builder: (context) => ConfirmAttendeesDialog()));
     var args = {'confirmedParticipants': amount};

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -87,7 +87,7 @@ class _AttestingPageState extends State<AttestingPage> {
         .where((x) => x != null)
         .toList();
 
-    List<Attestation> attestations = new List();
+    List<Attestation> attestations = [];
     for (int i = 0; i < attestationsHex.length; i++) {
       attestations.add(await webApi.encointer.parseAttestation(attestationsHex[i]));
     }

--- a/lib/page-encointer/phases/registering/registeringPage.dart
+++ b/lib/page-encointer/phases/registering/registeringPage.dart
@@ -18,8 +18,6 @@ class _RegisteringPageState extends State<RegisteringPage> {
 
   final AppStore store;
 
-  String _tab = 'DOT';
-
   @override
   Widget build(BuildContext context) {
     return SafeArea(

--- a/lib/page/account/import/importAccountForm.dart
+++ b/lib/page/account/import/importAccountForm.dart
@@ -31,7 +31,6 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
   ];
 
   KeySelection _keySelection = KeySelection.MNEMONIC;
-  bool _observationSubmitting = false;
 
   final _formKey = GlobalKey<FormState>();
 
@@ -148,7 +147,6 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
 
   Future<void> _onAddObservationAccount() async {
     setState(() {
-      _observationSubmitting = true;
     });
     showCupertinoDialog(
       context: context,
@@ -175,7 +173,6 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
     int exist = widget.store.settings.contactList.indexWhere((i) => i.address == address);
     if (exist > -1) {
       setState(() {
-        _observationSubmitting = false;
       });
       Navigator.of(context).pop();
 
@@ -202,7 +199,6 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
       webApi.account.encodeAddress([pubKey]);
       webApi.account.getPubKeyIcons([pubKey]);
       setState(() {
-        _observationSubmitting = false;
       });
       // go to home page
       Navigator.popUntil(context, ModalRoute.withName('/'));

--- a/lib/page/account/import/importAccountForm.dart
+++ b/lib/page/account/import/importAccountForm.dart
@@ -79,7 +79,7 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
             validator: (v) {
               // TODO: fix me: disable validator for polkawallet-RN exported keystore importing
               return null;
-              return v.trim().length > 0 ? null : dic['create.password.error'];
+              // return v.trim().length > 0 ? null : dic['create.password.error'];
             },
           ),
         ),
@@ -306,8 +306,8 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
                 ),
                 _keySelection != KeySelection.OBSERVATION
                     ? Padding(
-                    key: Key('account-source'),
-                    padding: EdgeInsets.only(left: 16, right: 16),
+                        key: Key('account-source'),
+                        padding: EdgeInsets.only(left: 16, right: 16),
                         child: TextFormField(
                           decoration: InputDecoration(
                             hintText: selected,

--- a/lib/page/account/txConfirmPage.dart
+++ b/lib/page/account/txConfirmPage.dart
@@ -8,7 +8,6 @@ import 'package:encointer_wallet/page/account/uos/qrSenderPage.dart';
 import 'package:encointer_wallet/page/profile/contacts/contactListPage.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/account/types/accountData.dart';
-import 'package:encointer_wallet/store/account/types/accountRecoveryInfo.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
@@ -86,10 +85,8 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
     print('callback triggered, blockHash: ${res['hash']}');
     store.assets.setSubmitting(false);
     if (mounted) {
-      final ScaffoldState state = Scaffold.of(context);
-
-      state.removeCurrentSnackBar();
-      state.showSnackBar(SnackBar(
+      ScaffoldMessenger.of(context).removeCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         backgroundColor: Colors.white,
         content: ListTile(
           leading: Container(
@@ -105,7 +102,7 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
       ));
 
       Timer(Duration(seconds: 2), () {
-        if (state.mounted) {
+        if (Scaffold.of(context).mounted) {
           (args['onFinish'] as Function(BuildContext, Map))(context, res);
         }
       });
@@ -116,7 +113,7 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
     final Map<String, String> dic = I18n.of(context).home;
     store.assets.setSubmitting(false);
     if (mounted) {
-      Scaffold.of(context).removeCurrentSnackBar();
+      ScaffoldMessenger.of(context).removeCurrentSnackBar();
     }
     showCupertinoDialog(
       context: context,
@@ -223,7 +220,7 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
   }
 
   void _showTxStatusSnackbar(BuildContext context, String status, Widget leading) {
-    Scaffold.of(context).showSnackBar(SnackBar(
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       backgroundColor: Theme.of(context).cardColor,
       content: ListTile(
         leading: leading,

--- a/lib/page/account/txConfirmPage.dart
+++ b/lib/page/account/txConfirmPage.dart
@@ -300,7 +300,6 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
   @override
   Widget build(BuildContext context) {
     final Map<String, String> dic = I18n.of(context).home;
-    final Map<String, String> dicAcc = I18n.of(context).account;
     final Map<String, String> dicAsset = I18n.of(context).assets;
     final String symbol = store.settings.networkState.tokenSymbol ?? '';
     final int decimals = store.settings.networkState.tokenDecimals ?? ert_decimals;
@@ -318,7 +317,6 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
         child: Observer(builder: (BuildContext context) {
           final bool isObservation = store.account.currentAccount.observation ?? false;
           final bool isProxyObservation = _proxyAccount != null ? _proxyAccount.observation ?? false : false;
-          final AccountRecoveryInfo recoverable = store.account.recoveryInfo;
 
           return Column(
             children: <Widget>[

--- a/lib/page/account/txConfirmPage.dart
+++ b/lib/page/account/txConfirmPage.dart
@@ -487,8 +487,8 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
                   Expanded(
                     child: Container(
                       color: store.assets.submitting ? Colors.black12 : Colors.orange,
-                      child: FlatButton(
-                        padding: EdgeInsets.all(16),
+                      child: TextButton(
+                        style: TextButton.styleFrom(padding: EdgeInsets.all(16)),
                         child: Text(dic['cancel'], style: TextStyle(color: Colors.white)),
                         onPressed: () {
                           Navigator.of(context).pop();
@@ -499,8 +499,8 @@ class _TxConfirmPageState extends State<TxConfirmPage> {
                   Expanded(
                     child: Container(
                       color: store.assets.submitting ? Theme.of(context).disabledColor : Theme.of(context).primaryColor,
-                      child: FlatButton(
-                        padding: EdgeInsets.all(16),
+                      child: TextButton(
+                        style: TextButton.styleFrom(padding: EdgeInsets.all(16)),
                         child: Text(
                           isUnsigned
                               ? dic['submit.no.sign']

--- a/lib/page/assets/asset/assetPage.dart
+++ b/lib/page/assets/asset/assetPage.dart
@@ -149,7 +149,6 @@ class _AssetPageState extends State<AssetPage> with SingleTickerProviderStateMix
       Tab(text: dic['out']),
     ];
 
-    final int decimals = store.settings.networkState.tokenDecimals;
     final String symbol = store.settings.networkState.tokenSymbol;
     final String tokenView = Fmt.tokenView(token);
     final bool isBaseToken = token == symbol;

--- a/lib/page/assets/asset/assetPage.dart
+++ b/lib/page/assets/asset/assetPage.dart
@@ -349,8 +349,8 @@ class _AssetPageState extends State<AssetPage> with SingleTickerProviderStateMix
                       child: Container(
                         key: Key('transfer'),
                         color: Colors.lightBlue,
-                        child: FlatButton(
-                          padding: EdgeInsets.all(16),
+                        child: TextButton(
+                          style: TextButton.styleFrom(padding: EdgeInsets.all(16)),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
@@ -380,8 +380,8 @@ class _AssetPageState extends State<AssetPage> with SingleTickerProviderStateMix
                     Expanded(
                       child: Container(
                         color: Colors.lightGreen,
-                        child: FlatButton(
-                          padding: EdgeInsets.all(16),
+                        child: TextButton(
+                          style: TextButton.styleFrom(padding: EdgeInsets.all(16)),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[

--- a/lib/page/assets/transfer/transferCrossChainPage.dart
+++ b/lib/page/assets/transfer/transferCrossChainPage.dart
@@ -8,7 +8,6 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:encointer_wallet/common/components/addressFormItem.dart';
 import 'package:encointer_wallet/common/components/currencyWithIcon.dart';
 import 'package:encointer_wallet/common/components/roundedButton.dart';
-import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/page/assets/asset/assetPage.dart';
 import 'package:encointer_wallet/page/assets/transfer/transferPage.dart';

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -9,7 +9,6 @@ import 'package:encointer_wallet/page/account/scanPage.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/page/assets/asset/assetPage.dart';
 import 'package:encointer_wallet/page/assets/transfer/currencySelectPage.dart';
-import 'package:encointer_wallet/page/assets/transfer/transferCrossChainPage.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/account/types/accountData.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -51,8 +50,6 @@ class _TransferPageState extends State<TransferPage> {
   AccountData _accountTo;
   String _tokenSymbol;
   bool _isEncointerCommunityCurrency;
-
-  bool _crossChain = false;
 
   Future<void> _onScan() async {
     final to = await Navigator.of(context).pushNamed(ScanPage.route);
@@ -136,46 +133,6 @@ class _TransferPageState extends State<TransferPage> {
     }
   }
 
-  void _onCrossChain() {
-    showCupertinoModalPopup(
-      context: context,
-      builder: (_) => CupertinoActionSheet(
-        actions: [
-          CupertinoActionSheetAction(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Padding(
-                  padding: EdgeInsets.only(right: 8),
-                  child: CircleAvatar(
-                    child: Image.asset(
-                      'assets/images/public/acala-mandala.png',
-                    ),
-                    radius: 16,
-                  ),
-                ),
-              ],
-            ),
-            onPressed: () {
-              final TransferPageParams args = ModalRoute.of(context).settings.arguments;
-              Navigator.of(context).popAndPushNamed(TransferCrossChainPage.route,
-                  arguments: TransferPageParams(
-                    symbol: _tokenSymbol,
-                    redirect: args?.redirect,
-                  ));
-            },
-          ),
-        ],
-        cancelButton: CupertinoActionSheetAction(
-          child: Text(I18n.of(context).home['cancel']),
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
-      ),
-    );
-  }
-
   @override
   void initState() {
     super.initState();
@@ -236,8 +193,6 @@ class _TransferPageState extends State<TransferPage> {
         BigInt available; // BigInt
         available = _getAvailableEncointerOrBaseToken(isBaseToken, symbol);
         print('Available: $available');
-
-        final Map pubKeyAddressMap = store.account.pubKeyAddressMap[store.settings.endpoint.ss58];
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/page/profile/account/accountManagePage.dart
+++ b/lib/page/profile/account/accountManagePage.dart
@@ -94,10 +94,12 @@ class AccountManagePage extends StatelessWidget {
               Row(
                 children: <Widget>[
                   Expanded(
-                    child: FlatButton(
-                      padding: EdgeInsets.all(16),
-                      color: Colors.white,
-                      textColor: Colors.red,
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        padding: EdgeInsets.all(16),
+                        backgroundColor: Colors.white,
+                        textStyle: TextStyle(color: Colors.red),
+                      ),
                       child: Text(dic['delete']),
                       onPressed: () => _onDeleteAccount(context),
                     ),

--- a/lib/page/profile/account/changePasswordPage.dart
+++ b/lib/page/profile/account/changePasswordPage.dart
@@ -134,7 +134,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
                       validator: (v) {
                         // TODO: fix me: disable validator for polkawallet-RN exported keystore importing
                         return null;
-                        return Fmt.checkPassword(v.trim()) ? null : accDic['create.password.error'];
+                        // return Fmt.checkPassword(v.trim()) ? null : accDic['create.password.error'];
                       },
                       obscureText: true,
                       inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:encointer_wallet/common/components/addressIcon.dart';
 import 'package:encointer_wallet/page/profile/aboutPage.dart';
 import 'package:encointer_wallet/page/profile/account/accountManagePage.dart';
@@ -10,6 +7,9 @@ import 'package:encointer_wallet/store/account/types/accountData.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/i18n/index.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 
 class Profile extends StatelessWidget {
   Profile(this.store);
@@ -50,10 +50,12 @@ class Profile extends StatelessWidget {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                        RaisedButton(
-                          padding: EdgeInsets.fromLTRB(24, 8, 24, 8),
-                          color: primaryColor,
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                        ElevatedButton(
+                          style: TextButton.styleFrom(
+                            padding: EdgeInsets.fromLTRB(24, 8, 24, 8),
+                            backgroundColor: primaryColor,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                          ),
                           child: Text(
                             dic['account'],
                             style: Theme.of(context).textTheme.button,

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -188,7 +188,7 @@ class Api {
     if (store.settings.endpointIsCantillon) {
       var worker = store.settings.endpoint.worker;
       var mrenclave = store.settings.endpoint.mrenclave;
-      String res = await evalJavascript('settings.setWorkerEndpoint("$worker", "$mrenclave")');
+      await evalJavascript('settings.setWorkerEndpoint("$worker", "$mrenclave")');
     }
 
     fetchNetworkProps();
@@ -210,7 +210,7 @@ class Api {
     if (store.settings.endpointIsCantillon) {
       var worker = store.settings.endpoint.worker;
       var mrenclave = store.settings.endpoint.mrenclave;
-      String res = await evalJavascript('settings.setWorkerEndpoint("$worker", "$mrenclave")');
+      await evalJavascript('settings.setWorkerEndpoint("$worker", "$mrenclave")');
     }
 
     int index = store.settings.endpointList.indexWhere((i) => i.value == res);

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -7,9 +7,7 @@ import 'package:encointer_wallet/service/substrateApi/apiAccount.dart';
 import 'package:encointer_wallet/service/substrateApi/apiAssets.dart';
 import 'package:encointer_wallet/service/substrateApi/encointer/apiEncointer.dart';
 import 'package:encointer_wallet/service/substrateApi/types/genExternalLinksParams.dart';
-import 'package:encointer_wallet/service/walletApi.dart';
 import 'package:encointer_wallet/store/app.dart';
-import 'package:encointer_wallet/utils/UI.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
@@ -64,26 +62,6 @@ class Api {
     // one seems to succeed
     print("second launch of webview");
     await launchWebview();
-  }
-
-  Future<void> _checkJSCodeUpdate() async {
-    // check js code update
-    final network = store.settings.endpoint.info;
-    final jsVersion = await WalletApi.fetchPolkadotJSVersion(network);
-    final bool needUpdate = await UI.checkJSCodeUpdate(context, jsVersion, network);
-    if (needUpdate) {
-      await UI.updateJSCode(context, jsStorage, network, jsVersion);
-    }
-  }
-
-  void _startJSCode(String js) {
-    // inject js file to webview
-    _web.evalJavascript(js);
-
-    // load keyPairs from local data
-    account.initAccounts();
-    // connect remote node
-    _connectFunc();
   }
 
   Future<void> launchWebview({bool customNode = false}) async {

--- a/lib/service/substrateApi/apiAccount.dart
+++ b/lib/service/substrateApi/apiAccount.dart
@@ -110,16 +110,6 @@ class ApiAccount {
     return res;
   }
 
-  Future<dynamic> _testSendTx() async {
-    Completer c = new Completer();
-    void onComplete(res) {
-      c.complete(res);
-    }
-
-    Timer(Duration(seconds: 6), () => onComplete({'hash': '0x79867'}));
-    return c.future;
-  }
-
   Future<dynamic> sendTx(Map txInfo, List params, String pageTile, String notificationTitle, {String rawParam}) async {
     String param = rawParam != null ? rawParam : jsonEncode(params);
     String call = 'account.sendTx(${jsonEncode(txInfo)}, $param)';

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -155,10 +155,7 @@ class ApiEncointer {
   Future<List<String>> getMeetupRegistry() async {
     print("api: getMeetupRegistry");
     int cIndex = store.encointer.currentCeremonyIndex;
-    String cid = store.encointer.chosenCid;
-    if (cid == null) {
-      return new List(); // empty
-    }
+    String cid = store.encointer.chosenCid ?? [];
     String pubKey = store.account.currentAccountPubKey;
     int mIndex = store.encointer.meetupIndex;
     print("api: get meetup registry for cindex " + cIndex.toString() + " mindex " + mIndex.toString() + " cid " + cid);
@@ -312,11 +309,7 @@ class ApiEncointer {
   Future<List<String>> getCommunityIdentifiers() async {
     Map<String, dynamic> res = await apiRoot.evalJavascript('encointer.getCommunityIdentifiers()');
 
-    List<String> cids = new List<String>();
-    res['cids'].forEach((e) {
-      cids.add(e.toString());
-    });
-
+    List<String> cids = List<String>.from(res['cids']);
     print("CID: " + cids.toString());
     store.encointer.setCommunityIdentifiers(cids);
     return cids;

--- a/lib/store/settings.dart
+++ b/lib/store/settings.dart
@@ -247,7 +247,7 @@ abstract class _SettingsStore with Store {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(createFactory: false)
 class NetworkState extends _NetworkState {
   NetworkState(String endpoint, int ss58Format, int tokenDecimals, String tokenSymbol)
       : super(endpoint, ss58Format, tokenDecimals, tokenSymbol);

--- a/lib/store/settings.g.dart
+++ b/lib/store/settings.g.dart
@@ -6,15 +6,6 @@ part of 'settings.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-NetworkState _$NetworkStateFromJson(Map<String, dynamic> json) {
-  return NetworkState(
-    json['endpoint'] as String,
-    json['ss58Format'] as int,
-    json['tokenDecimals'] as int,
-    json['tokenSymbol'] as String,
-  );
-}
-
 Map<String, dynamic> _$NetworkStateToJson(NetworkState instance) =>
     <String, dynamic>{
       'endpoint': instance.endpoint,

--- a/lib/utils/localStorage.dart
+++ b/lib/utils/localStorage.dart
@@ -123,16 +123,8 @@ class _LocalStorage {
   }
 
   Future<void> addItemToList(String storeKey, Map<String, dynamic> acc) async {
-    var ls = new List<Map<String, dynamic>>();
-
-    String str = await getKV(storeKey);
-    if (str != null) {
-      Iterable l = jsonDecode(str);
-      ls = l.map((i) => Map<String, dynamic>.from(i)).toList();
-    }
-
+    List<Map<String, dynamic>> ls = await getList(storeKey);
     ls.add(acc);
-
     setKV(storeKey, jsonEncode(ls));
   }
 
@@ -152,7 +144,7 @@ class _LocalStorage {
   }
 
   Future<List<Map<String, dynamic>>> getList(String storeKey) async {
-    var res = new List<Map<String, dynamic>>();
+    List<Map<String, dynamic>> res =[];
 
     String str = await getKV(storeKey);
     if (str != null) {

--- a/lib/utils/localStorage.dart
+++ b/lib/utils/localStorage.dart
@@ -144,7 +144,7 @@ class _LocalStorage {
   }
 
   Future<List<Map<String, dynamic>>> getList(String storeKey) async {
-    List<Map<String, dynamic>> res =[];
+    List<Map<String, dynamic>> res = [];
 
     String str = await getKV(storeKey);
     if (str != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ description: EncointerWallet made with Flutter.
 
 version: 1.0.2+810
 
+publish_to: none
+
 environment:
   sdk: ">=2.2.0 <3.0.0"
 

--- a/test_driver/scanPage.dart
+++ b/test_driver/scanPage.dart
@@ -13,6 +13,7 @@ import 'package:rxdart/rxdart.dart';
 /// background in the app bundle. Flutter does not yet support build configuration /-flavor dependant asset inclusion.
 ///
 void main() async {
+  // ignore: close_sinks
   final PublishSubject<ImageProvider> stream = PublishSubject();
 
   // ignore: missing_return


### PR DESCRIPTION
There were tons of warnings that accumulated over time. Here all of them are fixed, most of the warnings consisted of:

* unused imports/variables
* usages of deprecated stuff
* Some fields not marked as final in `Stateless Widgets`, which inherently need to be final.

This PR also adds a `flutter analyze` task, which throws a fatal error when warnings occur.

NOTE: First merge #141 
