### PR TITLE
Fix cache loading after account switch

### DIFF
--- a/lib/common/components/editIcon.dart
+++ b/lib/common/components/editIcon.dart
@@ -16,15 +16,12 @@ class EditIcon extends StatelessWidget {
 
   Future<void> _onSelect(AccountData i, String address) async {
     if (address != store.account.currentAddress) {
-      print("we are here changing from address ${store.account.currentAddress} to $address");
+      print("[editIcon] changing from address ${store.account.currentAddress} to $address");
 
-      /// set current account
       store.account.setCurrentAccount(i.pubKey);
-
       await store.loadAccountCache();
 
-      /// reload account info
-      webApi.assets.fetchBalance();
+      webApi.fetchAccountData();
     }
   }
 

--- a/lib/common/components/editIcon.dart
+++ b/lib/common/components/editIcon.dart
@@ -13,7 +13,6 @@ class EditIcon extends StatelessWidget {
   final double size;
   final AppStore store;
 
-
   Future<void> _onSelect(AccountData i, String address) async {
     if (address != store.account.currentAddress) {
       print("[editIcon] changing from address ${store.account.currentAddress} to $address");

--- a/lib/common/components/editIcon.dart
+++ b/lib/common/components/editIcon.dart
@@ -13,20 +13,15 @@ class EditIcon extends StatelessWidget {
   final double size;
   final AppStore store;
 
-  void _loadAccountCache() {
-    // refresh balance
-    store.assets.clearTxs();
-    store.assets.loadAccountCache();
-    store.encointer.loadCache();
-  }
 
   Future<void> _onSelect(AccountData i, String address) async {
     if (address != store.account.currentAddress) {
-      print("we are here changing from addres ${store.account.currentAddress} to $address");
+      print("we are here changing from address ${store.account.currentAddress} to $address");
 
       /// set current account
       store.account.setCurrentAccount(i.pubKey);
-      _loadAccountCache();
+
+      await store.loadAccountCache();
 
       /// reload account info
       webApi.assets.fetchBalance();

--- a/lib/js_service_encointer/test/gesell.test-e2e.js
+++ b/lib/js_service_encointer/test/gesell.test-e2e.js
@@ -40,7 +40,7 @@ describe('encointer', () => {
       const param = ['0xf26bfaa0feee0968ec0637e1933e64cd1947294d3b667d43b76b3915fc330b53', null];
 
       const res = await account.txFeeEstimate(txInfo, param);
-      expect(res.partialFee.toString()).toBe('125000117');
+      expect(res.weight.toNumber()).toBe(10000);
     });
   });
 
@@ -70,7 +70,7 @@ describe('encointer', () => {
     const param = [[claim, claim]];
     console.log(param.toString());
     const res = await account.txFeeEstimate(txInfo, param);
-    expect(res.partialFee.toString()).toBeDefined();
+    expect(res.weight.toNumber()).toEqual(10000);
   });
 
   describe('accountgetBalances method', () => {

--- a/lib/page/account/create/addAccountPage.dart
+++ b/lib/page/account/create/addAccountPage.dart
@@ -48,7 +48,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
     await store.account.addAccount(acc, store.account.newAccount.password);
     webApi.account.encodeAddress([acc['pubKey']]);
 
-    store.assets.loadAccountCache();
+    await store.loadAccountCache();
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];

--- a/lib/page/account/create/addAccountPage.dart
+++ b/lib/page/account/create/addAccountPage.dart
@@ -52,7 +52,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];
-    webApi.assets.fetchBalance();
+    webApi.fetchAccountData();
     webApi.account.fetchAccountsBonded([pubKey]);
     webApi.account.getPubKeyIcons([pubKey]);
     store.account.setCurrentAccount(pubKey);

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -47,7 +47,7 @@ class _CreatePinPageState extends State<CreatePinPage> {
     await store.account.addAccount(acc, store.account.newAccount.password);
     webApi.account.encodeAddress([acc['pubKey']]);
 
-    store.assets.loadAccountCache();
+    await store.loadAccountCache();
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -51,7 +51,7 @@ class _CreatePinPageState extends State<CreatePinPage> {
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];
-    webApi.assets.fetchBalance();
+    webApi.fetchAccountData();
     webApi.account.fetchAccountsBonded([pubKey]);
     webApi.account.getPubKeyIcons([pubKey]);
     store.account.setCurrentAccount(pubKey);

--- a/lib/page/account/import/importAccountForm.dart
+++ b/lib/page/account/import/importAccountForm.dart
@@ -89,7 +89,7 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
       await widget.store.settings.addContact(acc);
 
       webApi.account.changeCurrentAccount(pubKey: pubKey);
-      webApi.assets.fetchBalance();
+      webApi.fetchAccountData();
       webApi.account.encodeAddress([pubKey]);
       webApi.account.getPubKeyIcons([pubKey]);
       setState(() {});

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -162,7 +162,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
     await store.account.addAccount(acc, store.account.newAccount.password);
     webApi.account.encodeAddress([acc['pubKey']]);
 
-    store.assets.loadAccountCache();
+    await store.loadAccountCache();
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -166,7 +166,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
 
     // fetch info for the imported account
     String pubKey = acc['pubKey'];
-    webApi.assets.fetchBalance();
+    webApi.fetchAccountData();
     webApi.account.fetchAccountsBonded([pubKey]);
     webApi.account.getPubKeyIcons([pubKey]);
     store.account.setCurrentAccount(pubKey);

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -238,8 +238,7 @@ class _TransferPageState extends State<TransferPage> {
         _cid = args.cid;
       });
 
-      webApi.assets.fetchBalance();
-      webApi.encointer.getEncointerBalance();
+      webApi.fetchAccountData();
     });
   }
 

--- a/lib/page/networkSelectPage.dart
+++ b/lib/page/networkSelectPage.dart
@@ -87,9 +87,8 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
       if (isCurrentNetwork) {
         await store.loadAccountCache();
 
-        /// reload account info
-        webApi.assets.fetchBalance();
-        webApi.fetchEncointerCommunityData();
+        webApi.fetchAccountData();
+
       } else {
         /// set new network and reload web view
         // todo  remove the two options here, and fix the caching issue, explained in #219

--- a/lib/page/networkSelectPage.dart
+++ b/lib/page/networkSelectPage.dart
@@ -42,13 +42,6 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
   EndpointData _selectedNetwork;
   bool _networkChanging = false;
 
-  void _loadAccountCache() {
-    // refresh balance
-    store.assets.clearTxs();
-    store.assets.loadAccountCache();
-    store.encointer.loadCache();
-  }
-
   Future<void> _reloadNetwork() async {
     setState(() {
       _networkChanging = true;
@@ -67,7 +60,7 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
     await store.settings.setNetworkConst({}, needCache: false);
     store.settings.setEndpoint(_selectedNetwork);
 
-    _loadAccountCache();
+    store.loadAccountCache();
     //webApi.closeWebView();
 
     await store.settings.loadNetworkStateCache();
@@ -92,10 +85,11 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
       store.account.setCurrentAccount(i.pubKey);
 
       if (isCurrentNetwork) {
-        _loadAccountCache();
+        await store.loadAccountCache();
 
         /// reload account info
         webApi.assets.fetchBalance();
+        webApi.fetchEncointerCommunityData();
       } else {
         /// set new network and reload web view
         // todo  remove the two options here, and fix the caching issue, explained in #219

--- a/lib/page/networkSelectPage.dart
+++ b/lib/page/networkSelectPage.dart
@@ -60,13 +60,12 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
     await store.settings.setNetworkConst({}, needCache: false);
     store.settings.setEndpoint(_selectedNetwork);
 
-    store.loadAccountCache();
-    //webApi.closeWebView();
-
-    await store.settings.loadNetworkStateCache();
-
-    store.assets.loadCache();
-    store.encointer.loadCache();
+    await Future.wait([
+      store.loadAccountCache(),
+      store.settings.loadNetworkStateCache(),
+      store.assets.loadCache(),
+      store.encointer.loadCache()
+    ]);
 
     webApi.launchWebview();
     changeTheme();

--- a/lib/page/networkSelectPage.dart
+++ b/lib/page/networkSelectPage.dart
@@ -88,7 +88,6 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
         await store.loadAccountCache();
 
         webApi.fetchAccountData();
-
       } else {
         /// set new network and reload web view
         // todo  remove the two options here, and fix the caching issue, explained in #219

--- a/lib/page/profile/account/accountManagePage.dart
+++ b/lib/page/profile/account/accountManagePage.dart
@@ -57,10 +57,11 @@ class _AccountManagePageState extends State<AccountManagePage> {
               child: Text(I18n.of(context).translationsForLocale().home.ok),
               onPressed: () => {
                 store.account.removeAccount(store.account.currentAccount).then(
-                  (_) {
+                  (_) async{
                     // refresh balance
-                    store.assets.loadAccountCache();
+                    await store.loadAccountCache();
                     webApi.assets.fetchBalance();
+                    webApi.fetchEncointerCommunityData();
                     Navigator.of(context).pop();
                   },
                 ),

--- a/lib/page/profile/account/accountManagePage.dart
+++ b/lib/page/profile/account/accountManagePage.dart
@@ -60,8 +60,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
                   (_) async{
                     // refresh balance
                     await store.loadAccountCache();
-                    webApi.assets.fetchBalance();
-                    webApi.fetchEncointerCommunityData();
+                    webApi.fetchAccountData();
                     Navigator.of(context).pop();
                   },
                 ),

--- a/lib/page/profile/account/accountManagePage.dart
+++ b/lib/page/profile/account/accountManagePage.dart
@@ -57,7 +57,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
               child: Text(I18n.of(context).translationsForLocale().home.ok),
               onPressed: () => {
                 store.account.removeAccount(store.account.currentAccount).then(
-                  (_) async{
+                  (_) async {
                     // refresh balance
                     await store.loadAccountCache();
                     webApi.fetchAccountData();

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -32,7 +32,6 @@ class _ProfileState extends State<Profile> {
   final Api api = webApi;
   EndpointData _selectedNetwork;
 
-
   Future<void> _onSelect(AccountData i, String address) async {
     if (address != store.account.currentAddress) {
       print("changing from addres ${store.account.currentAddress} to $address");

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -37,15 +37,10 @@ class _ProfileState extends State<Profile> {
     if (address != store.account.currentAddress) {
       print("changing from addres ${store.account.currentAddress} to $address");
 
-      /// set current account
       store.account.setCurrentAccount(i.pubKey);
       await store.loadAccountCache();
 
-      /// reload account info
-      print("onSelect: assets.fetchBalance");
-      webApi.assets.fetchBalance();
-      print("onSelct: fetching encointerCommunityData");
-      webApi.fetchEncointerCommunityData();
+      webApi.fetchAccountData();
     }
   }
 

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -32,12 +32,6 @@ class _ProfileState extends State<Profile> {
   final Api api = webApi;
   EndpointData _selectedNetwork;
 
-  void _loadAccountCache() {
-    // refresh balance
-    store.assets.clearTxs();
-    store.assets.loadAccountCache();
-    store.encointer.loadCache();
-  }
 
   Future<void> _onSelect(AccountData i, String address) async {
     if (address != store.account.currentAddress) {
@@ -45,10 +39,13 @@ class _ProfileState extends State<Profile> {
 
       /// set current account
       store.account.setCurrentAccount(i.pubKey);
-      _loadAccountCache();
+      await store.loadAccountCache();
 
       /// reload account info
+      print("onSelect: assets.fetchBalance");
       webApi.assets.fetchBalance();
+      print("onSelct: fetching encointerCommunityData");
+      webApi.fetchEncointerCommunityData();
     }
   }
 

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -224,17 +224,17 @@ class Api {
   }
 
   void fetchAccountData() {
-    webApi.assets.fetchBalance();
+    assets.fetchBalance();
     fetchEncointerCommunityData();
   }
 
   void fetchEncointerCommunityData() {
-    webApi.encointer.getBusinesses();
-    webApi.encointer.getMeetupIndex();
-    webApi.encointer.getParticipantIndex();
-    webApi.encointer.getEncointerBalance();
-    webApi.encointer.getCommunityMetadata();
-    webApi.encointer.getDemurrage();
+    encointer.getBusinesses();
+    encointer.getMeetupIndex();
+    encointer.getParticipantIndex();
+    encointer.getEncointerBalance();
+    encointer.getCommunityMetadata();
+    encointer.getDemurrage();
   }
 
   Future<void> fetchNetworkProps() async {

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -223,6 +223,11 @@ class Api {
     fetchEncointerCommunityData();
   }
 
+  void fetchAccountData() {
+    webApi.assets.fetchBalance();
+    fetchEncointerCommunityData();
+  }
+
   void fetchEncointerCommunityData() {
     webApi.encointer.getBusinesses();
     webApi.encointer.getMeetupIndex();

--- a/lib/service/substrateApi/apiAccount.dart
+++ b/lib/service/substrateApi/apiAccount.dart
@@ -90,9 +90,10 @@ class ApiAccount {
 
     // refresh balance
     store.assets.clearTxs();
-    store.assets.loadAccountCache();
+    await store.loadAccountCache();
     if (fetchData) {
       webApi.assets.fetchBalance();
+      webApi.fetchEncointerCommunityData();
     }
   }
 

--- a/lib/service/substrateApi/apiAccount.dart
+++ b/lib/service/substrateApi/apiAccount.dart
@@ -88,12 +88,9 @@ class ApiAccount {
     }
     store.account.setCurrentAccount(current);
 
-    // refresh balance
-    store.assets.clearTxs();
     await store.loadAccountCache();
     if (fetchData) {
-      webApi.assets.fetchBalance();
-      webApi.fetchEncointerCommunityData();
+      webApi.fetchAccountData();
     }
   }
 

--- a/lib/store/app.dart
+++ b/lib/store/app.dart
@@ -74,7 +74,7 @@ abstract class _AppStore with Store {
   ///
   /// Should be used whenever one switches to a new account. This function needs to be awaited most of the time.
   /// Otherwise, calling webApi queries when the cache has not finished loading might result in outdated or wrong data.
-  /// E.g., not awaiting this call led to #357.
+  /// E.g. not awaiting this call was the cause of #357.
   Future<void> loadAccountCache() {
     return Future.wait([assets.clearTxs(), assets.loadAccountCache(), encointer.loadCache()]);
   }

--- a/lib/store/app.dart
+++ b/lib/store/app.dart
@@ -1,10 +1,10 @@
-import 'package:mobx/mobx.dart';
 import 'package:encointer_wallet/store/account/account.dart';
 import 'package:encointer_wallet/store/assets/assets.dart';
-import 'package:encointer_wallet/store/encointer/encointer.dart';
 import 'package:encointer_wallet/store/chain/chain.dart';
+import 'package:encointer_wallet/store/encointer/encointer.dart';
 import 'package:encointer_wallet/store/settings.dart';
 import 'package:encointer_wallet/utils/localStorage.dart';
+import 'package:mobx/mobx.dart';
 
 part 'app.g.dart';
 
@@ -68,5 +68,14 @@ abstract class _AppStore with Store {
 
   String getCacheKey(String key) {
     return '${settings.endpoint.info}_$key';
+  }
+
+  /// Loads all account associated data.
+  ///
+  /// Should be used whenever one switches to a new account. This function needs to be awaited most of the time.
+  /// Otherwise, calling webApi queries when the cache has not finished loading might result in outdated or wrong data.
+  /// E.g., not awaiting this call led to #357.
+  Future<void> loadAccountCache() {
+    return Future.wait([assets.clearTxs(), assets.loadAccountCache(), encointer.loadCache()]);
   }
 }

--- a/lib/store/assets/assets.dart
+++ b/lib/store/assets/assets.dart
@@ -254,7 +254,7 @@ abstract class _AssetsStore with Store {
       });
     }
 
-    loadAccountCache();
+    return loadAccountCache();
   }
 }
 


### PR DESCRIPTION
* Closes #357 

The reason for #357 was that the loading of account-specific data was not awaited before making `webApi` calls. This lead to webApi calls with wrong/outdated arguments.

Changes in this PR:
* unify redundant definitions of `_loadAccountCache` in `appStore.loadAccountCache`
* introduce `webApi.fetchAccountData()` which fetches all account-specific data.
* always await loading of cache to prevent potential bad states while making webApi calls.