### PR TITLE
Fix invalid meetup registry in store

### DIFF
--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -145,8 +145,8 @@ class Api {
   ///
   /// If [wrapPromise] is true, evaluation of [code] will directly be awaited and the result is returned.
   /// Otherwise, a future is created and put into the list of pending JS-calls.
-  /// If [allowRepeat] is true call to the same JS-method can be made repeatedly. Otherwise, subsequent calls will not
-  /// have any effect.
+  /// If [allowRepeat] is true, a call to the same JS-method can be made repeatedly. Otherwise, subsequent calls will
+  /// not have any effect.
   Future<dynamic> evalJavascript(
     String code, {
     bool wrapPromise = true,

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -141,10 +141,18 @@ class Api {
     return _evalJavascriptUID++;
   }
 
+  /// Evaluate javascript [code] in the webView.
+  ///
+  /// If [wrapPromise] is true, evaluation of [code] will directly be awaited and the result is returned.
+  /// Otherwise, a future is created and put into the list of pending JS-calls.
+  /// If [allowRepeat] is true call to the same JS-method can be made repeatedly. Otherwise, subsequent calls will not
+  /// have any effect.
   Future<dynamic> evalJavascript(
     String code, {
     bool wrapPromise = true,
-    bool allowRepeat = false,
+    // True is the safe approach; otherwise a crashing (and therefore not returning) JS-call, will prevent subsequent
+    // calls to the same method.
+    bool allowRepeat = true,
   }) async {
     // check if there's a same request loading
     if (!allowRepeat) {
@@ -168,10 +176,11 @@ class Api {
     _msgCompleters[method] = c;
 
     String script = '$code.then(function(res) {'
-        '  PolkaWallet.postMessage(JSON.stringify({ path: "$method", data: res }));'
+        '  PolkaWallet.postMessage(JSON.stringify({ path: "$method:result", data: res }));'
         '}).catch(function(err) {'
-        '  PolkaWallet.postMessage(JSON.stringify({ path: "log", data: err.message }));'
+        '  PolkaWallet.postMessage(JSON.stringify({ path: "$method:error", data: err.message }));'
         '})';
+
     _web.evalJavascript(script);
 
     return c.future;

--- a/lib/service/substrateApi/api.dart
+++ b/lib/service/substrateApi/api.dart
@@ -176,7 +176,7 @@ class Api {
     _msgCompleters[method] = c;
 
     String script = '$code.then(function(res) {'
-        '  PolkaWallet.postMessage(JSON.stringify({ path: "$method:result", data: res }));'
+        '  PolkaWallet.postMessage(JSON.stringify({ path: "$method", data: res }));'
         '}).catch(function(err) {'
         '  PolkaWallet.postMessage(JSON.stringify({ path: "$method:error", data: err.message }));'
         '})';

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -70,7 +70,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
 
 class TranslationsDeEncointer implements TranslationsEncointer {
   get registerParticipant => 'Registeriere Teilnehmer';
-  get attestationsSubmit => 'Anwesenheit einreichen';
+  get attestationsSubmit => 'Attestierungen einreichen';
   get ceremony => 'Encointer Zeremonie';
   get ceremonyNext => 'Nächste Zeremonie findet statt am Mittag am:';
   get claimQr => 'Meine Behauptung der Anwesenheit';


### PR DESCRIPTION
* Quite positive that this closes #374. I am not 100% certain though because I couldn't reproduce the bug before. Below is my guess to why this solves the issue:

I remember seeing the following error in the logs without being able to identify what it could cause:

```
unable to create type `MeetupIndexType` with negative number
```

I deemed it to be not relevant because it was in the registering phase. However, the default case was that a failing JS-call without proper error handling, will make subsequent calls to the same JS-method noop's because dart was still waiting for the responsible message completer to return (See #387). I guess a failing `encointer.getMeetupRegistry` call prevented the `meetupRegistry` from being updated, causing the above issue.

Changes in this PR:
* default `allowRepeat` to true as mitigation of potential crashing JS-calls
* better input sanitation for JS-calls.