### PR TITLE
addAccountPage checks itself if the PIN needs to be entered

### DIFF
--- a/lib/page/account/create/addAccountForm.dart
+++ b/lib/page/account/create/addAccountForm.dart
@@ -14,7 +14,7 @@ class AddAccountForm extends StatelessWidget {
   final bool submitting;
   final AppStore store;
 
-  final _formKey = GlobalKey<FormState>();
+  static final _formKey = GlobalKey<FormState>();
 
   final TextEditingController _nameCtrl = new TextEditingController();
 

--- a/lib/page/account/create/addAccountPage.dart
+++ b/lib/page/account/create/addAccountPage.dart
@@ -1,12 +1,13 @@
 import 'package:encointer_wallet/common/components/accountAdvanceOption.dart';
+import 'package:encointer_wallet/common/components/passwordInputDialog.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page/account/create/addAccountForm.dart';
 import 'package:encointer_wallet/service/substrateApi/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:encointer_wallet/utils/translations/translations.dart';
 
 class AddAccountPage extends StatefulWidget {
   const AddAccountPage(this.store);
@@ -82,6 +83,39 @@ class _AddAccountPageState extends State<AddAccountPage> {
         );
       },
     );
+  }
+
+  Future<void> _showEnterPinDialog(BuildContext context) async {
+    await showCupertinoDialog(
+      context: context,
+      builder: (_) {
+        return Container(
+          child: showPasswordInputDialog(
+            context,
+            store.account.currentAccount,
+            Text(I18n.of(context).translationsForLocale().profile.unlock),
+            (password) {
+              setState(() {
+                store.settings.setPin(password);
+              });
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (store.settings.cachedPin.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        setState(() {
+          _showEnterPinDialog(context);
+        });
+      });
+    }
   }
 
   @override

--- a/lib/page/account/create/addAccountPage.dart
+++ b/lib/page/account/create/addAccountPage.dart
@@ -124,16 +124,11 @@ class _AddAccountPageState extends State<AddAccountPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          dic.profile.addAccount,
-        ),
+        title: Text(dic.profile.addAccount),
         leading: Container(),
         actions: <Widget>[
           IconButton(
-            icon: Icon(
-              Icons.close,
-              color: encointerGrey,
-            ),
+            icon: Icon(Icons.close, color: encointerGrey),
             onPressed: () {
               Navigator.popUntil(context, ModalRoute.withName('/'));
             },

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -44,30 +44,6 @@ class _ProfileState extends State<Profile> {
     }
   }
 
-  Future<void> _onAddAccount() async {
-    Navigator.of(context).pushNamed(AddAccountPage.route);
-  }
-
-  Future<void> _showPasswordDialog(BuildContext context) async {
-    await showCupertinoDialog(
-      context: context,
-      builder: (_) {
-        return Container(
-          child: showPasswordInputDialog(
-            context,
-            store.account.currentAccount,
-            Text(I18n.of(context).translationsForLocale().profile.unlock),
-            (password) {
-              setState(() {
-                store.settings.setPin(password);
-              });
-            },
-          ),
-        );
-      },
-    );
-  }
-
   List<Widget> _buildAccountList() {
     List<Widget> allAccountsAsWidgets = [];
 
@@ -160,9 +136,7 @@ class _ProfileState extends State<Profile> {
                         IconButton(
                             icon: Icon(Iconsax.add_square),
                             color: ZurichLion.shade500,
-                            onPressed: () {
-                              store.settings.cachedPin.isEmpty ? _showPasswordDialog(context) : _onAddAccount();
-                            }),
+                            onPressed: () => Navigator.of(context).pushNamed(AddAccountPage.route)),
                       ],
                     ),
                   ),

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -1,5 +1,4 @@
 import 'package:encointer_wallet/common/components/addressIcon.dart';
-import 'package:encointer_wallet/common/components/passwordInputDialog.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page/account/create/addAccountPage.dart';
 import 'package:encointer_wallet/page/profile/aboutPage.dart';


### PR DESCRIPTION
As we can arrive to that page from multiple paths, it is a potential error source that the `addAccountPage` does not check itself if the PIN has already been entered. See https://github.com/encointer/encointer-wallet-flutter/pull/502#pullrequestreview-922087463.

Here, we change the paradigm such that the page checks itself upon initialization if it needs to ask for the PIN.

This also removed the weird UX that we need to press twice on the `addAccount` button on the profile page.