### PR TITLE
Add combined account community selector and fix remaining issues from #327

### DIFF
--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -128,11 +128,12 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                 ],
               ),
               SizedBox(height: 4),
-              if (widget.isClickable) Text(
-                '${store.encointer.communityName}\n${Fmt.accountName(context, store.account.currentAccount)}',
-                style: Theme.of(context).textTheme.headline4.copyWith(color: encointerGrey, height: 1.5),
-                textAlign: TextAlign.center,
-              ),
+              if (widget.isClickable)
+                Text(
+                  '${store.encointer.communityName}\n${Fmt.accountName(context, store.account.currentAccount)}',
+                  style: Theme.of(context).textTheme.headline4.copyWith(color: encointerGrey, height: 1.5),
+                  textAlign: TextAlign.center,
+                ),
             ],
           ),
         ),
@@ -158,7 +159,7 @@ class CommunityAvatar extends StatelessWidget {
     return Card(
       elevation: 10,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(96),
+        borderRadius: BorderRadius.circular(avatarSize),
       ),
       child: SizedBox(
         width: avatarSize,

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -77,10 +77,16 @@ class _CommunityChooserPanelState extends State<CommunityChooserPanel> {
   }
 }
 
+/// the CombinedCommunityAndAccountAvatar should be wrapped in an InkWell to provide the callback on a click
 class CombinedCommunityAndAccountAvatar extends StatefulWidget {
-  const CombinedCommunityAndAccountAvatar(this.store, {Key key}) : super(key: key);
+  const CombinedCommunityAndAccountAvatar(this.store, {Key key, this.isClickable = true}) : super(key: key);
 
   final AppStore store;
+
+  /// whether this UI element should be interactive (i.e. clickable) or readonly
+  /// the text beneath the icons will be hidden in case it is readonly
+  /// the CombinedCommunityAndAccountAvatar should be wrapped in an InkWell to provide the callback on a click
+  final bool isClickable;
 
   @override
   _CombinedCommunityAndAccountAvatarState createState() => _CombinedCommunityAndAccountAvatarState(store);
@@ -122,7 +128,7 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                 ],
               ),
               SizedBox(height: 4),
-              Text(
+              if (widget.isClickable) Text(
                 '${store.encointer.communityName}\n${Fmt.accountName(context, store.account.currentAccount)}',
                 style: Theme.of(context).textTheme.headline4.copyWith(color: encointerGrey, height: 1.5),
                 textAlign: TextAlign.center,

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -78,14 +78,11 @@ class _CommunityChooserPanelState extends State<CommunityChooserPanel> {
 
 /// the CombinedCommunityAndAccountAvatar should be wrapped in an InkWell to provide the callback on a click
 class CombinedCommunityAndAccountAvatar extends StatefulWidget {
-  const CombinedCommunityAndAccountAvatar(this.store, {Key key, this.isClickable = true}) : super(key: key);
+  const CombinedCommunityAndAccountAvatar(this.store, {Key key, this.showCommunityNameAndAccountName = true}) : super(key: key);
 
   final AppStore store;
 
-  /// whether this UI element should be interactive (i.e. clickable) or readonly
-  /// the text beneath the icons will be hidden in case it is readonly
-  /// the CombinedCommunityAndAccountAvatar should be wrapped in an InkWell to provide the callback on a click
-  final bool isClickable;
+  final bool showCommunityNameAndAccountName;
 
   @override
   _CombinedCommunityAndAccountAvatarState createState() => _CombinedCommunityAndAccountAvatarState(store);
@@ -135,7 +132,7 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                 ],
               ),
               SizedBox(height: 4),
-              if (widget.isClickable)
+              if (widget.showCommunityNameAndAccountName)
                 Text(
                   '${store.encointer.communityName}\n${Fmt.accountName(context, store.account.currentAccount)}',
                   style: Theme.of(context).textTheme.headline4.copyWith(color: encointerGrey, height: 1.5),

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -78,9 +78,16 @@ class _CommunityChooserPanelState extends State<CommunityChooserPanel> {
 
 /// the CombinedCommunityAndAccountAvatar should be wrapped in an InkWell to provide the callback on a click
 class CombinedCommunityAndAccountAvatar extends StatefulWidget {
-  const CombinedCommunityAndAccountAvatar(this.store, {Key key, this.showCommunityNameAndAccountName = true}) : super(key: key);
+  const CombinedCommunityAndAccountAvatar(this.store,
+      {Key key,
+      this.showCommunityNameAndAccountName = true,
+      this.communityAvatarSize = 96,
+      this.accountAvatarSize = 34})
+      : super(key: key);
 
   final AppStore store;
+  final double communityAvatarSize;
+  final double accountAvatarSize;
 
   final bool showCommunityNameAndAccountName;
 
@@ -90,8 +97,6 @@ class CombinedCommunityAndAccountAvatar extends StatefulWidget {
 
 class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAndAccountAvatar> {
   final AppStore store;
-  static const double communityAvatarSize = 96;
-  static const double accountAvatarSize = 34;
 
   _CombinedCommunityAndAccountAvatarState(this.store);
 
@@ -110,12 +115,12 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                     child: Card(
                       elevation: 10,
                       shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(communityAvatarSize),
+                        borderRadius: BorderRadius.circular(widget.communityAvatarSize),
                       ),
                       child: CommunityAvatar(
                         store: store,
                         avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                        avatarSize: communityAvatarSize,
+                        avatarSize: widget.communityAvatarSize,
                       ),
                     ),
                   ),
@@ -124,7 +129,7 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                     right: 0,
                     child: AddressIcon(
                       '',
-                      size: accountAvatarSize,
+                      size: widget.accountAvatarSize,
                       pubKey: store.account.currentAccount.pubKey,
                       tapToCopy: false,
                     ),

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -8,6 +8,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:encointer_wallet/utils/format.dart';
+import 'package:encointer_wallet/common/theme.dart';
+import 'package:encointer_wallet/common/components/addressIcon.dart';
 
 class CommunityChooserPanel extends StatefulWidget {
   CommunityChooserPanel(this.store);
@@ -74,19 +77,19 @@ class _CommunityChooserPanelState extends State<CommunityChooserPanel> {
   }
 }
 
-class CommunityWithCommunityChooser extends StatefulWidget {
-  const CommunityWithCommunityChooser(this.store, {Key key}) : super(key: key);
+class CombinedCommunityAndAccountAvatar extends StatefulWidget {
+  const CombinedCommunityAndAccountAvatar(this.store, {Key key}) : super(key: key);
 
   final AppStore store;
 
   @override
-  _CommunityWithCommunityChooserState createState() => _CommunityWithCommunityChooserState(store);
+  _CombinedCommunityAndAccountAvatarState createState() => _CombinedCommunityAndAccountAvatarState(store);
 }
 
-class _CommunityWithCommunityChooserState extends State<CommunityWithCommunityChooser> {
+class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAndAccountAvatar> {
   final AppStore store;
 
-  _CommunityWithCommunityChooserState(this.store);
+  _CombinedCommunityAndAccountAvatarState(this.store);
 
   @override
   Widget build(BuildContext context) {
@@ -94,48 +97,76 @@ class _CommunityWithCommunityChooserState extends State<CommunityWithCommunityCh
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Observer(
-          builder: (_) => InkWell(
-            key: Key('cid-avatar'),
-            child: Column(
-              children: [
-                Card(
-                  elevation: 10,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(96),
+          builder: (_) => Column(
+            children: [
+              Stack(
+                children: [
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(0, 0, 2, 2),
+                    child: CommunityAvatar(
+                        store: store,
+                        avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
+                        avatarSize: 96),
                   ),
-                  child: SizedBox(
-                    width: 96,
-                    height: 96,
-                    child: FutureBuilder<SvgPicture>(
-                      future: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                      builder: (_, AsyncSnapshot<SvgPicture> snapshot) {
-                        if (snapshot.hasData) {
-                          return snapshot.data;
-                        } else {
-                          return CupertinoActivityIndicator();
-                        }
-                      },
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: AddressIcon(
+                      '',
+                      size: 34,
+                      pubKey: store.account.currentAccount.pubKey,
+                      tapToCopy: false,
                     ),
-                  ),
-                ),
-                SizedBox(height: 6),
-                Text(
-                  store.encointer.communityName ?? '...',
-                  style: Theme.of(context).textTheme.headline4,
-                ),
-              ],
-            ),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => CommunityChooserOnMap(store),
-                ),
-              );
-            },
+                  )
+                ],
+              ),
+              SizedBox(height: 4),
+              Text(
+                '${store.encointer.communityName}\n${Fmt.accountName(context, store.account.currentAccount)}',
+                style: Theme.of(context).textTheme.headline4.copyWith(color: encointerGrey, height: 1.5),
+                textAlign: TextAlign.center,
+              ),
+            ],
           ),
         ),
       ],
+    );
+  }
+}
+
+class CommunityAvatar extends StatelessWidget {
+  const CommunityAvatar({
+    Key key,
+    @required this.store,
+    @required this.avatarIcon,
+    this.avatarSize = 120,
+  }) : super(key: key);
+
+  final AppStore store;
+  final double avatarSize;
+  final Future<SvgPicture> avatarIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 10,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(96),
+      ),
+      child: SizedBox(
+        width: avatarSize,
+        height: avatarSize,
+        child: FutureBuilder<SvgPicture>(
+          future: avatarIcon,
+          builder: (_, AsyncSnapshot<SvgPicture> snapshot) {
+            if (snapshot.hasData) {
+              return snapshot.data;
+            } else {
+              return CupertinoActivityIndicator();
+            }
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -1,5 +1,4 @@
 import 'package:encointer_wallet/common/components/roundedCard.dart';
-import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -109,11 +109,16 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                 children: [
                   Padding(
                     padding: EdgeInsets.fromLTRB(0, 0, 2, 2),
-                    child: CommunityAvatar(
+                    child: Card(
+                      elevation: 10,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(96),
+                      ),
+                      child: CommunityAvatar(
                       store: store,
                       avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
                       avatarSize: 96,
-                    ),
+                    ),),
                   ),
                   Positioned(
                     bottom: 0,
@@ -156,24 +161,18 @@ class CommunityAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 10,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(avatarSize),
-      ),
-      child: SizedBox(
-        width: avatarSize,
-        height: avatarSize,
-        child: FutureBuilder<SvgPicture>(
-          future: avatarIcon,
-          builder: (_, AsyncSnapshot<SvgPicture> snapshot) {
-            if (snapshot.hasData) {
-              return snapshot.data;
-            } else {
-              return CupertinoActivityIndicator();
-            }
-          },
-        ),
+    return SizedBox(
+      width: avatarSize,
+      height: avatarSize,
+      child: FutureBuilder<SvgPicture>(
+        future: avatarIcon,
+        builder: (_, AsyncSnapshot<SvgPicture> snapshot) {
+          if (snapshot.hasData) {
+            return snapshot.data;
+          } else {
+            return CupertinoActivityIndicator();
+          }
+        },
       ),
     );
   }

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -104,9 +104,9 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                   Padding(
                     padding: EdgeInsets.fromLTRB(0, 0, 2, 2),
                     child: CommunityAvatar(
-                        store: store,
-                        avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                        avatarSize: 96,
+                      store: store,
+                      avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
+                      avatarSize: 96,
                     ),
                   ),
                   Positioned(

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -94,6 +94,8 @@ class CombinedCommunityAndAccountAvatar extends StatefulWidget {
 
 class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAndAccountAvatar> {
   final AppStore store;
+  static const double communityAvatarSize = 96;
+  static const double accountAvatarSize = 34;
 
   _CombinedCommunityAndAccountAvatarState(this.store);
 
@@ -112,12 +114,12 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                     child: Card(
                       elevation: 10,
                       shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(96),
+                        borderRadius: BorderRadius.circular(communityAvatarSize),
                       ),
                       child: CommunityAvatar(
                       store: store,
                       avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                      avatarSize: 96,
+                      avatarSize: communityAvatarSize,
                     ),),
                   ),
                   Positioned(
@@ -125,7 +127,7 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                     right: 0,
                     child: AddressIcon(
                       '',
-                      size: 34,
+                      size: accountAvatarSize,
                       pubKey: store.account.currentAccount.pubKey,
                       tapToCopy: false,
                     ),

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -117,10 +117,11 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                         borderRadius: BorderRadius.circular(communityAvatarSize),
                       ),
                       child: CommunityAvatar(
-                      store: store,
-                      avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                      avatarSize: communityAvatarSize,
-                    ),),
+                        store: store,
+                        avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
+                        avatarSize: communityAvatarSize,
+                      ),
+                    ),
                   ),
                   Positioned(
                     bottom: 0,

--- a/lib/page-encointer/common/communityChooserPanel.dart
+++ b/lib/page-encointer/common/communityChooserPanel.dart
@@ -106,7 +106,8 @@ class _CombinedCommunityAndAccountAvatarState extends State<CombinedCommunityAnd
                     child: CommunityAvatar(
                         store: store,
                         avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                        avatarSize: 96),
+                        avatarSize: 96,
+                    ),
                   ),
                   Positioned(
                     bottom: 0,

--- a/lib/page/account/create/addAccountPage.dart
+++ b/lib/page/account/create/addAccountPage.dart
@@ -91,7 +91,7 @@ class _AddAccountPageState extends State<AddAccountPage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          dic.profile.accountAdd,
+          dic.profile.addAccount,
         ),
         leading: Container(),
         actions: <Widget>[

--- a/lib/page/assets/account_or_community/AccountOrCommunityData.dart
+++ b/lib/page/assets/account_or_community/AccountOrCommunityData.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class AccountOrCommunityData {
   final Widget avatar; // later Image
   final String name;
+  final bool isSelected;
 
-  AccountOrCommunityData({this.avatar, this.name});
+  AccountOrCommunityData({this.avatar, this.name, this.isSelected = false});
 }

--- a/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
+++ b/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
@@ -6,13 +6,13 @@ import 'AccountOrCommunityData.dart';
 class AccountOrCommunityItemHorizontal extends StatefulWidget {
   final AccountOrCommunityData itemData;
   final int index;
-  final Function onAvatarTapped;
+  final Function onTap;
 
   const AccountOrCommunityItemHorizontal({
     Key key,
     @required this.itemData,
     @required this.index,
-    @required this.onAvatarTapped,
+    @required this.onTap,
   }) : super(key: key);
 
   @override
@@ -25,7 +25,7 @@ class _AccountOrCommunityItemHorizontalState extends State<AccountOrCommunityIte
     return Column(
       children: [
         InkWell(
-          onTap: () => widget.onAvatarTapped(widget.index),
+          onTap: () => widget.onTap(widget.index),
           child: Container(
             padding: EdgeInsets.all(4),
             decoration: BoxDecoration(

--- a/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
+++ b/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
@@ -26,25 +26,15 @@ class _AccountOrCommunityItemHorizontalState extends State<AccountOrCommunityIte
   Widget build(BuildContext context) {
     return Column(
       children: [
-        SizedBox(
-          height: 4,
-        ),
         InkWell(
           onTap: () => widget.onAvatarTapped(widget.index),
           child: Container(
             padding: EdgeInsets.all(4),
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(100),
+              shape: BoxShape.circle,
               border: Border.all(width: 2, color: widget.isSelected ? ZurichLion.shade500 : Colors.transparent),
             ),
-            child: Container(
-              padding: EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: ZurichLion.shade50,
-                  boxShadow: [BoxShadow(blurRadius: 4, color: Color(0x11000000), spreadRadius: 4)]),
-              child: widget.itemData.avatar,
-            ),
+            child: widget.itemData.avatar,
           ),
         ),
         SizedBox(height: 16),

--- a/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
+++ b/lib/page/assets/account_or_community/accountOrCommunityItemHorizontal.dart
@@ -7,14 +7,12 @@ class AccountOrCommunityItemHorizontal extends StatefulWidget {
   final AccountOrCommunityData itemData;
   final int index;
   final Function onAvatarTapped;
-  final bool isSelected;
 
   const AccountOrCommunityItemHorizontal({
     Key key,
     @required this.itemData,
     @required this.index,
     @required this.onAvatarTapped,
-    @required this.isSelected,
   }) : super(key: key);
 
   @override
@@ -32,7 +30,8 @@ class _AccountOrCommunityItemHorizontalState extends State<AccountOrCommunityIte
             padding: EdgeInsets.all(4),
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              border: Border.all(width: 2, color: widget.isSelected ? ZurichLion.shade500 : Colors.transparent),
+              border:
+                  Border.all(width: 2, color: widget.itemData.isSelected ? ZurichLion.shade500 : Colors.transparent),
             ),
             child: widget.itemData.avatar,
           ),

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -21,14 +21,14 @@ class SwitchAccountOrCommunity extends StatefulWidget {
 }
 
 class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
-  static const double identiconPlusTextHeight = 110;
+  static const double identiconPlusTextHeight = 130;
   static const double itemExtent = 90;
 
   @override
   Widget build(BuildContext context) {
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       SizedBox(
-        height: 20,
+        height: 15,
       ),
       Center(
         child: Text(
@@ -36,7 +36,7 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
           style: Theme.of(context).textTheme.headline2,
         ),
       ),
-      SizedBox(height: 20),
+      SizedBox(height: 15),
       SizedBox(
         height: identiconPlusTextHeight,
         // otherwise ListView would use infinite height

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -7,12 +7,12 @@ class SwitchAccountOrCommunity extends StatefulWidget {
   SwitchAccountOrCommunity({
     this.rowTitle,
     this.data,
-    this.onAvatarTapped,
+    this.onTap,
   });
 
   final String rowTitle;
   final List<AccountOrCommunityData> data;
-  final Function onAvatarTapped;
+  final Function onTap;
 
   @override
   _SwitchAccountOrCommunityState createState() => _SwitchAccountOrCommunityState();
@@ -52,7 +52,7 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
                 itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
                   itemData: widget.data[index],
                   index: index,
-                  onAvatarTapped: widget.onAvatarTapped,
+                  onTap: widget.onTap,
                 ),
               ),
             ),

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -7,13 +7,11 @@ class SwitchAccountOrCommunity extends StatefulWidget {
   SwitchAccountOrCommunity({
     this.rowTitle,
     this.data,
-    this.selectedItem,
     this.onAvatarTapped,
   });
 
   final String rowTitle;
   final List<AccountOrCommunityData> data;
-  final int selectedItem;
   final Function onAvatarTapped;
 
   @override
@@ -47,7 +45,6 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
           itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
             itemData: widget.data[index],
             index: index,
-            isSelected: index == widget.selectedItem,
             onAvatarTapped: widget.onAvatarTapped,
           ),
         ),

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -38,18 +38,42 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
       SizedBox(
         height: identiconPlusTextHeight,
         // otherwise ListView would use infinite height
-        child: Center(
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            shrinkWrap: true,
-            itemExtent: itemExtent,
-            itemCount: widget.data != null ? widget.data.length : 0,
-            itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
-              itemData: widget.data[index],
-              index: index,
-              onAvatarTapped: widget.onAvatarTapped,
+        child: Stack(
+          children: [
+            Center(
+              child: ListView.builder(
+                padding: EdgeInsets.symmetric(horizontal: 20),
+                scrollDirection: Axis.horizontal,
+                shrinkWrap: true,
+                itemExtent: itemExtent,
+                itemCount: widget.data != null ? widget.data.length : 0,
+                itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
+                  itemData: widget.data[index],
+                  index: index,
+                  onAvatarTapped: widget.onAvatarTapped,
+                ),
+              ),
             ),
-          ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Container(
+                    decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                      colors: [Colors.white, Color(0x00ffffff)],
+                    )),
+                    height: identiconPlusTextHeight,
+                    width: 32),
+                Container(
+                    decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                      colors: [Color(0x00ffffff), Colors.white],
+                    )),
+                    height: identiconPlusTextHeight,
+                    width: 32),
+              ],
+            ),
+          ],
         ),
       ),
     ]);

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -38,14 +38,17 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
       SizedBox(
         height: identiconPlusTextHeight,
         // otherwise ListView would use infinite height
-        child: ListView.builder(
-          scrollDirection: Axis.horizontal,
-          itemExtent: itemExtent,
-          itemCount: widget.data != null ? widget.data.length : 0,
-          itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
-            itemData: widget.data[index],
-            index: index,
-            onAvatarTapped: widget.onAvatarTapped,
+        child: Center(
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            shrinkWrap: true,
+            itemExtent: itemExtent,
+            itemCount: widget.data != null ? widget.data.length : 0,
+            itemBuilder: (context, index) => AccountOrCommunityItemHorizontal(
+              itemData: widget.data[index],
+              index: index,
+              onAvatarTapped: widget.onAvatarTapped,
+            ),
           ),
         ),
       ),

--- a/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
+++ b/lib/page/assets/account_or_community/switchAccountOrCommunity.dart
@@ -21,6 +21,8 @@ class SwitchAccountOrCommunity extends StatefulWidget {
 class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
   static const double identiconPlusTextHeight = 130;
   static const double itemExtent = 90;
+  static const double fadeWidth = 32;
+  static const Color whiteTransparent = Color(0x00ffffff);
 
   @override
   Widget build(BuildContext context) {
@@ -59,18 +61,20 @@ class _SwitchAccountOrCommunityState extends State<SwitchAccountOrCommunity> {
               children: [
                 Container(
                     decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                      colors: [Colors.white, Color(0x00ffffff)],
-                    )),
+                      gradient: LinearGradient(
+                        colors: [Colors.white, whiteTransparent],
+                      ),
+                    ),
                     height: identiconPlusTextHeight,
-                    width: 32),
+                    width: fadeWidth),
                 Container(
                     decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                      colors: [Color(0x00ffffff), Colors.white],
-                    )),
+                      gradient: LinearGradient(
+                        colors: [whiteTransparent, Colors.white],
+                      ),
+                    ),
                     height: identiconPlusTextHeight,
-                    width: 32),
+                    width: fadeWidth),
               ],
             ),
           ],

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:ui';
 import 'dart:math';
 
-import 'package:encointer_wallet/common/components/addressIcon.dart';
 import 'package:encointer_wallet/common/components/dragHandle.dart';
 import 'package:encointer_wallet/common/components/gradientElements.dart';
 import 'package:encointer_wallet/common/components/passwordInputDialog.dart';
@@ -11,7 +10,6 @@ import 'package:encointer_wallet/page-encointer/ceremony_box/ceremonyBox.dart';
 import 'package:encointer_wallet/page-encointer/common/communityChooserPanel.dart';
 import 'package:encointer_wallet/page/assets/receive/receivePage.dart';
 import 'package:encointer_wallet/page/assets/transfer/transferPage.dart';
-import 'package:encointer_wallet/page/profile/account/accountManagePage.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/account/types/accountData.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -144,36 +142,13 @@ class _AssetsState extends State<Assets> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        CommunityWithCommunityChooser(store),
                         InkWell(
-                          child: Column(
-                            children: [
-                              AddressIcon(
-                                '',
-                                pubKey: store.account.currentAccount.pubKey,
-                                tapToCopy: false,
-                              ),
-                              SizedBox(height: 6),
-                              Text(
-                                Fmt.accountName(context, accountData),
-                                style: Theme.of(context).textTheme.headline4,
-                              ),
-                            ],
-                          ),
-                          onTap: () => Navigator.of(context).pushNamed(
-                            AccountManagePage.route,
-                          ),
-                        ),
-                        if (store.settings.developerMode)
-                          IconButton(
-                            icon: Icon(Icons.add),
-                            onPressed: () {
-                              // open sliding up panel
+                            child: CombinedCommunityAndAccountAvatar(store),
+                            onTap: () {
                               if (panelController != null && panelController.isAttached) {
                                 panelController.open();
                               }
-                            },
-                          ),
+                            }),
                       ],
                     ),
                     Observer(

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -45,6 +45,7 @@ class _AssetsState extends State<Assets> {
   final AppStore store;
   static const double panelHeight = 396;
   static const double fractionOfScreenHeight = .7;
+  static const double avatarSize = 70;
 
   bool _enteredPin = false;
 
@@ -76,17 +77,7 @@ class _AssetsState extends State<Assets> {
     _panelHeightOpen = min(MediaQuery.of(context).size.height * fractionOfScreenHeight,
         panelHeight); // should typically not be higher than panelHeight, but on really small devices it should not exceed fractionOfScreenHeight x the screen height.
 
-    List<AccountOrCommunityData> allCommunities = [
-      AccountOrCommunityData(
-        avatar: SizedBox(
-          child: Image.asset('assets/images/assets/ERT.png'),
-          height: 24,
-        ),
-        name: 'Default Community',
-      ),
-      AccountOrCommunityData(avatar: Icon(Icons.account_balance), name: 'Ba Community'),
-      AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Community'),
-    ];
+    List<AccountOrCommunityData> allCommunities = [];
     List<AccountOrCommunityData> allAccounts = [];
 
     return Scaffold(
@@ -120,7 +111,7 @@ class _AssetsState extends State<Assets> {
 
                 if (ModalRoute.of(context).isCurrent &&
                     !_enteredPin & store.settings.cachedPin.isEmpty & !store.settings.endpointIsGesell) {
-                  // The pin is not immeditally propagated to the store, hence we track if the pin has been entered to prevent
+                  // The pin is not immediately propagated to the store, hence we track if the pin has been entered to prevent
                   // showing the dialog multiple times.
                   WidgetsBinding.instance.addPostFrameCallback(
                     (_) {
@@ -294,27 +285,73 @@ class _AssetsState extends State<Assets> {
               ),
               DragHandle(),
               Column(children: [
-                SwitchAccountOrCommunity(
-                  rowTitle: 'Switch Community',
-                  data: allCommunities,
-                  selectedItem: selectedCommunityIndex,
-                  onAvatarTapped: (int index) {
-                    setState(() {
-                      selectedCommunityIndex = index;
-                    });
-                    if (index == allCommunities.length - 1) {
-                      print('TODO open add community');
-                      Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
-                    }
+                Observer(
+                  builder: (BuildContext context) {
+                    allCommunities = [];
+                    // TODO add back end code so we can initialize the list of communities similar to the commented out code
+                    // allCommunities.addAll(store.communities.communitiesList.map((community) => AccountOrCommunityData(
+                    //     avatar: webApi.ipfs.getCommunityIcon(community),
+                    //     name: community.name)));
+
+                    // For now show the selected community if available and let the user add a community from the world map community chooser
+                    allCommunities.add(
+                      AccountOrCommunityData(
+                          avatar: CommunityAvatar(
+                            store: store,
+                            avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
+                            avatarSize: avatarSize,
+                          ),
+                          name: '${store.encointer.communityIconsCid ?? '...'}'),
+                    );
+                    allCommunities.add(
+                      AccountOrCommunityData(
+                          avatar: Container(
+                            height: avatarSize,
+                            width: avatarSize,
+                            decoration: BoxDecoration(
+                              color: ZurichLion.shade50,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(Icons.add, size: 36),
+                          ),
+                          name: 'Add Community',
+                      ),
+                    );
+
+                    return SwitchAccountOrCommunity(
+                      rowTitle: 'Switch Community',
+                      data: allCommunities,
+                      selectedItem: selectedCommunityIndex,
+                      onAvatarTapped: (int index) {
+                        setState(() {
+                          selectedCommunityIndex = index;
+                        });
+                        if (index == allCommunities.length - 1) {
+                          print('TODO open add community');
+                          Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
+                        }
+                      },
+                    );
                   },
                 ),
                 Observer(builder: (BuildContext context) {
                   allAccounts = [];
-                  allAccounts.addAll(store.account.accountListAll.map((account) => AccountOrCommunityData(
-                      avatar: AddressIcon('', pubKey: account.pubKey, size: 36, tapToCopy: false),
-                      name: account.name)));
+                  allAccounts.addAll(store.account.accountListAll.map(
+                    (account) => AccountOrCommunityData(
+                        avatar: AddressIcon('', pubKey: account.pubKey, size: avatarSize, tapToCopy: false),
+                        name: account.name),
+                  ));
                   allAccounts.add(
-                    AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Account'),
+                    AccountOrCommunityData(
+                      avatar: Container(
+                      height: avatarSize,
+                      width: avatarSize,
+                      decoration: BoxDecoration(
+                        color: ZurichLion.shade50,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(Icons.add, size: 36),
+                    ), name: 'Add Account'),
                   );
 
                   return SwitchAccountOrCommunity(

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -309,7 +309,6 @@ class _AssetsState extends State<Assets> {
                   },
                 ),
                 Observer(builder: (BuildContext context) {
-                  print('llllll: ${store.account.accountListAll.length}');
                   allAccounts = [];
                   allAccounts.addAll(store.account.accountListAll.map((account) => AccountOrCommunityData(
                       avatar: AddressIcon('', pubKey: account.pubKey, size: 36, tapToCopy: false),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -289,7 +289,7 @@ class _AssetsState extends State<Assets> {
                     return SwitchAccountOrCommunity(
                       rowTitle: 'Switch Community',
                       data: allCommunities,
-                      onAvatarTapped: (int index) {
+                      onTap: (int index) {
                         if (index == allCommunities.length - 1) {
                           Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
                         } else {
@@ -306,7 +306,7 @@ class _AssetsState extends State<Assets> {
                   return SwitchAccountOrCommunity(
                     rowTitle: 'Switch Account',
                     data: allAccounts,
-                    onAvatarTapped: (int index) {
+                    onTap: (int index) {
                       if (index == allAccounts.length - 1) {
                         Navigator.of(context).pushNamed(AddAccountPage.route);
                       } else {

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -285,39 +285,7 @@ class _AssetsState extends State<Assets> {
               Column(children: [
                 Observer(
                   builder: (BuildContext context) {
-                    allCommunities = [];
-                    // TODO add back end code so we can initialize the list of communities similar to the commented out code
-                    // allCommunities.addAll(store.communities.communitiesList.map((community) => AccountOrCommunityData(
-                    //     avatar: webApi.ipfs.getCommunityIcon(community),
-                    //     name: community.name)));
-
-                    // For now show the selected community if available and let the user add a community from the world map community chooser
-                    allCommunities.add(
-                      AccountOrCommunityData(
-                        avatar: CommunityAvatar(
-                          store: store,
-                          avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
-                          avatarSize: avatarSize,
-                        ),
-                        name: '${store.encointer.communityName ?? '...'}',
-                        isSelected: true, // TODO this should later be a function applied on each community
-                      ),
-                    );
-                    allCommunities.add(
-                      AccountOrCommunityData(
-                        avatar: Container(
-                          height: avatarSize,
-                          width: avatarSize,
-                          decoration: BoxDecoration(
-                            color: ZurichLion.shade50,
-                            shape: BoxShape.circle,
-                          ),
-                          child: Icon(Icons.add, size: 36),
-                        ),
-                        name: 'Add Community',
-                      ),
-                    );
-
+                    allCommunities = initAllCommunities();
                     return SwitchAccountOrCommunity(
                       rowTitle: 'Switch Community',
                       data: allCommunities,
@@ -335,29 +303,7 @@ class _AssetsState extends State<Assets> {
                   },
                 ),
                 Observer(builder: (BuildContext context) {
-                  allAccounts = [];
-                  allAccounts.addAll(store.account.accountListAll.map(
-                    (account) => AccountOrCommunityData(
-                      avatar: AddressIcon('', pubKey: account.pubKey, size: avatarSize, tapToCopy: false),
-                      name: account.name,
-                      isSelected: account.pubKey == store.account.currentAccountPubKey,
-                    ),
-                  ));
-                  allAccounts.add(
-                    AccountOrCommunityData(
-                        avatar: Container(
-                          height: avatarSize,
-                          width: avatarSize,
-                          decoration: BoxDecoration(
-                            color: ZurichLion.shade50,
-                            shape: BoxShape.circle,
-                          ),
-                          child: Icon(Icons.add, size: 36),
-                        ),
-                        name: dic.profile.addAccount,
-                    ),
-                  );
-
+                  allAccounts = initAllAccounts(dic);
                   return SwitchAccountOrCommunity(
                     rowTitle: 'Switch Account',
                     data: allAccounts,
@@ -379,6 +325,68 @@ class _AssetsState extends State<Assets> {
         borderRadius: BorderRadius.only(topLeft: Radius.circular(40.0), topRight: Radius.circular(40.0)),
       ),
     );
+  }
+
+  List<AccountOrCommunityData> initAllCommunities() {
+    List<AccountOrCommunityData> allCommunities = [];
+    // TODO add back end code so we can initialize the list of communities similar to the commented out code
+    // allCommunities.addAll(store.communities.communitiesList.map((community) => AccountOrCommunityData(
+    //     avatar: webApi.ipfs.getCommunityIcon(community),
+    //     name: community.name)));
+
+    // For now show the selected community if available and let the user add a community from the world map community chooser
+    allCommunities.add(
+      AccountOrCommunityData(
+        avatar: CommunityAvatar(
+          store: store,
+          avatarIcon: webApi.ipfs.getCommunityIcon(store.encointer.communityIconsCid),
+          avatarSize: avatarSize,
+        ),
+        name: '${store.encointer.communityName ?? '...'}',
+        isSelected: true, // TODO this should later be a function applied on each community
+      ),
+    );
+    allCommunities.add(
+      AccountOrCommunityData(
+        avatar: Container(
+          height: avatarSize,
+          width: avatarSize,
+          decoration: BoxDecoration(
+            color: ZurichLion.shade50,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(Icons.add, size: 36),
+        ),
+        name: 'Add Community',
+      ),
+    );
+    return allCommunities;
+  }
+
+  List<AccountOrCommunityData> initAllAccounts(Translations dic) {
+    List<AccountOrCommunityData> allAccounts = [];
+    allAccounts.addAll(store.account.accountListAll.map(
+      (account) => AccountOrCommunityData(
+        avatar: AddressIcon('', pubKey: account.pubKey, size: avatarSize, tapToCopy: false),
+        name: account.name,
+        isSelected: account.pubKey == store.account.currentAccountPubKey,
+      ),
+    ));
+    allAccounts.add(
+      AccountOrCommunityData(
+          avatar: Container(
+            height: avatarSize,
+            width: avatarSize,
+            decoration: BoxDecoration(
+              color: ZurichLion.shade50,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(Icons.add, size: 36),
+          ),
+          name: dic.profile.addAccount,
+      ),
+    );
+    return allAccounts;
   }
 
   Future<void> switchAccount(AccountData account) async {

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -23,6 +23,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
+import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
 
 import 'account_or_community/AccountOrCommunityData.dart';
 import 'account_or_community/switchAccountOrCommunity.dart';
@@ -82,9 +83,6 @@ class _AssetsState extends State<Assets> {
         name: 'Default Community',
       ),
       AccountOrCommunityData(avatar: Icon(Icons.account_balance), name: 'Ba Community'),
-      AccountOrCommunityData(avatar: Icon(Icons.add_a_photo_sharp), name: 'Photo Phhhhh'),
-      AccountOrCommunityData(avatar: Icon(Icons.shop), name: 'Shop shop shop'),
-      AccountOrCommunityData(avatar: Icon(Icons.gamepad), name: 'Gamepad'),
       AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Community'),
     ];
     var accountData = [
@@ -310,6 +308,9 @@ class _AssetsState extends State<Assets> {
                     });
                     if (index == communityData.length - 1) {
                       print('TODO open add community');
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
                     }
                   },
                 ),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -25,6 +25,7 @@ import 'package:iconsax/iconsax.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
 import 'package:encointer_wallet/page/account/create/addAccountPage.dart';
+import 'package:encointer_wallet/common/components/addressIcon.dart';
 
 import 'account_or_community/AccountOrCommunityData.dart';
 import 'account_or_community/switchAccountOrCommunity.dart';
@@ -75,7 +76,7 @@ class _AssetsState extends State<Assets> {
     _panelHeightOpen = min(MediaQuery.of(context).size.height * fractionOfScreenHeight,
         panelHeight); // should typically not be higher than panelHeight, but on really small devices it should not exceed fractionOfScreenHeight x the screen height.
 
-    var communityData = [
+    List<AccountOrCommunityData> allCommunities = [
       AccountOrCommunityData(
         avatar: SizedBox(
           child: Image.asset('assets/images/assets/ERT.png'),
@@ -86,14 +87,8 @@ class _AssetsState extends State<Assets> {
       AccountOrCommunityData(avatar: Icon(Icons.account_balance), name: 'Ba Community'),
       AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Community'),
     ];
-    var accountData = [
-      AccountOrCommunityData(avatar: Icon(Icons.access_alarm), name: 'Alarm aaa bbbbbbb'),
-      AccountOrCommunityData(avatar: Icon(Icons.account_balance), name: 'Balance asfda df'),
-      AccountOrCommunityData(avatar: Icon(Icons.add_a_photo_sharp), name: 'Photo assfd asdf'),
-      AccountOrCommunityData(avatar: Icon(Icons.shop), name: 'Shop asfd'),
-      AccountOrCommunityData(avatar: Icon(Icons.gamepad), name: 'Gamepad'),
-      AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Account'),
-    ];
+    List<AccountOrCommunityData> allAccounts = [];
+
     return Scaffold(
       appBar: AppBar(
         title: Text(dic.assets.home),
@@ -301,34 +296,43 @@ class _AssetsState extends State<Assets> {
               Column(children: [
                 SwitchAccountOrCommunity(
                   rowTitle: 'Switch Community',
-                  data: communityData,
+                  data: allCommunities,
                   selectedItem: selectedCommunityIndex,
                   onAvatarTapped: (int index) {
                     setState(() {
                       selectedCommunityIndex = index;
                     });
-                    if (index == communityData.length - 1) {
+                    if (index == allCommunities.length - 1) {
                       print('TODO open add community');
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
+                      Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
                     }
                   },
                 ),
-                SwitchAccountOrCommunity(
-                  rowTitle: 'Switch Account',
-                  data: accountData,
-                  selectedItem: selectedAccountIndex,
-                  onAvatarTapped: (int index) {
-                    setState(() {
-                      selectedAccountIndex = index;
-                    });
-                    if (index == accountData.length - 1) {
-                      print('TODO open add Account');
-                      Navigator.of(context).pushNamed(AddAccountPage.route);
-                    }
-                  },
-                ),
+                Observer(builder: (BuildContext context) {
+                  print('llllll: ${store.account.accountListAll.length}');
+                  allAccounts = [];
+                  allAccounts.addAll(store.account.accountListAll.map((account) => AccountOrCommunityData(
+                      avatar: AddressIcon('', pubKey: account.pubKey, size: 36, tapToCopy: false),
+                      name: account.name)));
+                  allAccounts.add(
+                    AccountOrCommunityData(avatar: Icon(Icons.add), name: 'Add Account'),
+                  );
+
+                  return SwitchAccountOrCommunity(
+                    rowTitle: 'Switch Account',
+                    data: allAccounts,
+                    selectedItem: selectedAccountIndex,
+                    onAvatarTapped: (int index) {
+                      setState(() {
+                        selectedAccountIndex = index;
+                      });
+                      if (index == allAccounts.length - 1) {
+                        print('TODO open add Account');
+                        Navigator.of(context).pushNamed(AddAccountPage.route);
+                      }
+                    },
+                  );
+                }),
               ]),
             ],
           ),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -373,16 +373,16 @@ class _AssetsState extends State<Assets> {
     ));
     allAccounts.add(
       AccountOrCommunityData(
-          avatar: Container(
-            height: avatarSize,
-            width: avatarSize,
-            decoration: BoxDecoration(
-              color: ZurichLion.shade50,
-              shape: BoxShape.circle,
-            ),
-            child: Icon(Icons.add, size: 36),
+        avatar: Container(
+          height: avatarSize,
+          width: avatarSize,
+          decoration: BoxDecoration(
+            color: ZurichLion.shade50,
+            shape: BoxShape.circle,
           ),
-          name: dic.profile.addAccount,
+          child: Icon(Icons.add, size: 36),
+        ),
+        name: dic.profile.addAccount,
       ),
     );
     return allAccounts;

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -291,7 +291,6 @@ class _AssetsState extends State<Assets> {
                       data: allCommunities,
                       onAvatarTapped: (int index) {
                         if (index == allCommunities.length - 1) {
-                          print('TODO open add community');
                           Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
                         } else {
                           setState(() {
@@ -329,7 +328,7 @@ class _AssetsState extends State<Assets> {
 
   List<AccountOrCommunityData> initAllCommunities() {
     List<AccountOrCommunityData> allCommunities = [];
-    // TODO add back end code so we can initialize the list of communities similar to the commented out code
+    // TODO #507 add back end code so we can initialize the list of communities similar to the commented out code
     // allCommunities.addAll(store.communities.communitiesList.map((community) => AccountOrCommunityData(
     //     avatar: webApi.ipfs.getCommunityIcon(community),
     //     name: community.name)));
@@ -343,7 +342,7 @@ class _AssetsState extends State<Assets> {
           avatarSize: avatarSize,
         ),
         name: '${store.encointer.communityName ?? '...'}',
-        isSelected: true, // TODO this should later be a function applied on each community
+        isSelected: true, // TODO #507 this should later be a function applied on each community, cf. initAllAccounts
       ),
     );
     allCommunities.add(

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -305,16 +305,16 @@ class _AssetsState extends State<Assets> {
                     );
                     allCommunities.add(
                       AccountOrCommunityData(
-                          avatar: Container(
-                            height: avatarSize,
-                            width: avatarSize,
-                            decoration: BoxDecoration(
-                              color: ZurichLion.shade50,
-                              shape: BoxShape.circle,
-                            ),
-                            child: Icon(Icons.add, size: 36),
+                        avatar: Container(
+                          height: avatarSize,
+                          width: avatarSize,
+                          decoration: BoxDecoration(
+                            color: ZurichLion.shade50,
+                            shape: BoxShape.circle,
                           ),
-                          name: 'Add Community',
+                          child: Icon(Icons.add, size: 36),
+                        ),
+                        name: 'Add Community',
                       ),
                     );
 
@@ -323,12 +323,13 @@ class _AssetsState extends State<Assets> {
                       data: allCommunities,
                       selectedItem: selectedCommunityIndex,
                       onAvatarTapped: (int index) {
-                        setState(() {
-                          selectedCommunityIndex = index;
-                        });
                         if (index == allCommunities.length - 1) {
                           print('TODO open add community');
                           Navigator.push(context, MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)));
+                        } else {
+                          setState(() {
+                            selectedCommunityIndex = index;
+                          });
                         }
                       },
                     );
@@ -343,15 +344,16 @@ class _AssetsState extends State<Assets> {
                   ));
                   allAccounts.add(
                     AccountOrCommunityData(
-                      avatar: Container(
-                      height: avatarSize,
-                      width: avatarSize,
-                      decoration: BoxDecoration(
-                        color: ZurichLion.shade50,
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(Icons.add, size: 36),
-                    ), name: 'Add Account'),
+                        avatar: Container(
+                          height: avatarSize,
+                          width: avatarSize,
+                          decoration: BoxDecoration(
+                            color: ZurichLion.shade50,
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(Icons.add, size: 36),
+                        ),
+                        name: 'Add Account'),
                   );
 
                   return SwitchAccountOrCommunity(
@@ -359,12 +361,13 @@ class _AssetsState extends State<Assets> {
                     data: allAccounts,
                     selectedItem: selectedAccountIndex,
                     onAvatarTapped: (int index) {
-                      setState(() {
-                        selectedAccountIndex = index;
-                      });
                       if (index == allAccounts.length - 1) {
                         print('TODO open add Account');
                         Navigator.of(context).pushNamed(AddAccountPage.route);
+                      } else {
+                        setState(() {
+                          selectedAccountIndex = index;
+                        });
                       }
                     },
                   );

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -24,6 +24,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
+import 'package:encointer_wallet/page/account/create/addAccountPage.dart';
 
 import 'account_or_community/AccountOrCommunityData.dart';
 import 'account_or_community/switchAccountOrCommunity.dart';
@@ -324,6 +325,7 @@ class _AssetsState extends State<Assets> {
                     });
                     if (index == accountData.length - 1) {
                       print('TODO open add Account');
+                      Navigator.of(context).pushNamed(AddAccountPage.route);
                     }
                   },
                 ),

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -354,7 +354,8 @@ class _AssetsState extends State<Assets> {
                           ),
                           child: Icon(Icons.add, size: 36),
                         ),
-                        name: 'Add Account'),
+                        name: dic.profile.addAccount,
+                    ),
                   );
 
                   return SwitchAccountOrCommunity(
@@ -362,7 +363,6 @@ class _AssetsState extends State<Assets> {
                     data: allAccounts,
                     onAvatarTapped: (int index) {
                       if (index == allAccounts.length - 1) {
-                        print('TODO open add Account');
                         Navigator.of(context).pushNamed(AddAccountPage.route);
                       } else {
                         setState(() {

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -93,7 +93,7 @@ class _TransferPageState extends State<TransferPage> {
                   Expanded(
                     child: ListView(
                       children: [
-                        CombinedCommunityAndAccountAvatar(store, isClickable: false),
+                        CombinedCommunityAndAccountAvatar(store, showCommunityNameAndAccountName: false),
                         SizedBox(height: 12),
                         store.encointer.communityBalance != null
                             ? AccountBalanceWithMoreDigits(store: store, available: available, decimals: decimals)

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -93,7 +93,7 @@ class _TransferPageState extends State<TransferPage> {
                   Expanded(
                     child: ListView(
                       children: [
-                        CommunityWithCommunityChooser(store),
+                        CombinedCommunityAndAccountAvatar(store),
                         store.encointer.communityBalance != null
                             ? AccountBalanceWithMoreDigits(store: store, available: available, decimals: decimals)
                             : CupertinoActivityIndicator(),

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -93,7 +93,8 @@ class _TransferPageState extends State<TransferPage> {
                   Expanded(
                     child: ListView(
                       children: [
-                        CombinedCommunityAndAccountAvatar(store),
+                        CombinedCommunityAndAccountAvatar(store, isClickable: false),
+                        SizedBox(height: 12),
                         store.encointer.communityBalance != null
                             ? AccountBalanceWithMoreDigits(store: store, available: available, decimals: decimals)
                             : CupertinoActivityIndicator(),

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -33,11 +33,11 @@ class _ProfileState extends State<Profile> {
   final Api api = webApi;
   EndpointData _selectedNetwork;
 
-  Future<void> _onSelect(AccountData i, String address) async {
+  Future<void> _onSelect(AccountData account, String address) async {
     if (address != store.account.currentAddress) {
       print("changing from addres ${store.account.currentAddress} to $address");
 
-      store.account.setCurrentAccount(i.pubKey);
+      store.account.setCurrentAccount(account.pubKey);
       await store.loadAccountCache();
 
       webApi.fetchAccountData();
@@ -69,14 +69,14 @@ class _ProfileState extends State<Profile> {
   }
 
   List<Widget> _buildAccountList() {
-    List<Widget> res = [];
+    List<Widget> allAccountsAsWidgets = [];
 
     List<AccountData> accounts = store.account.accountListAll;
 
-    res.addAll(accounts.map((i) {
-      String address = i.address;
+    allAccountsAsWidgets.addAll(accounts.map((account) {
+      String address = account.address;
       if (store.account.pubKeyAddressMap[_selectedNetwork.ss58] != null) {
-        address = store.account.pubKeyAddressMap[_selectedNetwork.ss58][i.pubKey];
+        address = store.account.pubKeyAddressMap[_selectedNetwork.ss58][account.pubKey];
       }
       return InkWell(
         child: Column(
@@ -86,7 +86,7 @@ class _ProfileState extends State<Profile> {
                 AddressIcon(
                   '',
                   size: 70,
-                  pubKey: i.pubKey,
+                  pubKey: account.pubKey,
                   // addressToCopy: address,
                   tapToCopy: false,
                 ),
@@ -98,7 +98,7 @@ class _ProfileState extends State<Profile> {
             ),
             SizedBox(height: 6),
             Text(
-              Fmt.accountName(context, i),
+              Fmt.accountName(context, account),
               style: Theme.of(context).textTheme.headline4,
             ),
             // This sizedBox is here to define a distance between the accounts
@@ -106,12 +106,12 @@ class _ProfileState extends State<Profile> {
           ],
         ),
         onTap: () => {
-          _onSelect(i, address),
+          _onSelect(account, address),
           Navigator.pushNamed(context, AccountManagePage.route),
         },
       );
     }).toList());
-    return res;
+    return allAccountsAsWidgets;
   }
 
   @override

--- a/lib/utils/translations/translationsProfile.dart
+++ b/lib/utils/translations/translationsProfile.dart
@@ -59,7 +59,7 @@ abstract class TranslationsProfile {
   String get shareLinkHint;
   String get title;
   String get unlock;
-  String get accountAdd;
+  String get addAccount;
   String get accountCreate;
   String get doYouAlreadyHaveAnAccount;
   String get accountNameChooseHint;
@@ -144,7 +144,7 @@ class TranslationsEnProfile implements TranslationsProfile {
   get share => 'Share';
   get title => 'Profile';
   get unlock => 'You need to enter your PIN to add a new account';
-  get accountAdd => 'Add account';
+  get addAccount => 'Add account';
   get accountCreate => 'Create account';
   get doYouAlreadyHaveAnAccount => 'Do you already have an account?';
   get accountNameChooseHint => 'You can change it later in your profile settings.';
@@ -228,7 +228,7 @@ class TranslationsDeProfile implements TranslationsProfile {
   get shareLinkHint => 'Oder über Link teilen:';
   get title => 'Profil';
   get unlock => 'Du musst deinen PIN eingeben um einen neuen Account hinzuzufügen';
-  get accountAdd => 'Konto hinzufügen';
+  get addAccount => 'Konto hinzufügen';
   get accountCreate => 'Konto kreieren';
   get doYouAlreadyHaveAnAccount => 'Hast du bereits ein Konto?';
   get accountNameChooseHint => 'Du kannst den Namen später ändern in den Profileinstellungen.';
@@ -303,7 +303,7 @@ class TranslationsZhProfile implements TranslationsProfile {
   get pinHint => '您将需要此 PIN 进行交易和添加新帐户。';
   get pinInfo => 'PIN 应至少包含 4 位数字。 如果 PIN 码丢失，则无法恢复帐户，除非您通过个人资料页面进行了备份。';
   get pinSecure => '使用 PIN 保护您的帐户。';
-  get accountAdd => '添加帐户';
+  get addAccount => '添加帐户';
   get recoveryProxy => 'recovery proxy';
   get ceremonies => throw UnimplementedError();
   get reputation => throw UnimplementedError();


### PR DESCRIPTION
* Add a combined community/account selector
* No longer show mock data but show the actual available accounts in the sliding up panel
* Add community opens the world map with pins with communities, so you can select a community there
* Add account opens the existing add account page
* The selected account/community gets highlighted with a blue circle
* clicking outside the panel closes it (this is the only way to close it)
* closes #331 and remainder of #327 