### PR TITLE
[assignmentPanel] fix: show meetup time in 24 hour format

### DIFF
--- a/lib/page-encointer/common/assignmentPanel.dart
+++ b/lib/page-encointer/common/assignmentPanel.dart
@@ -37,7 +37,7 @@ class AssignmentPanel extends StatelessWidget {
                                 children: <Widget>[
                                   Text(dic.encointer.youAreRegistered, style: TextStyle(color: Colors.green)),
                                   Text(dic.encointer.ceremonyWillTakePlaceOn),
-                                  MaybeMeetupTime(store.encointer.meetupTime, dateFormat: 'yyyy-MM-dd-hh:mm'),
+                                  MaybeMeetupTime(store.encointer.meetupTime, dateFormat: 'yyyy-MM-dd-HH:mm'),
                                   ElevatedButton(
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
* Closes #412

Note: I have not thoroughly tested it. But as @brenzi said that it only seemed to be a 12 vs 24 hours format issue, the issue should be solved as the timestamp given in https://github.com/encointer/encointer-wallet-flutter/issues/412#issuecomment-1080376435 is displayed as `2022-03-28-13:08` now.