### PR TITLE
Better error for invalid mnemonic

### DIFF
--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -3,12 +3,11 @@ import 'package:encointer_wallet/page/account/create/createAccountForm.dart';
 import 'package:encointer_wallet/page/account/import/importAccountForm.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
-import 'package:encointer_wallet/utils/UI.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:encointer_wallet/utils/translations/translations.dart';
 
 class ImportAccountPage extends StatefulWidget {
   const ImportAccountPage(this.store);
@@ -57,38 +56,33 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
     /// check if account duplicate
     if (acc != null) {
       if (acc['error'] != null) {
+        var msg = acc['error'];
+
         if (acc['error'] == 'unreachable') {
-          showCupertinoDialog(
-            context: context,
-            builder: (BuildContext context) {
-              final Translations dic = I18n.of(context).translationsForLocale();
-              return CupertinoAlertDialog(
-                title: Container(),
-                // content: Text('${accDic['importInvalid']} ${accDic[_keyType]}'),
-                content: Text('${dic.account.importInvalid} accDic[_keyType]'), // TODO what is this?
-                actions: <Widget>[
-                  CupertinoButton(
-                    child: Text(I18n.of(context).translationsForLocale().home.ok),
-                    onPressed: () {
-                      setState(() {
-                        _step = 0;
-                        _submitting = false;
-                      });
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ],
-              );
-            },
-          );
-        } else {
-          UI.alertWASM(context, () {
-            setState(() {
-              _step = 0;
-              _submitting = false;
-            });
-          });
+          msg = "${I18n.of(context).translationsForLocale().account.importInvalid}: $_keyType";
         }
+
+        showCupertinoDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return CupertinoAlertDialog(
+              title: Container(),
+              content: Text('$msg'),
+              actions: <Widget>[
+                CupertinoButton(
+                  child: Text(I18n.of(context).translationsForLocale().home.ok),
+                  onPressed: () {
+                    setState(() {
+                      _step = 0;
+                      _submitting = false;
+                    });
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ],
+            );
+          },
+        );
         return;
       }
       _checkAccountDuplicate(acc);


### PR DESCRIPTION
Before, there was always a cryptic error message of `sr25519` key type not being supported, when something with an account import failed. This is not only cryptic, but also most of the time wrong.

Here we introduce the change that the JS-returned error is not simply swallowed but transparently displayed in that `CupertinoAlertDialog`.