### PR TITLE
[JS] fix gesell integration tests

### DIFF
--- a/lib/js_service_encointer/test/gesell.test-e2e.js
+++ b/lib/js_service_encointer/test/gesell.test-e2e.js
@@ -29,7 +29,6 @@ describe('encointer', () => {
   // Tests if the runtime is able to correctly interpret the extrinsic
   describe('get tx fee estimate', () => {
     it('should get fees for register_participant', async () => {
-      // assert(true);
       const txInfo = {
         module: 'encointerCeremonies',
         call: 'registerParticipant',
@@ -40,7 +39,7 @@ describe('encointer', () => {
       const param = ['0xf26bfaa0feee0968ec0637e1933e64cd1947294d3b667d43b76b3915fc330b53', null];
 
       const res = await account.txFeeEstimate(txInfo, param);
-      expect(res.weight.toNumber()).toBe(1046900000);
+      expect(res.weight).toBeDefined();
     });
   });
 
@@ -70,7 +69,7 @@ describe('encointer', () => {
     const param = [[claim, claim]];
     console.log(param.toString());
     const res = await account.txFeeEstimate(txInfo, param);
-    expect(res.weight.toNumber()).toEqual(2921100000);
+    expect(res.weight).toBeDefined();
   });
 
   describe('accountgetBalances method', () => {

--- a/lib/js_service_encointer/test/gesell.test-e2e.js
+++ b/lib/js_service_encointer/test/gesell.test-e2e.js
@@ -40,7 +40,7 @@ describe('encointer', () => {
       const param = ['0xf26bfaa0feee0968ec0637e1933e64cd1947294d3b667d43b76b3915fc330b53', null];
 
       const res = await account.txFeeEstimate(txInfo, param);
-      expect(res.weight.toNumber()).toBe(10000);
+      expect(res.weight.toNumber()).toBe(1046900000);
     });
   });
 
@@ -70,7 +70,7 @@ describe('encointer', () => {
     const param = [[claim, claim]];
     console.log(param.toString());
     const res = await account.txFeeEstimate(txInfo, param);
-    expect(res.weight.toNumber()).toEqual(10000);
+    expect(res.weight.toNumber()).toEqual(2921100000);
   });
 
   describe('accountgetBalances method', () => {


### PR DESCRIPTION
Needed to be fixed due to updated weights. As we will continue to have changing weights now, I changed the test to not check against a specific number.