### PR TITLE
Replace unregister button by "participant registered" card

### DIFF
--- a/lib/page-encointer/phases/registering/registerParticipantPanel.dart
+++ b/lib/page-encointer/phases/registering/registerParticipantPanel.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:encointer_wallet/common/components/roundedButton.dart';
+import 'package:encointer_wallet/common/components/roundedCard.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -97,10 +98,11 @@ class _RegisterParticipantPanel extends State<RegisterParticipantPanel> {
               ? CupertinoActivityIndicator()
               : store.encointer.participantIndex == 0
                   ? RoundedButton(text: "Register Participant", onPressed: () => _submit())
-                  : RoundedButton(
-                      text: "Unregister",
-                      //for: " + Fmt.communityIdentifier(store.encointer.chosenCid).toString(),
-                      onPressed: null),
+                  : RoundedCard(
+                      child: ListTile(
+                      title: Text("Participant is registered", textAlign: TextAlign.center),
+                    ),
+          ),
         ],
       ),
     );

--- a/lib/page-encointer/phases/registering/registerParticipantPanel.dart
+++ b/lib/page-encointer/phases/registering/registerParticipantPanel.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:encointer_wallet/common/components/roundedButton.dart';
-import 'package:encointer_wallet/common/components/roundedCard.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -98,11 +97,10 @@ class _RegisterParticipantPanel extends State<RegisterParticipantPanel> {
               ? CupertinoActivityIndicator()
               : store.encointer.participantIndex == 0
                   ? RoundedButton(text: "Register Participant", onPressed: () => _submit())
-                  : RoundedCard(
-                      child: ListTile(
-                      title: Text("Participant is registered", textAlign: TextAlign.center),
-                    ),
-          ),
+                  : RoundedButton(
+                      text: "Already Registered",
+                      onPressed: null,
+                      color: Theme.of(context).primaryColor.withOpacity(0.5)),
         ],
       ),
     );

--- a/lib/page-encointer/phases/registering/registerParticipantPanel.dart
+++ b/lib/page-encointer/phases/registering/registerParticipantPanel.dart
@@ -97,10 +97,7 @@ class _RegisterParticipantPanel extends State<RegisterParticipantPanel> {
               ? CupertinoActivityIndicator()
               : store.encointer.participantIndex == 0
                   ? RoundedButton(text: "Register Participant", onPressed: () => _submit())
-                  : RoundedButton(
-                      text: "Already Registered",
-                      onPressed: null,
-                      color: Theme.of(context).primaryColor.withOpacity(0.5)),
+                  : RoundedButton(text: "Already Registered", onPressed: null, color: Theme.of(context).disabledColor),
         ],
       ),
     );


### PR DESCRIPTION
After discussing the unregister button which does nothing in the background, it was decided to remove it. 
I thought maybe just leaving a card with the info that the participant is registered. 
Thoughts?
closes #207
