### PR TITLE
Allow Purging of scanned claims

### DIFF
--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -67,7 +67,7 @@ class _AttestingPageState extends State<AttestingPage> {
                   children: [Text(dic.encointer.claimsPurge)],
                 ),
                 onPressed: () =>
-                    store.encointer.scannedClaimsCount > 0 ? store.encointer.purgeParticipantsClaims() : null,
+                    store.encointer.scannedClaimsCount > 0 ? _confirmPurgeClaimsDialog(context, store) : null,
               ),
             ],
           ),
@@ -93,4 +93,32 @@ class _AttestingPageState extends State<AttestingPage> {
     };
     Navigator.of(context).pushNamed(TxConfirmPage.route, arguments: args);
   }
+}
+
+void _confirmPurgeClaimsDialog(BuildContext context, AppStore store) {
+  var dic = I18n
+      .of(context)
+      .translationsForLocale();
+
+  showCupertinoDialog(
+    context: context,
+    builder: (_) {
+      return CupertinoAlertDialog(
+        title: Text(dic.encointer.claimsPurgeConfirm),
+        actions: <Widget>[
+          CupertinoButton(
+            child: Text(dic.home.cancel),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          CupertinoButton(
+            child: Text(dic.home.ok),
+            onPressed: () {
+              store.encointer.purgeParticipantsClaims();
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      );
+    },
+  );
 }

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -96,9 +96,7 @@ class _AttestingPageState extends State<AttestingPage> {
 }
 
 void _confirmPurgeClaimsDialog(BuildContext context, AppStore store) {
-  var dic = I18n
-      .of(context)
-      .translationsForLocale();
+  var dic = I18n.of(context).translationsForLocale();
 
   showCupertinoDialog(
     context: context,

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -31,39 +31,46 @@ class _AttestingPageState extends State<AttestingPage> {
     return SafeArea(
       child: Column(children: <Widget>[
         AssignmentPanel(store),
-        ListView(
-          shrinkWrap: true,
-          children: <Widget>[
-            SizedBox(height: 16),
-            Observer(
-              builder: (_) => ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
-                  ? Text(dic.encointer.meetupNotAssigned)
-                  : PrimaryButton(
-                      key: Key('start-meetup'),
-                      child: Text(dic.encointer.meetupStart),
-                      onPressed: () => startMeetup(context, store),
-                    ),
-            ),
-            SizedBox(height: 16),
-            Observer(
-              builder: (_) => Text(
-                dic.encointer.claimsScanned
-                    .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString()),
-                style: Theme.of(context).textTheme.headline3.copyWith(color: encointerGrey),
-                textAlign: TextAlign.center,
-              ),
-            ),
-            SizedBox(height: 16),
-            ElevatedButton(
+        Observer(
+          builder: (_) => ListView(
+            shrinkWrap: true,
+            children: <Widget>[
+              SizedBox(height: 16),
+              ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
+                    ? Text(dic.encointer.meetupNotAssigned)
+                    : PrimaryButton(
+                        key: Key('start-meetup'),
+                        child: Text(dic.encointer.meetupStart),
+                        onPressed: () => startMeetup(context, store),
+                      ),
+              SizedBox(height: 16),
+              Text(
+                  dic.encointer.claimsScanned
+                      .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString()),
+                  style: Theme.of(context).textTheme.headline3.copyWith(color: encointerGrey),
+                  textAlign: TextAlign.center,
+                ),
+              SizedBox(height: 16),
+              ElevatedButton(
                 style: ElevatedButton.styleFrom(padding: EdgeInsets.symmetric(vertical: 16)),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(dic.encointer.attestationsSubmit)
-                  ],
+                  children: [Text(dic.encointer.claimsSubmit)],
                 ),
-                onPressed: () =>  store.encointer.scannedClaimsCount > 0 ? () => _submit(context) : null),
-          ],
+                onPressed: () => store.encointer.scannedClaimsCount > 0 ? () => _submit(context) : null,
+              ),
+              SizedBox(height: 16),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(padding: EdgeInsets.symmetric(vertical: 16)),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [Text(dic.encointer.claimsPurge)],
+                ),
+                onPressed: () =>
+                    store.encointer.scannedClaimsCount > 0 ? store.encointer.purgeParticipantsClaims() : null,
+              ),
+            ],
+          ),
         ),
       ]),
     );

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -1,14 +1,14 @@
-import 'package:encointer_wallet/common/components/roundedButton.dart';
-import 'package:encointer_wallet/common/components/roundedCard.dart';
+import 'package:encointer_wallet/common/components/gradientElements.dart';
+import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page-encointer/common/assignmentPanel.dart';
 import 'package:encointer_wallet/page-encointer/meetup/startMeetup.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:encointer_wallet/utils/translations/translations.dart';
 
 class AttestingPage extends StatefulWidget {
   AttestingPage(this.store);
@@ -31,37 +31,40 @@ class _AttestingPageState extends State<AttestingPage> {
     return SafeArea(
       child: Column(children: <Widget>[
         AssignmentPanel(store),
-        SizedBox(height: 16),
-        Container(
-          width: double.infinity,
-          child: RoundedCard(
-            padding: EdgeInsets.all(8),
-            child: Column(children: <Widget>[
-              Observer(
-                builder: (_) => ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
-                    ? Text(dic.encointer.meetupNotAssigned)
-                    : Container(
-                        key: Key('start-meetup'),
-                        child: RoundedButton(
-                            text: dic.encointer.meetupStart, onPressed: () => startMeetup(context, store))),
+        ListView(
+          shrinkWrap: true,
+          children: <Widget>[
+            SizedBox(height: 16),
+            Observer(
+              builder: (_) => ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
+                  ? Text(dic.encointer.meetupNotAssigned)
+                  : PrimaryButton(
+                      key: Key('start-meetup'),
+                      child: Text(dic.encointer.meetupStart),
+                      onPressed: () => startMeetup(context, store),
+                    ),
+            ),
+            SizedBox(height: 16),
+            Observer(
+              builder: (_) => Text(
+                dic.encointer.claimsScanned
+                    .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString()),
+                style: Theme.of(context).textTheme.headline3.copyWith(color: encointerGrey),
+                textAlign: TextAlign.center,
               ),
-            ]),
-          ),
+            ),
+            SizedBox(height: 16),
+            ElevatedButton(
+                style: ElevatedButton.styleFrom(padding: EdgeInsets.symmetric(vertical: 16)),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(dic.encointer.attestationsSubmit)
+                  ],
+                ),
+                onPressed: () =>  store.encointer.scannedClaimsCount > 0 ? () => _submit(context) : null),
+          ],
         ),
-        SizedBox(height: 16),
-        Container(
-          width: double.infinity,
-          child: Observer(
-              builder: (_) => RoundedCard(
-                  padding: const EdgeInsets.only(top: 16, bottom: 16),
-                  child: Column(children: <Widget>[
-                    Text(dic.encointer.claimsScanned
-                        .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString())),
-                    ElevatedButton(
-                        child: Text(dic.encointer.attestationsSubmit),
-                        onPressed: store.encointer.scannedClaimsCount > 0 ? () => _submit(context) : null)
-                  ]))),
-        )
       ]),
     );
   }

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -96,7 +96,7 @@ class _AttestingPageState extends State<AttestingPage> {
 }
 
 void _confirmPurgeClaimsDialog(BuildContext context, AppStore store) {
-  var dic = I18n.of(context).translationsForLocale();
+  final dic = I18n.of(context).translationsForLocale();
 
   showCupertinoDialog(
     context: context,

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -57,7 +57,7 @@ class _AttestingPageState extends State<AttestingPage> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [Text(dic.encointer.claimsSubmit)],
                 ),
-                onPressed: () => store.encointer.scannedClaimsCount > 0 ? () => _submit(context) : null,
+                onPressed: () => store.encointer.scannedClaimsCount > 0 ? _submit(context) : null,
               ),
               SizedBox(height: 16),
               ElevatedButton(

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -37,19 +37,19 @@ class _AttestingPageState extends State<AttestingPage> {
             children: <Widget>[
               SizedBox(height: 16),
               ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
-                    ? Text(dic.encointer.meetupNotAssigned)
-                    : PrimaryButton(
-                        key: Key('start-meetup'),
-                        child: Text(dic.encointer.meetupStart),
-                        onPressed: () => startMeetup(context, store),
-                      ),
+                  ? Text(dic.encointer.meetupNotAssigned)
+                  : PrimaryButton(
+                      key: Key('start-meetup'),
+                      child: Text(dic.encointer.meetupStart),
+                      onPressed: () => startMeetup(context, store),
+                    ),
               SizedBox(height: 16),
               Text(
-                  dic.encointer.claimsScanned
-                      .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString()),
-                  style: Theme.of(context).textTheme.headline3.copyWith(color: encointerGrey),
-                  textAlign: TextAlign.center,
-                ),
+                dic.encointer.claimsScanned
+                    .replaceAll('AMOUNT_PLACEHOLDER', store.encointer.scannedClaimsCount.toString()),
+                style: Theme.of(context).textTheme.headline3.copyWith(color: encointerGrey),
+                textAlign: TextAlign.center,
+              ),
               SizedBox(height: 16),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(padding: EdgeInsets.symmetric(vertical: 16)),

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -4,6 +4,7 @@ abstract class TranslationsEncointer {
   String get registerParticipant;
   String get claimsSubmit;
   String get claimsPurge;
+  String get claimsPurgeConfirm;
   String get ceremony;
   String get ceremonyNext;
   String get claimQr;
@@ -40,6 +41,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   get registerParticipant => 'Register Participant';
   get claimsSubmit => 'Submit claims';
   get claimsPurge => 'Purge previously scanned claims';
+  get claimsPurgeConfirm => 'Are you sure, you want to purge all scanned claims?';
   get ceremony => 'Encointer Ceremony';
   get ceremonyNext => 'Next ceremony will happen at high sun on:';
   get claimQr => 'My Claim of Attendance';
@@ -76,6 +78,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get registerParticipant => 'Registeriere Teilnehmer';
   get claimsSubmit => 'Meetupbestätigungen einreichen';
   get claimsPurge => 'Bereits gescannte Meetupbestätigungen löschen';
+  get claimsPurgeConfirm => 'Bist du sicher, dass du alles gescannte Meetupbestätigungen löschen möchtest?';
   get ceremony => 'Encointer Zeremonie';
   get ceremonyNext => 'Nächste Zeremonie findet statt am Mittag am:';
   get claimQr => 'Meine Behauptung der Anwesenheit';
@@ -112,6 +115,7 @@ class TranslationsZhEncointer implements TranslationsEncointer {
   get registerParticipant => '注册参与者';
   get claimsSubmit => '提交证明';
   get claimsPurge => throw UnimplementedError();
+  get claimsPurgeConfirm => throw UnimplementedError();
   get ceremony => 'Encointer 仪式';
   get ceremonyNext => '下一个仪式将在烈日下举行：';
   get claimQr => '我的出席声明';

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -2,7 +2,8 @@
 /// always add a new getter here in the abstract class first, then generate/implement the getters in the subclasses
 abstract class TranslationsEncointer {
   String get registerParticipant;
-  String get attestationsSubmit;
+  String get claimsSubmit;
+  String get claimsPurge;
   String get ceremony;
   String get ceremonyNext;
   String get claimQr;
@@ -37,7 +38,8 @@ abstract class TranslationsEncointer {
 
 class TranslationsEnEncointer implements TranslationsEncointer {
   get registerParticipant => 'Register Participant';
-  get attestationsSubmit => 'Submit attestations';
+  get claimsSubmit => 'Submit claims';
+  get claimsPurge => 'Purge previously scanned claims';
   get ceremony => 'Encointer Ceremony';
   get ceremonyNext => 'Next ceremony will happen at high sun on:';
   get claimQr => 'My Claim of Attendance';
@@ -72,7 +74,8 @@ class TranslationsEnEncointer implements TranslationsEncointer {
 
 class TranslationsDeEncointer implements TranslationsEncointer {
   get registerParticipant => 'Registeriere Teilnehmer';
-  get attestationsSubmit => 'Attestierungen einreichen';
+  get claimsSubmit => 'Meetupbestätigung einreichen';
+  get claimsPurge => 'Bereits gescannte Meetupbestätigung löschen';
   get ceremony => 'Encointer Zeremonie';
   get ceremonyNext => 'Nächste Zeremonie findet statt am Mittag am:';
   get claimQr => 'Meine Behauptung der Anwesenheit';
@@ -107,7 +110,8 @@ class TranslationsDeEncointer implements TranslationsEncointer {
 
 class TranslationsZhEncointer implements TranslationsEncointer {
   get registerParticipant => '注册参与者';
-  get attestationsSubmit => '提交证明';
+  get claimsSubmit => '提交证明';
+  get claimsPurge => throw UnimplementedError();
   get ceremony => 'Encointer 仪式';
   get ceremonyNext => '下一个仪式将在烈日下举行：';
   get claimQr => '我的出席声明';

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -74,8 +74,8 @@ class TranslationsEnEncointer implements TranslationsEncointer {
 
 class TranslationsDeEncointer implements TranslationsEncointer {
   get registerParticipant => 'Registeriere Teilnehmer';
-  get claimsSubmit => 'Meetupbestätigung einreichen';
-  get claimsPurge => 'Bereits gescannte Meetupbestätigung löschen';
+  get claimsSubmit => 'Meetupbestätigungen einreichen';
+  get claimsPurge => 'Bereits gescannte Meetupbestätigungen löschen';
   get ceremony => 'Encointer Zeremonie';
   get ceremonyNext => 'Nächste Zeremonie findet statt am Mittag am:';
   get claimQr => 'Meine Behauptung der Anwesenheit';


### PR DESCRIPTION
* Closes #431 

Changes:
* add button `Purge previously scanned claims` on attesting phase view
* minimaly update the design by using our new design templated widgets.
* change deprecated texts: attestations -> claims