### PR TITLE
adapt outdated ipfs call to get community icon

### DIFF
--- a/lib/mocks/api/apiIpfs.dart
+++ b/lib/mocks/api/apiIpfs.dart
@@ -13,7 +13,7 @@ class MockIpfs extends Ipfs {
   }
 
   @override
-  Future<Image> getCommunityIcon (String cid, double devicePixelRatio) async{
+  Future<Image> getCommunityIcon(String cid, double devicePixelRatio) async {
     return await Image.asset('assets/images/assets/Assets_nav_0.png');
   }
 

--- a/lib/mocks/api/apiIpfs.dart
+++ b/lib/mocks/api/apiIpfs.dart
@@ -13,8 +13,8 @@ class MockIpfs extends Ipfs {
   }
 
   @override
-  Image getCommunityIcon(String cid, double devicePixelRatio) {
-    return Image.asset('assets/images/assets/Assets_nav_0.png');
+  Future<Image> getCommunityIcon (String cid, double devicePixelRatio) async{
+    return await Image.asset('assets/images/assets/Assets_nav_0.png');
   }
 
   @override

--- a/lib/mocks/api/apiIpfs.dart
+++ b/lib/mocks/api/apiIpfs.dart
@@ -14,7 +14,7 @@ class MockIpfs extends Ipfs {
 
   @override
   Future<Image> getCommunityIcon(String cid, double devicePixelRatio) async {
-    return await Image.asset('assets/images/assets/Assets_nav_0.png');
+    return Image.asset('assets/images/assets/Assets_nav_0.png');
   }
 
   @override

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -496,8 +496,7 @@ class _AssetsState extends State<Assets> {
                                 }
 
                                 return Container();
-                              }
-                              )
+                              })
                           // store.encointer.iconReady ? webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid, devicePixelRatio) : CupertinoActivityIndicator(),
                           ),
                       title: Text(store.encointer.communityName + " (${store.encointer.communitySymbol})"),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -475,15 +475,31 @@ class _AssetsState extends State<Assets> {
         CommunityChooserPanel(store),
         Observer(
           builder: (_) {
+            // CHECK HERE THAT FILES ARE ALREADY STORED AND JUST THEN GET THE IMAGE
             return (store.encointer.communityName != null) & (store.encointer.chosenCid != null)
                 ? RoundedCard(
                     margin: EdgeInsets.only(top: 16),
                     child: ListTile(
                       key: Key('cid-asset'),
                       leading: Container(
-                        width: 36,
-                        child: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid, devicePixelRatio),
-                      ),
+                          width: 36,
+                          // child: store.encointer.iconReady ? webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid, devicePixelRatio) : Container(),
+                          child: FutureBuilder(
+                              future: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid, devicePixelRatio),
+                              builder: (context, snapshot) {
+                                if (snapshot.connectionState == ConnectionState.waiting) {
+                                  return CupertinoActivityIndicator();
+                                }
+
+                                if (snapshot.hasData) {
+                                  return snapshot.data;
+                                }
+
+                                return Container();
+                              }
+                              )
+                          // store.encointer.iconReady ? webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid, devicePixelRatio) : CupertinoActivityIndicator(),
+                          ),
                       title: Text(store.encointer.communityName + " (${store.encointer.communitySymbol})"),
                       trailing: store.encointer.communityBalance != null
                           ? Text(

--- a/lib/service/ipfsApi/httpApi.dart
+++ b/lib/service/ipfsApi/httpApi.dart
@@ -7,18 +7,20 @@ import 'package:encointer_wallet/config/consts.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
+import 'package:encointer_wallet/store/app.dart';
 // import 'dart:io' as io;
 
 class Ipfs {
   // Todo: remove default -> migrate bazaar to use ipfs field from webApi instance
-  Ipfs({this.gateway = ipfs_gateway_encointer});
+  Ipfs({this.gateway = ipfs_gateway_encointer, this.store});
 
+  final AppStore store;
   final String gateway;
   String _dir;
   // String ipfsGateWay = 'http://ipfs.encointer.org:8080/ipfs/QmP2fzfikh7VqTu8pvzd2G2vAd4eK7EaazXTEgqGN6AWoD';
 
   String infuraGateway = 'https://infura-ipfs.io';
-
+  String icon;
   Future getJson(String cid) async {
     try {
       final dio = IpfsDio(BaseOptions(baseUrl: gateway));
@@ -83,17 +85,23 @@ class Ipfs {
       if (file.isFile) {
         var outFile = File(fileName);
         print('File: ' + outFile.path);
+        icon = outFile.path;
         outFile = await outFile.create(recursive: true);
+        await outFile.writeAsBytes(file.content);
       }
     }
+    // store.encointer.setIconReady(true);
+    //SET store.encointer.iconReady true
+    //And when changing community/Network, setting iconReady false
   }
 
-  Image getCommunityIcon(String cid, double devicePixelRatio) {
+  Future<Image> getCommunityIcon (String cid, double devicePixelRatio) async{
+    // store.encointer.setIconReady(false);
     String communityIconUrl = getCommunityIconsUrl(cid);
-    _downloadZip(communityIconUrl, cid);
+    await _downloadZip(communityIconUrl, cid);
     // HERE CHECK THAT unarchiveAndSave succeded
-    // return Image.file(File('$_dir/${devicePixelRatioToResolution(devicePixelRatio)}community_icon.png'));
-
+    Image res = Image.file(File('$_dir/${devicePixelRatioToResolution(devicePixelRatio)}community_icon.png'));
+    return res;
     // return Image.network(getCommunityIconsUrl(cid, devicePixelRatio), errorBuilder: (_, error, __) {
     //   print("Image.network error: ${error.toString()}");
     //   return Image.asset('assets/images/assets/ERT.png');

--- a/lib/service/ipfsApi/httpApi.dart
+++ b/lib/service/ipfsApi/httpApi.dart
@@ -95,7 +95,7 @@ class Ipfs {
     //And when changing community/Network, setting iconReady false
   }
 
-  Future<Image> getCommunityIcon (String cid, double devicePixelRatio) async{
+  Future<Image> getCommunityIcon(String cid, double devicePixelRatio) async {
     // store.encointer.setIconReady(false);
     String communityIconUrl = getCommunityIconsUrl(cid);
     await _downloadZip(communityIconUrl, cid);

--- a/lib/service/ipfsApi/httpApi.dart
+++ b/lib/service/ipfsApi/httpApi.dart
@@ -15,7 +15,9 @@ class Ipfs {
 
   final String gateway;
   String _dir;
-  String workingLink = 'http://ipfs.encointer.org:8080/ipfs/QmP2fzfikh7VqTu8pvzd2G2vAd4eK7EaazXTEgqGN6AWoD';
+  // String ipfsGateWay = 'http://ipfs.encointer.org:8080/ipfs/QmP2fzfikh7VqTu8pvzd2G2vAd4eK7EaazXTEgqGN6AWoD';
+
+  String infuraGateway = 'https://infura-ipfs.io';
 
   Future getJson(String cid) async {
     try {
@@ -57,7 +59,7 @@ class Ipfs {
   }
 
   Future<File> _downloadFile(String url, String fileName) async {
-    var req = await http.Client().get(Uri.parse(workingLink));
+    var req = await http.Client().get(Uri.parse(url));
     // var pathToSDCard = await getExternalStorageDirectory();
     // var _dir = pathToSDCard.path;
     // accessing app memory in /data/user/0/org.encointer.wallet/app_flutter/
@@ -91,6 +93,7 @@ class Ipfs {
     _downloadZip(communityIconUrl, cid);
     // HERE CHECK THAT unarchiveAndSave succeded
     // return Image.file(File('$_dir/${devicePixelRatioToResolution(devicePixelRatio)}community_icon.png'));
+
     // return Image.network(getCommunityIconsUrl(cid, devicePixelRatio), errorBuilder: (_, error, __) {
     //   print("Image.network error: ${error.toString()}");
     //   return Image.asset('assets/images/assets/ERT.png');
@@ -99,7 +102,8 @@ class Ipfs {
 
   String getCommunityIconsUrl(String cid) {
     // return '$gateway/ipfs/$cid/icons/${devicePixelRatioToResolution(devicePixelRatio)}community_icon.png';
-    var zipUrl = 'http://ipfs.encointer.org:8080/ipfs/$cid';
+    // var zipUrl = 'http://ipfs.encointer.org:8080/ipfs/$cid';
+    var zipUrl = '$infuraGateway/ipfs/$cid';
     return zipUrl;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -30,7 +30,7 @@ packages:
     source: hosted
     version: "0.0.4"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       url: "https://pub.dartlang.org"
@@ -608,7 +608,7 @@ packages:
     source: hosted
     version: "0.2.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   get_storage: ^2.0.2
   convert: ^2.1.1
   http: ^0.13.1
+  path_provider: ^2.0.1
+  archive: ^2.0.8
   flutter_webview_plugin: ^0.3.11
   rxdart: ^0.26.0
   flutter_local_notifications: ^5.0.0+1
@@ -95,7 +97,6 @@ flutter_icons:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
Now: download zipped file, unzip and save all files/folders in local app memory (might be too much, maybe only save the actual wanted file with the correct size). 
Remarks:
getting the image to the widget does not working right now because I need somehow to await the whole process, but can't assign to the widget a function which is async.
The commented line at:
https://github.com/encointer/encointer-wallet-flutter/blob/unzip-ipfs/lib/service/ipfsApi/httpApi.dart#L93 
 won't work, because _dir needs to be assigned and the only way I found was async (maybe there is a synchroinous assignment?). And it also won't work, because the writing needs to be done before accessing the image. Making the function async and awaiting the Image is not possible (apparently), since this line:
https://github.com/encointer/encointer-wallet-flutter/blob/unzip-ipfs/lib/page/assets/index.dart#L485
will complain: "error: The expression doesn't evaluate to a function, so it can't be invoked. (invocation_of_non_function_expression at [encointer_wallet] lib\page\assets\index.dart:486)"

Therer are 2 solution i thought about: 
1. make an init funciton in ipfs class to initialize _dir and then initializeDir --> save store variable dirInitialized i.e. and add it as a condition before loading community Icon 
2. widget call will still call getCommunityIcon,  but inside getCommunityIcon call the async function in another thread (does that work in flutter?) on c# its possible^^

Another remark: the function call getCommunityIcon is called every once in a while (rerender of widget), so the http call gets called again, everytime. I don't know if this is a bad practice. One way to maybe circumvent it is checking, if we already have the icon and didn't change community, so we don't have to do everything again and again (getting zip, unarchiving, saving).

Last Remark: 
files added to ipfs with the local ipfs daemon (ipfs add ... ) can be found with the gateway: http://ipfs.encointer.org/ipfs/CID
files added to infura (remote ipfs) can be found with the gateway: https://infura-ipfs.io/ipfs/CID