### PR TITLE
Fix flaky gesell integration test: `sendFaucetTx method`

### DIFF
--- a/lib/js_service_encointer/test/cantillon.test-e2e.js
+++ b/lib/js_service_encointer/test/cantillon.test-e2e.js
@@ -28,8 +28,6 @@ describe('cantillon', () => {
   let worker;
 
   beforeAll(async () => {
-    jest.setTimeout(90000);
-
     const setup = await testSetup(network);
     keyring = new Keyring({ type: 'sr25519' });
 
@@ -41,7 +39,7 @@ describe('cantillon', () => {
     });
     window.workerShieldingKey = await worker.getShieldingKey();
     window.mrenclave = network.mrenclave;
-  });
+  }, 90000);
 
   describe('on-chain', () => {
     describe('init api', () => {

--- a/lib/js_service_encointer/test/gesell.test-e2e.js
+++ b/lib/js_service_encointer/test/gesell.test-e2e.js
@@ -8,16 +8,13 @@ import account from '../src/service/account';
 import { u8aToHex } from '@polkadot/util';
 import { gesellNetwork } from './testUtils/networks';
 
-import { jest } from '@jest/globals';
 import { testSetup } from './testUtils/testSetup';
 
 describe('encointer', () => {
   const network = gesellNetwork();
   beforeAll(async () => {
-    jest.setTimeout(90000);
-
     await testSetup(network);
-  });
+  }, 90000);
 
   describe('init api', () => {
     it('should get gesell genesis hash', async () => {
@@ -84,13 +81,12 @@ describe('encointer', () => {
 
   describe('sendFaucetTx method', () => {
     it('should send balance', async () => {
-      jest.setTimeout(90000);
       const address = '5DPgv6nn4R1Gi1MUiAnzFDPaKF56SYKD9Zq4Q6REUGLhUZk1';
       const Ert001 = 1000000000;
       const result = await account.sendFaucetTx(address, Ert001);
       console.log(result);
       expect(result).toBeDefined();
-    });
+    }, 90000);
   });
 
   describe('can transform problematic location', () => {

--- a/lib/js_service_encointer/test/service/account.test.js
+++ b/lib/js_service_encointer/test/service/account.test.js
@@ -7,15 +7,12 @@ import account from '../../src/service/account';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { gesellNetwork, localDockerNetwork } from '../testUtils/networks';
 import { testSetup } from '../testUtils/testSetup';
-import { jest } from '@jest/globals';
 import { Keyring } from '@polkadot/api';
 
 describe('account', () => {
   const network = localDockerNetwork();
   let keyring;
   beforeAll(async () => {
-    jest.setTimeout(90000);
-
     await testSetup(network);
     keyring = new Keyring({ type: 'sr25519' });
   });

--- a/lib/js_service_encointer/test/service/encointer.test.js
+++ b/lib/js_service_encointer/test/service/encointer.test.js
@@ -20,11 +20,9 @@ describe('encointer', () => {
   const network = localDockerNetwork();
   let keyring;
   beforeAll(async () => {
-    jest.setTimeout(90000);
-
     await testSetup(network);
-    keyring =new Keyring({ type: 'sr25519' });
-  });
+    keyring = new Keyring({ type: 'sr25519' });
+  }, 90000);
 
   describe('getCurrentPhase', () => {
     it('should return promise', async () => {

--- a/lib/js_service_encointer/test/service/substratee.test.js
+++ b/lib/js_service_encointer/test/service/substratee.test.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-import { beforeAll, describe, it, jest } from '@jest/globals';
+import { beforeAll, describe, it, } from '@jest/globals';
 import { cantillonNetwork, localDockerNetwork } from '../testUtils/networks';
 
 import substratee from '../../src/service/substratee';
@@ -21,10 +21,8 @@ global.window = window;
 describe.skip('substratee', () => {
   const network = localDockerNetwork();
   beforeAll(async () => {
-    jest.setTimeout(90000);
-
     await testSetup(network);
-  });
+  }, 90000);
 
   it('getEnclave works', async () => {
     // remember: indexes start at one on-chain


### PR DESCRIPTION
As of jest > 27 the `jest.setTimout` method does not seem to work correctly: https://github.com/facebook/jest/issues/11500. This leads to a timeout error-rate of 30% in the CI.

This workaround should solve this and thereby fix the flaky gesell-integration test.

Edit: Seems to do the trick. I run the tests about 10 times, and it did not fail once.