### PR TITLE
bugfix bottom navigation bar, swiping is now disabled

### DIFF
--- a/lib/page-encointer/homePage.dart
+++ b/lib/page-encointer/homePage.dart
@@ -116,6 +116,7 @@ class _EncointerHomePageState extends State<EncointerHomePage> {
       key: EncointerHomePage.encointerHomePageKey,
       backgroundColor: Colors.white,
       body: PageView(
+        physics: NeverScrollableScrollPhysics(),
         controller: _pageController,
         children: [
           Assets(store),


### PR DESCRIPTION
* the user has to tap on the icons in the bottom navigation bar now and cannot swipe between tabs. Closes #420 