### PR TITLE
Fix endless activity indicator on assignment panel

### DIFF
--- a/lib/js_service_encointer/src/service/encointer.js
+++ b/lib/js_service_encointer/src/service/encointer.js
@@ -197,6 +197,15 @@ export async function getNextMeetupLocation (cid, cIndex, mIndex, address) {
 }
 
 /**
+ * Get all meetup locations for cid.
+ */
+export async function getAllMeetupLocations (cid) {
+  const cidT = api.createType('CommunityIdentifier', cid);
+
+  return api.rpc.communities.getLocations(cidT)
+}
+
+/**
  * Checks if the ceremony rewards has been issued.
  *
  * @param cid CommunityIdentifier
@@ -367,6 +376,7 @@ export default {
   getNextMeetupTime,
   getDemurrage,
   getCommunityMetadata,
+  getAllMeetupLocations,
   communitiesGetAll,
   getMeetupIndex,
   getParticipantIndex,

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -37,7 +37,7 @@ class AssignmentPanel extends StatelessWidget {
                                 children: <Widget>[
                                   Text("You are registered! ", style: TextStyle(color: Colors.green)),
                                   Text("Ceremony will take place on:"),
-                                  MaybeMeetupTime(store.encointer.meetupTime, dateFormat: 'yyyy-mm-dd-hh:mm'),
+                                  MaybeMeetupTime(store.encointer.meetupTime, dateFormat: 'yyyy-MM-dd-hh:mm'),
                                   ElevatedButton(
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -35,65 +35,60 @@ class _AssignmentPanelState extends State<AssignmentPanel> {
         child: Column(
           children: <Widget>[
             Observer(
-              builder: (_) => widget.store.encointer.meetupTime != null
-                  ? widget.store.encointer.communities == null
-                      ? Text(dic.assets.communitiesNotFound)
-                      : Column(
-                          children: <Widget>[
-                            widget.store.encointer.meetupIndex > 0
-                                ? Column(
-                                    children: <Widget>[
-                                      Text("You are registered! ", style: TextStyle(color: Colors.green)),
-                                      Text("Ceremony will take place on:"),
-                                      Text(new DateTime.fromMillisecondsSinceEpoch(widget.store.encointer.meetupTime)
-                                          .toIso8601String()),
-                                      Text("at location:"),
-                                      ElevatedButton(
-                                        child: Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            widget.store.encointer.meetupLocation != null
-                                                ? Icon(
-                                                    Icons.location_on,
-                                                    size: 25,
-                                                    color: Colors.blueAccent,
-                                                  )
-                                                : CupertinoActivityIndicator(),
-                                            Text(dic.encointer.meetupLocation),
-                                          ],
-                                        ),
-                                        onPressed: widget.store.encointer.meetupLocation != null
-                                            ? () => Navigator.push(
-                                                  context,
-                                                  MaterialPageRoute(
-                                                    builder: (context) {
-                                                      return EncointerMap(
-                                                        widget.store,
-                                                        popupBuilder: (BuildContext context, Marker marker) =>
-                                                            SizedBox(),
-                                                        markers: buildMarkers(widget.store.encointer.meetupLocation),
-                                                        title: dic.encointer.meetupLocation,
-                                                        center: widget.store.encointer.meetupLocation.toLatLng(),
-                                                        initialZoom: initialZoom,
-                                                      );
-                                                    },
-                                                  ),
+                builder: (_) => widget.store.encointer.communities == null
+                    ? Text(dic.assets.communitiesNotFound)
+                    : Column(
+                        children: <Widget>[
+                          widget.store.encointer.meetupIndex > 0
+                              ? Column(
+                                  children: <Widget>[
+                                    Text("You are registered! ", style: TextStyle(color: Colors.green)),
+                                    Text("Ceremony will take place on:"),
+                                    Text(new DateTime.fromMillisecondsSinceEpoch(widget.store.encointer.meetupTime)
+                                        .toIso8601String()),
+                                    ElevatedButton(
+                                      child: Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          widget.store.encointer.meetupLocation != null
+                                              ? Icon(
+                                                  Icons.location_on,
+                                                  size: 25,
+                                                  color: Colors.blueAccent,
                                                 )
-                                            : null,
-                                      )
-                                    ],
-                                  )
-                                : Text(
-                                    "You are not registered for ceremony on " +
-                                        DateFormat('yyyy-MM-dd').format(new DateTime.fromMillisecondsSinceEpoch(
-                                            widget.store.encointer.meetupTime)) +
-                                        " for the selected community",
-                                    style: TextStyle(color: Colors.red),
-                                  ),
-                          ],
-                        )
-                  : CupertinoActivityIndicator(),
-            )
+                                              : CupertinoActivityIndicator(),
+                                          Text(dic.encointer.meetupLocation),
+                                        ],
+                                      ),
+                                      onPressed: widget.store.encointer.meetupLocation != null
+                                          ? () => Navigator.push(
+                                                context,
+                                                MaterialPageRoute(
+                                                  builder: (context) {
+                                                    return EncointerMap(
+                                                      widget.store,
+                                                      popupBuilder: (BuildContext context, Marker marker) => SizedBox(),
+                                                      markers: buildMarkers(widget.store.encointer.meetupLocation),
+                                                      title: dic.encointer.meetupLocation,
+                                                      center: widget.store.encointer.meetupLocation.toLatLng(),
+                                                      initialZoom: initialZoom,
+                                                    );
+                                                  },
+                                                ),
+                                              )
+                                          : null,
+                                    )
+                                  ],
+                                )
+                              : Text(
+                                  "You are not registered for ceremony on " +
+                                      DateFormat('yyyy-MM-dd').format(
+                                          new DateTime.fromMillisecondsSinceEpoch(widget.store.encointer.meetupTime)) +
+                                      " for the selected community",
+                                  style: TextStyle(color: Colors.red),
+                                ),
+                        ],
+                      ))
           ],
         ),
       ),

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -75,7 +75,7 @@ class AssignmentPanel extends StatelessWidget {
                             : Column(
                                 children: [
                                   Text(
-                                    "You are not registered for ceremony on  for the selected community on:",
+                                    "You are not registered for a ceremony for the selected community on:",
                                     style: TextStyle(color: Colors.red),
                                     textAlign: TextAlign.center,
                                   ),

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -32,7 +32,7 @@ class AssignmentPanel extends StatelessWidget {
                     ? Text(dic.assets.communitiesNotFound)
                     : Column(
                         children: <Widget>[
-                          store.encointer.meetupIndex > 0
+                          store.encointer.isRegistered
                               ? Column(
                                   children: <Widget>[
                                     Text("You are registered! ", style: TextStyle(color: Colors.green)),

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -37,8 +37,10 @@ class AssignmentPanel extends StatelessWidget {
                                   children: <Widget>[
                                     Text("You are registered! ", style: TextStyle(color: Colors.green)),
                                     Text("Ceremony will take place on:"),
-                                    Text(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)
-                                        .toIso8601String()),
+                                    store.encointer.meetupTime != null
+                                        ? Text(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)
+                                            .toIso8601String())
+                                        : CupertinoActivityIndicator(),
                                     ElevatedButton(
                                       child: Row(
                                         mainAxisSize: MainAxisSize.min,

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -11,17 +11,10 @@ import 'package:intl/intl.dart';
 
 import 'encointerMap.dart';
 
-class AssignmentPanel extends StatefulWidget {
+class AssignmentPanel extends StatelessWidget {
   AssignmentPanel(this.store);
 
   final AppStore store;
-
-  @override
-  _AssignmentPanelState createState() => _AssignmentPanelState();
-}
-
-class _AssignmentPanelState extends State<AssignmentPanel> {
-  _AssignmentPanelState();
 
   final double initialZoom = 14;
 
@@ -35,22 +28,22 @@ class _AssignmentPanelState extends State<AssignmentPanel> {
         child: Column(
           children: <Widget>[
             Observer(
-                builder: (_) => widget.store.encointer.communities == null
+                builder: (_) => store.encointer.communities == null
                     ? Text(dic.assets.communitiesNotFound)
                     : Column(
                         children: <Widget>[
-                          widget.store.encointer.meetupIndex > 0
+                          store.encointer.meetupIndex > 0
                               ? Column(
                                   children: <Widget>[
                                     Text("You are registered! ", style: TextStyle(color: Colors.green)),
                                     Text("Ceremony will take place on:"),
-                                    Text(new DateTime.fromMillisecondsSinceEpoch(widget.store.encointer.meetupTime)
+                                    Text(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)
                                         .toIso8601String()),
                                     ElevatedButton(
                                       child: Row(
                                         mainAxisSize: MainAxisSize.min,
                                         children: [
-                                          widget.store.encointer.meetupLocation != null
+                                          store.encointer.meetupLocation != null
                                               ? Icon(
                                                   Icons.location_on,
                                                   size: 25,
@@ -60,17 +53,17 @@ class _AssignmentPanelState extends State<AssignmentPanel> {
                                           Text(dic.encointer.meetupLocation),
                                         ],
                                       ),
-                                      onPressed: widget.store.encointer.meetupLocation != null
+                                      onPressed: store.encointer.meetupLocation != null
                                           ? () => Navigator.push(
                                                 context,
                                                 MaterialPageRoute(
                                                   builder: (context) {
                                                     return EncointerMap(
-                                                      widget.store,
+                                                      store,
                                                       popupBuilder: (BuildContext context, Marker marker) => SizedBox(),
-                                                      markers: buildMarkers(widget.store.encointer.meetupLocation),
+                                                      markers: buildMarkers(store.encointer.meetupLocation),
                                                       title: dic.encointer.meetupLocation,
-                                                      center: widget.store.encointer.meetupLocation.toLatLng(),
+                                                      center: store.encointer.meetupLocation.toLatLng(),
                                                       initialZoom: initialZoom,
                                                     );
                                                   },
@@ -82,8 +75,8 @@ class _AssignmentPanelState extends State<AssignmentPanel> {
                                 )
                               : Text(
                                   "You are not registered for ceremony on " +
-                                      DateFormat('yyyy-MM-dd').format(
-                                          new DateTime.fromMillisecondsSinceEpoch(widget.store.encointer.meetupTime)) +
+                                      DateFormat('yyyy-MM-dd')
+                                          .format(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)) +
                                       " for the selected community",
                                   style: TextStyle(color: Colors.red),
                                 ),

--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -28,62 +28,63 @@ class AssignmentPanel extends StatelessWidget {
         child: Column(
           children: <Widget>[
             Observer(
-                builder: (_) => store.encointer.communities == null
-                    ? Text(dic.assets.communitiesNotFound)
-                    : Column(
-                        children: <Widget>[
-                          store.encointer.isRegistered
-                              ? Column(
-                                  children: <Widget>[
-                                    Text("You are registered! ", style: TextStyle(color: Colors.green)),
-                                    Text("Ceremony will take place on:"),
-                                    store.encointer.meetupTime != null
-                                        ? Text(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)
-                                            .toIso8601String())
-                                        : CupertinoActivityIndicator(),
-                                    ElevatedButton(
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          store.encointer.meetupLocation != null
-                                              ? Icon(
-                                                  Icons.location_on,
-                                                  size: 25,
-                                                  color: Colors.blueAccent,
-                                                )
-                                              : CupertinoActivityIndicator(),
-                                          Text(dic.encointer.meetupLocation),
-                                        ],
-                                      ),
-                                      onPressed: store.encointer.meetupLocation != null
-                                          ? () => Navigator.push(
-                                                context,
-                                                MaterialPageRoute(
-                                                  builder: (context) {
-                                                    return EncointerMap(
-                                                      store,
-                                                      popupBuilder: (BuildContext context, Marker marker) => SizedBox(),
-                                                      markers: buildMarkers(store.encointer.meetupLocation),
-                                                      title: dic.encointer.meetupLocation,
-                                                      center: store.encointer.meetupLocation.toLatLng(),
-                                                      initialZoom: initialZoom,
-                                                    );
-                                                  },
-                                                ),
+              builder: (_) => store.encointer.communities == null
+                  ? Text(dic.assets.communitiesNotFound)
+                  : Column(
+                      children: <Widget>[
+                        store.encointer.isRegistered
+                            ? Column(
+                                children: <Widget>[
+                                  Text("You are registered! ", style: TextStyle(color: Colors.green)),
+                                  Text("Ceremony will take place on:"),
+                                  MaybeMeetupTime(store.encointer.meetupTime, dateFormat: 'yyyy-mm-dd-hh:mm'),
+                                  ElevatedButton(
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        store.encointer.meetupLocation != null
+                                            ? Icon(
+                                                Icons.location_on,
+                                                size: 25,
+                                                color: Colors.blueAccent,
                                               )
-                                          : null,
-                                    )
-                                  ],
-                                )
-                              : Text(
-                                  "You are not registered for ceremony on " +
-                                      DateFormat('yyyy-MM-dd')
-                                          .format(new DateTime.fromMillisecondsSinceEpoch(store.encointer.meetupTime)) +
-                                      " for the selected community",
-                                  style: TextStyle(color: Colors.red),
-                                ),
-                        ],
-                      ))
+                                            : CupertinoActivityIndicator(),
+                                        Text(dic.encointer.meetupLocation),
+                                      ],
+                                    ),
+                                    onPressed: store.encointer.meetupLocation != null
+                                        ? () => Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (context) {
+                                                  return EncointerMap(
+                                                    store,
+                                                    popupBuilder: (BuildContext context, Marker marker) => SizedBox(),
+                                                    markers: buildMarkers(store.encointer.meetupLocation),
+                                                    title: dic.encointer.meetupLocation,
+                                                    center: store.encointer.meetupLocation.toLatLng(),
+                                                    initialZoom: initialZoom,
+                                                  );
+                                                },
+                                              ),
+                                            )
+                                        : null,
+                                  )
+                                ],
+                              )
+                            : Column(
+                                children: [
+                                  Text(
+                                    "You are not registered for ceremony on  for the selected community on:",
+                                    style: TextStyle(color: Colors.red),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  MaybeMeetupTime(store.encointer.meetupTime),
+                                ],
+                              ),
+                      ],
+                    ),
+            )
           ],
         ),
       ),
@@ -110,5 +111,25 @@ class AssignmentPanel extends StatelessWidget {
       ),
     );
     return markers;
+  }
+}
+
+class MaybeMeetupTime extends StatelessWidget {
+  MaybeMeetupTime(this.meetupTime, {this.dateFormat = 'yyyy-MM-dd', this.style});
+
+  final int meetupTime;
+
+  final String dateFormat;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    String date;
+
+    if (meetupTime != null) {
+      date = DateFormat(dateFormat).format(new DateTime.fromMillisecondsSinceEpoch(meetupTime));
+    }
+
+    return meetupTime != null ? Text(date, style: this.style) : CupertinoActivityIndicator();
   }
 }

--- a/lib/page-encointer/encointerEntry.dart
+++ b/lib/page-encointer/encointerEntry.dart
@@ -125,7 +125,7 @@ class _PhaseAwareBoxState extends State<PhaseAwareBox> with SingleTickerProvider
   }
 
   Widget _getPhaseViewOffline() {
-    if (store.encointer.meetupIndex == null || store.encointer.meetupIndex == 0) {
+    if (store.encointer.isRegistered) {
       return RegisteringPage(store);
     } else {
       int timeToMeetup = store.encointer.getTimeToMeetup();

--- a/lib/page-encointer/phases/assigning/assigningPage.dart
+++ b/lib/page-encointer/phases/assigning/assigningPage.dart
@@ -73,7 +73,7 @@ class _AssigningPageState extends State<AssigningPage> {
       child: Column(children: <Widget>[
         AssignmentPanel(store),
         SizedBox(height: 16),
-        store.encointer.meetupIndex != null && store.encointer.meetupIndex > 0
+        store.encointer.isRegistered
             ? Container(
                 key: Key('start-meetup'),
                 child: Column(

--- a/lib/page-encointer/phases/attesting/attestingPage.dart
+++ b/lib/page-encointer/phases/attesting/attestingPage.dart
@@ -36,13 +36,13 @@ class _AttestingPageState extends State<AttestingPage> {
             shrinkWrap: true,
             children: <Widget>[
               SizedBox(height: 16),
-              ((store.encointer.meetupIndex == null) | (store.encointer.meetupIndex == 0))
-                  ? Text(dic.encointer.meetupNotAssigned)
-                  : PrimaryButton(
+              store.encointer.isRegistered
+                  ? PrimaryButton(
                       key: Key('start-meetup'),
                       child: Text(dic.encointer.meetupStart),
                       onPressed: () => startMeetup(context, store),
-                    ),
+                    )
+                  : Text(dic.encointer.meetupNotAssigned),
               SizedBox(height: 16),
               Text(
                 dic.encointer.claimsScanned

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -233,12 +233,12 @@ class ApiEncointer {
   Future<DateTime> getMeetupTime() async {
     print("api: getMeetupTime");
 
-    var mLocation = store.encointer.communityLocations.first;
-
-    if (mLocation == null) {
-      print("No meetup location set. Can't get meetup time");
+    if (store.encointer.communityLocations.isEmpty) {
+      print("No meetup locations found, can't get meetup time.");
       return null;
     }
+
+    var mLocation = store.encointer.communityLocations.first;
 
     int time = await apiRoot
         .evalJavascript(

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -233,6 +233,8 @@ class ApiEncointer {
   Future<DateTime> getMeetupTime() async {
     print("api: getMeetupTime");
 
+    // I we are not assigned to a meetup, we just get any location to get an estimate of the chosen community's meetup
+    // times.
     var mLocation = store.encointer.meetupLocation ?? store.encointer.communityLocations.isEmpty
         ? store.encointer.communityLocations.first
         : null;

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -233,12 +233,14 @@ class ApiEncointer {
   Future<DateTime> getMeetupTime() async {
     print("api: getMeetupTime");
 
+    var mLocation = store.encointer.meetupLocation ?? store.encointer.communityLocations.isEmpty
+        ? store.encointer.communityLocations.first
+        : null;
+
     if (store.encointer.communityLocations.isEmpty) {
       print("No meetup locations found, can't get meetup time.");
       return null;
     }
-
-    var mLocation = store.encointer.communityLocations.first;
 
     int time = await apiRoot
         .evalJavascript(

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -146,6 +146,25 @@ class ApiEncointer {
     }
   }
 
+  /// Queries the Communities pallet's RPC: api.rpc.communities.getLocations(cid)
+  ///
+  /// This is on-chain in Cantillon
+  Future<void> getAllMeetupLocations() async {
+    print("api: getAllMeetupLocations");
+    CommunityIdentifier cid = store.encointer.chosenCid;
+
+    if (cid == null) {
+      return;
+    }
+
+    List<Location> locs = await apiRoot
+        .evalJavascript('encointer.getAllMeetupLocations(${jsonEncode(cid)})')
+        .then((list) => List.from(list).map((l) => Location.fromJson(l)).toList());
+
+    print("api: getAllMeetupLocations: " + locs.toString());
+    store.encointer.setCommunityLocations(locs);
+  }
+
   /// Queries the Communities pallet: encointerCommunities.communityMetadata(cid)
   ///
   /// This is on-chain in Cantillon

--- a/lib/service/substrateApi/encointer/apiEncointer.dart
+++ b/lib/service/substrateApi/encointer/apiEncointer.dart
@@ -232,7 +232,8 @@ class ApiEncointer {
   /// We could fetch the phaseDurations at application startup, cache them and supply them in the call here.
   Future<DateTime> getMeetupTime() async {
     print("api: getMeetupTime");
-    var mLocation = store.encointer.meetupLocation;
+
+    var mLocation = store.encointer.communityLocations.first;
 
     if (mLocation == null) {
       print("No meetup location set. Can't get meetup time");

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -296,6 +296,8 @@ abstract class _EncointerStore with Store {
     communityLocations = ObservableList.of(locations);
     cacheObject(encointerCommunityLocationsKey, locations);
 
+    // There is no race-condition with the `getMeetupTime` call in `setMeetupLocation` because `getMeetupTime` uses
+    // internally the `meetupLocation`. Hence, the worst case scenario is a redundant rpc call.
     webApi.encointer.getMeetupTime();
   }
 

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -222,6 +222,11 @@ abstract class _EncointerStore with Store {
       cacheObject(encointerMeetupLocationKey, location);
       meetupLocation = location;
     }
+
+    if (location != null) {
+      // update depending values
+      webApi.encointer.getMeetupTime();
+    }
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -28,6 +28,7 @@ abstract class _EncointerStore with Store {
   final String encointerCommunityKey = 'wallet_encointer_community';
   final String encointerCommunityMetadataKey = 'wallet_encointer_community_metadata';
   final String encointerCommunitiesKey = 'wallet_encointer_communities';
+  final String encointerCommunityLocationsKey = 'wallet_encointer_community_locations';
 
   // offline meetup cache.
   final String encointerCurrentCeremonyIndexKey = 'wallet_encointer_current_ceremony_index';
@@ -111,6 +112,9 @@ abstract class _EncointerStore with Store {
 
   @observable
   ObservableList<AccountBusinessTuple> businessRegistry;
+
+  @observable
+  ObservableList<Location> communityLocations = new ObservableList();
 
   @computed
   String get communityName => communityMetadata?.name;
@@ -283,6 +287,13 @@ abstract class _EncointerStore with Store {
   }
 
   @action
+  void setCommunityLocations([List<Location> locations]) {
+    print("store: set communityLocations to ${locations.toString()}");
+    communityLocations = ObservableList.of(locations);
+    cacheObject(encointerCommunityLocationsKey, locations);
+  }
+
+  @action
   void setReputations(List<String> rep) {
     print("store: set communities to $rep");
     reputations = rep;
@@ -313,6 +324,7 @@ abstract class _EncointerStore with Store {
       webApi.encointer.getParticipantIndex();
       webApi.encointer.getEncointerBalance();
       webApi.encointer.getCommunityMetadata();
+      webApi.encointer.getAllMeetupLocations();
       webApi.encointer.getDemurrage();
     }
   }
@@ -401,6 +413,14 @@ abstract class _EncointerStore with Store {
       print("found cached communities. will recover it: " + cachedCommunities.toString());
       communities = cachedCommunities;
     }
+
+    List<dynamic> cachedLocations = await loadObject(encointerCommunityLocationsKey);
+    if (cachedLocations != null) {
+      List<Location> locations = cachedLocations.map((s) => Location.fromJson(s)).toList();
+      print("found cached communities. will recover it: " + locations.toString());
+      communityLocations = ObservableList.of(locations);
+    }
+
     // get meetup related data
     var data = await loadObject(encointerParticipantsClaimsKey);
     if (data != null) {

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -177,6 +177,7 @@ abstract class _EncointerStore with Store {
   void updateState() {
     switch (currentPhase) {
       case CeremonyPhase.REGISTERING:
+        webApi.encointer.getMeetupTime();
         break;
       case CeremonyPhase.ASSIGNING:
         webApi.encointer.getMeetupIndex();
@@ -220,11 +221,6 @@ abstract class _EncointerStore with Store {
     if (meetupLocation != location) {
       cacheObject(encointerMeetupLocationKey, location);
       meetupLocation = location;
-    }
-
-    if (location != null) {
-      // update depending values
-      webApi.encointer.getMeetupTime();
     }
   }
 
@@ -294,6 +290,8 @@ abstract class _EncointerStore with Store {
     print("store: set communityLocations to ${locations.toString()}");
     communityLocations = ObservableList.of(locations);
     cacheObject(encointerCommunityLocationsKey, locations);
+
+    webApi.encointer.getMeetupTime();
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -135,6 +135,9 @@ abstract class _EncointerStore with Store {
     return applyDemurrage(communityBalanceEntry);
   }
 
+  @computed
+  bool get isRegistered => meetupIndex != null && meetupIndex > 0;
+
   double applyDemurrage(BalanceEntry entry) {
     double res;
     if (rootStore.chain.latestHeaderNumber != null && entry != null && demurrage != null) {

--- a/lib/store/encointer/encointer.g.dart
+++ b/lib/store/encointer/encointer.g.dart
@@ -352,6 +352,21 @@ mixin _$EncointerStore on _EncointerStore, Store {
     });
   }
 
+  final _$communityLocationsAtom = Atom(name: '_EncointerStore.communityLocations');
+
+  @override
+  ObservableList<Location> get communityLocations {
+    _$communityLocationsAtom.reportRead();
+    return super.communityLocations;
+  }
+
+  @override
+  set communityLocations(ObservableList<Location> value) {
+    _$communityLocationsAtom.reportWrite(value, super.communityLocations, () {
+      super.communityLocations = value;
+    });
+  }
+
   final _$setTransferTxsAsyncAction = AsyncAction('_EncointerStore.setTransferTxs');
 
   @override
@@ -507,6 +522,16 @@ mixin _$EncointerStore on _EncointerStore, Store {
   }
 
   @override
+  void setCommunityLocations([List<Location> locations]) {
+    final _$actionInfo = _$_EncointerStoreActionController.startAction(name: '_EncointerStore.setCommunityLocations');
+    try {
+      return super.setCommunityLocations(locations);
+    } finally {
+      _$_EncointerStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   void setReputations(List<String> rep) {
     final _$actionInfo = _$_EncointerStoreActionController.startAction(name: '_EncointerStore.setReputations');
     try {
@@ -609,6 +634,7 @@ demurrage: ${demurrage},
 participantsClaims: ${participantsClaims},
 txsTransfer: ${txsTransfer},
 businessRegistry: ${businessRegistry},
+communityLocations: ${communityLocations},
 currentPhaseDuration: ${currentPhaseDuration},
 scannedClaimsCount: ${scannedClaimsCount},
 communityName: ${communityName},


### PR DESCRIPTION
* Closes #454 
* Closes #456 
* Closes #457

Changes:
* If the user is not assigned to a meetup, the meetup time is computed based on the community's first location.
* Fetch and cache all meetup locations of communities
* Introduce computed value `isRegistered`.