### PR TITLE
Fix apple appstore privacy issues

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -64,6 +64,8 @@ post_install do |installer|
           'PERMISSION_MEDIA_LIBRARY=0',
           ## dart: PermissionGroup.sensors
           'PERMISSION_SENSORS=0'
+          ## dart: PermissionGroup.bluetooth
+          'PERMISSION_BLUETOOTH=0',
         ]
     end
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,9 +63,9 @@ post_install do |installer|
           ## dart: PermissionGroup.mediaLibrary
           'PERMISSION_MEDIA_LIBRARY=0',
           ## dart: PermissionGroup.sensors
-          'PERMISSION_SENSORS=0'
+          'PERMISSION_SENSORS=0',
           ## dart: PermissionGroup.bluetooth
-          'PERMISSION_BLUETOOTH=0',
+          'PERMISSION_BLUETOOTH=0'
         ]
     end
   end


### PR DESCRIPTION
* Closes #241 

Not 100% sure that this solves the issue. There is very little information, but I guess that the appstore reports this because one of our dependencies needs that permission even though we don't use it.

I suggest we try this approach. If it does not work, we add the usage string here: https://github.com/encointer/encointer-wallet-flutter/blob/0a513055a5d996eccc8943e1d99e7be963a9a672/ios/Runner/Info.plist#L41