### PR TITLE
Gracefully handle no communities in onboarding.

### DIFF
--- a/lib/page-encointer/common/communityChooserOnMap.dart
+++ b/lib/page-encointer/common/communityChooserOnMap.dart
@@ -1,30 +1,35 @@
 import 'dart:convert';
 
 import 'package:dart_geohash/dart_geohash.dart';
+import 'package:encointer_wallet/page-encointer/common/encointerMap.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/communities.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import "package:latlong2/latlong.dart";
-import 'package:encointer_wallet/utils/translations/translations.dart';
-import 'package:encointer_wallet/page-encointer/common/encointerMap.dart';
 
 class CommunityChooserOnMap extends StatelessWidget {
   final AppStore store;
 
   final communityDataAt = Map<LatLng, CidName>();
 
+  List<Marker> get _markers => getMarkers(store);
+
   CommunityChooserOnMap(this.store) {
-    if (store.encointer.communities == null) return;
-    for (var community in store.encointer.communities) {
-      communityDataAt[coordinatesOf(community)] = community;
+    if (store.encointer.communities != null) {
+      for (var community in store.encointer.communities) {
+        communityDataAt[coordinatesOf(community)] = community;
+      }
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context).translationsForLocale();
+
     return EncointerMap(
       store,
       popupBuilder: (BuildContext context, Marker marker) =>
@@ -34,39 +39,6 @@ class CommunityChooserOnMap extends StatelessWidget {
       center: LatLng(47.389712, 8.517076),
       initialZoom: 0,
     );
-  }
-
-  List<Marker> get _markers {
-    List<Marker> markers = [];
-    if (store.encointer.communities != null) {
-      for (num index = 0; index < store.encointer.communities.length; index++) {
-        CidName community = store.encointer.communities[index];
-        markers.add(
-          Marker(
-            // marker is not a widget, hence test_driver cannot find it (it can find it in the Icon inside, though).
-            // But we need the key to derive the popup key
-            key: Key('cid-$index-marker'),
-            point: coordinatesOf(community),
-            width: 40,
-            height: 40,
-            builder: (_) => Icon(
-              Icons.location_on,
-              size: 40,
-              color: Colors.blueAccent,
-              key: Key('cid-$index-marker-icon'), // used for test_driver
-            ),
-            anchorPos: AnchorPos.align(AnchorAlign.top),
-          ),
-        );
-      }
-    }
-
-    return markers;
-  }
-
-  LatLng coordinatesOf(CidName community) {
-    GeoHash coordinates = GeoHash(utf8.decode(community.cid.geohash));
-    return LatLng(coordinates.latitude(), coordinates.longitude());
   }
 }
 
@@ -130,4 +102,37 @@ class _CommunityDetailsPopupState extends State<CommunityDetailsPopup> {
       ),
     );
   }
+}
+
+List<Marker> getMarkers(AppStore store) {
+  List<Marker> markers = [];
+  if (store.encointer.communities != null) {
+    for (num index = 0; index < store.encointer.communities.length; index++) {
+      CidName community = store.encointer.communities[index];
+      markers.add(
+        Marker(
+          // marker is not a widget, hence test_driver cannot find it (it can find it in the Icon inside, though).
+          // But we need the key to derive the popup key
+          key: Key('cid-$index-marker'),
+          point: coordinatesOf(community),
+          width: 40,
+          height: 40,
+          builder: (_) => Icon(
+            Icons.location_on,
+            size: 40,
+            color: Colors.blueAccent,
+            key: Key('cid-$index-marker-icon'), // used for test_driver
+          ),
+          anchorPos: AnchorPos.align(AnchorAlign.top),
+        ),
+      );
+    }
+  }
+
+  return markers;
+}
+
+LatLng coordinatesOf(CidName community) {
+  GeoHash coordinates = GeoHash(utf8.decode(community.cid.geohash));
+  return LatLng(coordinates.latitude(), coordinates.longitude());
 }

--- a/lib/page-encointer/common/encointerMap.dart
+++ b/lib/page-encointer/common/encointerMap.dart
@@ -1,5 +1,7 @@
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/store/app.dart';
+import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
@@ -34,30 +36,53 @@ class EncointerMap extends StatelessWidget {
           )
         ],
       ),
-      body: FlutterMap(
-        options: MapOptions(
-          center: center,
-          zoom: initialZoom,
-          maxZoom: 18.4,
-          onTap: (_) => _popupLayerController.hideAllPopups(), // Hide popup when the map is tapped.
-        ),
-        children: [
-          TileLayerWidget(
-            options: TileLayerOptions(
-              urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-              subdomains: ['a', 'b', 'c'],
-            ),
-          ),
-          PopupMarkerLayerWidget(
-            options: PopupMarkerLayerOptions(
-              popupController: _popupLayerController,
-              markers: markers,
-              markerRotateAlignment: PopupMarkerLayerOptions.rotationAlignmentFor(AnchorAlign.top),
-              popupBuilder: popupBuilder,
-            ),
-          ),
-        ],
-      ),
+      body: markers.isNotEmpty
+          ? FlutterMap(
+              options: MapOptions(
+                center: center,
+                zoom: initialZoom,
+                maxZoom: 18.4,
+                onTap: (_) => _popupLayerController.hideAllPopups(), // Hide popup when the map is tapped.
+              ),
+              children: [
+                TileLayerWidget(
+                  options: TileLayerOptions(
+                    backgroundColor: Colors.white,
+                    urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    subdomains: ['a', 'b', 'c'],
+                  ),
+                ),
+                PopupMarkerLayerWidget(
+                  options: PopupMarkerLayerOptions(
+                    popupController: _popupLayerController,
+                    markers: markers,
+                    markerRotateAlignment: PopupMarkerLayerOptions.rotationAlignmentFor(AnchorAlign.top),
+                    popupBuilder: popupBuilder,
+                  ),
+                ),
+              ],
+            ) :
+      Container(
+        color: Colors.white,
+        child: noCommunityDialog(context),
+      )
     );
   }
+}
+
+Widget noCommunityDialog(BuildContext context) {
+  var translations = I18n.of(context).translationsForLocale();
+
+  return CupertinoAlertDialog(
+    title: Container(),
+    content: Text(translations.encointer.noCommunitiesAreYouOffline),
+    actions: <Widget>[
+      CupertinoButton(
+        child: Text(translations.home.ok),
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+      ),
+    ],
+  );
 }

--- a/lib/page-encointer/common/encointerMap.dart
+++ b/lib/page-encointer/common/encointerMap.dart
@@ -61,11 +61,11 @@ class EncointerMap extends StatelessWidget {
                   ),
                 ),
               ],
-            ) :
-      Container(
-        color: Colors.white,
-        child: noCommunityDialog(context),
-      )
+            )
+          : Container(
+              color: Colors.white,
+              child: noCommunityDialog(context),
+            ),
     );
   }
 }

--- a/lib/page/account/create/createAccountForm.dart
+++ b/lib/page/account/create/createAccountForm.dart
@@ -5,10 +5,10 @@ import 'package:encointer_wallet/page/account/create/createPinPage.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
-import 'package:encointer_wallet/utils/translations/translations.dart';
 
 class CreateAccountForm extends StatelessWidget {
   CreateAccountForm({this.store});
@@ -118,7 +118,11 @@ class CreateAccountForm extends StatelessWidget {
               onPressed: () {
                 if (_formKey.currentState.validate()) {
                   store.account.setNewAccountName(_nameCtrl.text.trim());
-                  Navigator.pushNamed(context, CreatePinPage.route, arguments: CreatePinPageParams(_createAndImportAccount));
+                  Navigator.pushNamed(
+                    context,
+                    CreatePinPage.route,
+                    arguments: CreatePinPageParams(_createAndImportAccount),
+                  );
                 }
               },
             ),

--- a/lib/page/account/create/createPinForm.dart
+++ b/lib/page/account/create/createPinForm.dart
@@ -1,6 +1,5 @@
 import 'package:encointer_wallet/common/components/gradientElements.dart';
 import 'package:encointer_wallet/common/theme.dart';
-import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
@@ -148,14 +147,6 @@ class _CreatePinFormState extends State<CreatePinForm> {
                   store.settings.setPin(_passCtrl.text);
 
                   widget.onSubmit();
-
-                  // Even if we do not choose a community, we go back to the home screen.
-                  Navigator.popUntil(context, ModalRoute.withName('/'));
-
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
-                  );
                 }
               },
             ),

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -1,88 +1,41 @@
-import 'package:encointer_wallet/common/components/accountAdvanceOption.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page-encointer/common/communityChooserOnMap.dart';
 import 'package:encointer_wallet/page/account/create/createPinForm.dart';
-import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+class CreatePinPageParams {
+  CreatePinPageParams(this.onCreatePin);
+
+  final Future<void> Function() onCreatePin;
+}
+
 class CreatePinPage extends StatefulWidget {
-  const CreatePinPage(this.store, {this.importAccount});
+  const CreatePinPage(this.store);
 
   static const String route = '/account/createPin';
   final AppStore store;
 
-  final Future<void> Function() importAccount;
-
   @override
-  _CreatePinPageState createState() => _CreatePinPageState(store, importAccount: importAccount);
+  _CreatePinPageState createState() => _CreatePinPageState(store);
 }
 
 class _CreatePinPageState extends State<CreatePinPage> {
-  _CreatePinPageState(this.store, {this.importAccount});
+  _CreatePinPageState(this.store);
 
   final AppStore store;
 
-  Future<void> Function() importAccount;
+  Future<void> Function() onCreatePin;
 
   bool _submitting = false;
 
-  Future<void> _createAndImportAccount() async {
-    await webApi.account.generateAccount();
-
-    var acc = await webApi.account.importAccount(
-      cryptoType: AccountAdvanceOptionParams.encryptTypeSR,
-      derivePath: '',
-    );
-
-    if (acc['error'] != null) {
-      setState(() {
-        _submitting = false;
-      });
-      _showErrorCreatingAccountDialog(context);
-      return;
-    }
-
-    await store.account.addAccount(acc, store.account.newAccount.password);
-    webApi.account.encodeAddress([acc['pubKey']]);
-
-    await store.loadAccountCache();
-
-    // fetch info for the imported account
-    String pubKey = acc['pubKey'];
-    webApi.fetchAccountData();
-    webApi.account.fetchAccountsBonded([pubKey]);
-    webApi.account.getPubKeyIcons([pubKey]);
-    store.account.setCurrentAccount(pubKey);
-  }
-
-  static Future<void> _showErrorCreatingAccountDialog(BuildContext context) async {
-    showCupertinoDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return CupertinoAlertDialog(
-          title: Container(),
-          content: Text(I18n.of(context).translationsForLocale().account.createError),
-          actions: <Widget>[
-            CupertinoButton(
-              child: Text(I18n.of(context).translationsForLocale().home.ok),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (importAccount == null) {
-      importAccount = _createAndImportAccount;
-    }
+    CreatePinPageParams params = ModalRoute.of(context).settings.arguments;
+
+    onCreatePin = params.onCreatePin;
 
     return Scaffold(
       appBar: AppBar(
@@ -112,7 +65,7 @@ class _CreatePinPageState extends State<CreatePinPage> {
                     _submitting = true;
                   });
 
-                  await importAccount();
+                  await onCreatePin();
 
                   if (store.encointer.communities != null) {
                     await Navigator.push(

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -67,10 +67,10 @@ class _CreatePinPageState extends State<CreatePinPage> {
 
                   await onCreatePin();
 
-                    await Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
-                    );
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
+                  );
 
                   setState(() {
                     _submitting = false;

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -67,14 +67,10 @@ class _CreatePinPageState extends State<CreatePinPage> {
 
                   await onCreatePin();
 
-                  if (store.encointer.communities != null) {
                     await Navigator.push(
                       context,
                       MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
                     );
-                  } else {
-                    await showNoCommunityDialog(context);
-                  }
 
                   setState(() {
                     _submitting = false;
@@ -89,26 +85,4 @@ class _CreatePinPageState extends State<CreatePinPage> {
       ),
     );
   }
-}
-
-Future<void> showNoCommunityDialog(BuildContext context) {
-  var translations = I18n.of(context).translationsForLocale();
-
-  return showCupertinoDialog(
-    context: context,
-    builder: (context) {
-      return CupertinoAlertDialog(
-        title: Container(),
-        content: Text(translations.encointer.noCommunitiesFoundChooseLater),
-        actions: <Widget>[
-          CupertinoButton(
-            child: Text(translations.home.ok),
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-          ),
-        ],
-      );
-    },
-  );
 }

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -9,19 +9,23 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class CreatePinPage extends StatefulWidget {
-  const CreatePinPage(this.store);
+  const CreatePinPage(this.store, {this.importAccount});
 
   static const String route = '/account/createPin';
   final AppStore store;
 
+  final Future<void> Function() importAccount;
+
   @override
-  _CreatePinPageState createState() => _CreatePinPageState(store);
+  _CreatePinPageState createState() => _CreatePinPageState(store, importAccount: importAccount);
 }
 
 class _CreatePinPageState extends State<CreatePinPage> {
-  _CreatePinPageState(this.store);
+  _CreatePinPageState(this.store, {this.importAccount});
 
   final AppStore store;
+
+  Future<void> Function() importAccount;
 
   bool _submitting = false;
 
@@ -76,6 +80,10 @@ class _CreatePinPageState extends State<CreatePinPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (importAccount == null) {
+      importAccount = _createAndImportAccount;
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -104,7 +112,7 @@ class _CreatePinPageState extends State<CreatePinPage> {
                     _submitting = true;
                   });
 
-                  await _createAndImportAccount();
+                  await importAccount();
 
                   if (store.encointer.communities != null) {
                     await Navigator.push(

--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -105,7 +105,6 @@ Future<void> showNoCommunityDialog(BuildContext context) {
             child: Text(translations.home.ok),
             onPressed: () {
               Navigator.of(context).pop();
-              Navigator.of(context).pop();
             },
           ),
         ],

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -27,7 +27,6 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
   String _cryptoType = '';
   String _derivePath = '';
   bool _submitting = false;
-  Stage _stage = Stage.import;
 
   final TextEditingController _nameCtrl = new TextEditingController();
 
@@ -78,7 +77,6 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
                   child: Text(I18n.of(context).translationsForLocale().home.ok),
                   onPressed: () {
                     setState(() {
-                      _stage = Stage.import;
                       _submitting = false;
                     });
                     Navigator.of(context).pop();
@@ -179,27 +177,14 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-          title: Text(I18n.of(context).translationsForLocale().home.accountImport),
-          leading: _stage == Stage.createPin
-              ? IconButton(
-                  icon: Icon(Icons.arrow_back_ios),
-                  onPressed: () {
-                    setState(() {
-                      _stage = Stage.import;
-                    });
-                  },
-                )
-              : null // null means the regular pack button is used leading back to the entry page
-          ),
+      appBar: AppBar(title: Text(I18n.of(context).translationsForLocale().home.accountImport)),
       body: SafeArea(
-        child: !_submitting ? _getImportOrPinForm() : Center(child: CupertinoActivityIndicator()),
+        child: !_submitting ? _getImportForm() : Center(child: CupertinoActivityIndicator()),
       ),
     );
   }
 
-  Widget _getImportOrPinForm() {
-    if (_stage == Stage.import) {
+  Widget _getImportForm() {
       return ImportAccountForm(store, (Map<String, dynamic> data) {
         setState(() {
           _keyType = data['keyType'];
@@ -208,18 +193,11 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
         });
 
         if (store.account.isFirstAccount) {
-          setState(() {
-            _stage = Stage.createPin;
-          });
+          Navigator.pushNamed(context, CreatePinPage.route, arguments: CreatePinPageParams(_importAccount));
         } else {
           store.account.setNewAccountPin(store.settings.cachedPin);
           _importAccount();
         }
       });
-    } else {
-      return CreatePinPage(store, importAccount: _importAccount);
     }
-  }
 }
-
-enum Stage { import, createPin }

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -1,4 +1,4 @@
-import 'package:encointer_wallet/page/account/create/createPinForm.dart';
+import 'package:encointer_wallet/page/account/create/createPinPage.dart';
 import 'package:encointer_wallet/page/account/import/importAccountForm.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -217,7 +217,7 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
         }
       });
     } else {
-      return CreatePinForm(onSubmit: _importAccount, store: store);
+      return CreatePinPage(store, importAccount: _importAccount);
     }
   }
 }

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -169,9 +169,6 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
     webApi.account.fetchAccountsBonded([pubKey]);
     webApi.account.getPubKeyIcons([pubKey]);
     store.account.setCurrentAccount(pubKey);
-
-    // go to home page
-    Navigator.popUntil(context, ModalRoute.withName('/'));
   }
 
   @override

--- a/lib/page/account/import/importAccountPage.dart
+++ b/lib/page/account/import/importAccountPage.dart
@@ -185,19 +185,19 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
   }
 
   Widget _getImportForm() {
-      return ImportAccountForm(store, (Map<String, dynamic> data) {
-        setState(() {
-          _keyType = data['keyType'];
-          _cryptoType = data['cryptoType'];
-          _derivePath = data['derivePath'];
-        });
-
-        if (store.account.isFirstAccount) {
-          Navigator.pushNamed(context, CreatePinPage.route, arguments: CreatePinPageParams(_importAccount));
-        } else {
-          store.account.setNewAccountPin(store.settings.cachedPin);
-          _importAccount();
-        }
+    return ImportAccountForm(store, (Map<String, dynamic> data) {
+      setState(() {
+        _keyType = data['keyType'];
+        _cryptoType = data['cryptoType'];
+        _derivePath = data['derivePath'];
       });
-    }
+
+      if (store.account.isFirstAccount) {
+        Navigator.pushNamed(context, CreatePinPage.route, arguments: CreatePinPageParams(_importAccount));
+      } else {
+        store.account.setNewAccountPin(store.settings.cachedPin);
+        _importAccount();
+      }
+    });
+  }
 }

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -16,6 +16,7 @@ abstract class TranslationsEncointer {
   String get claimsScannedNOfM;
   String get claimsSubmitDetail;
   String get communities;
+  String get noCommunitiesFoundChooseLater;
   String get encointer;
   String get meetupAttended;
   String get meetupClaimantInvalid;
@@ -51,6 +52,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   get claimsScannedNOfM => "Scanned SCANNED_COUNT / TOTAL_COUNT Claims";
   get claimsSubmitDetail => 'Submitting AMOUNT claims for the recent ceremony';
   get communities => 'Communities';
+  get noCommunitiesFoundChooseLater => 'No communities were found. You can choose later.';
   get encointer => 'Encointer Ceremony';
   get meetupAttended => 'Attended last meetup';
   get meetupClaimantInvalid => 'This claimant is not part of the meetup. Claim is not stored.';
@@ -86,6 +88,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get claimsScannedNOfM => "SCANNED_COUNT / TOTAL_COUNT gescannte Behauptungen";
   get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';
   get communities => 'Gemeinschaften';
+  get noCommunitiesFoundChooseLater => 'Keine Gemeinschaftern gefunden. Du kannst später eine auswählen.';
   get encointer => 'Encointer Zeremonie';
   get meetupAttended => 'Am letzen Treffen teilgenommen';
   get meetupClaimantInvalid => 'Dieser Antragssteller gehört nicht zum Treffen. Behauptung wurde nicht gespeichert.';
@@ -128,6 +131,7 @@ class TranslationsZhEncointer implements TranslationsEncointer {
   get startCeremony => throw UnimplementedError();
   get youAreRegistered => '已经注册';
   get communities => throw UnimplementedError();
+  get noCommunitiesFoundChooseLater => throw UnimplementedError();
   get registerUntil => throw UnimplementedError();
   get showCeremonyLocation => throw UnimplementedError();
   get ceremonyIsOver => throw UnimplementedError();

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -86,9 +86,9 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get claimsScannedDecodeFailed => 'Gescannte Behauptung konnte nicht dekodiert werden.';
   get claimsScannedNew => 'Neue Behauptung gescannt';
   get claimsScannedNOfM => "SCANNED_COUNT / TOTAL_COUNT gescannte Behauptungen";
-  get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';
+  get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';ge
   get communities => 'Gemeinschaften';
-  get noCommunitiesAreYouOffline => 'Keine Gemeinschaftern gefunden, du kannst später eine auswählen. Bist du offline?';
+  get noCommunitiesAreYouOffline => 'Keine Gemeinschaften gefunden, du kannst später eine auswählen. Bist du offline?';
   get encointer => 'Encointer Zeremonie';
   get meetupAttended => 'Am letzen Treffen teilgenommen';
   get meetupClaimantInvalid => 'Dieser Antragssteller gehört nicht zum Treffen. Behauptung wurde nicht gespeichert.';

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -86,7 +86,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get claimsScannedDecodeFailed => 'Gescannte Behauptung konnte nicht dekodiert werden.';
   get claimsScannedNew => 'Neue Behauptung gescannt';
   get claimsScannedNOfM => "SCANNED_COUNT / TOTAL_COUNT gescannte Behauptungen";
-  get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';ge
+  get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';
   get communities => 'Gemeinschaften';
   get noCommunitiesAreYouOffline => 'Keine Gemeinschaften gefunden, du kannst später eine auswählen. Bist du offline?';
   get encointer => 'Encointer Zeremonie';

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -16,7 +16,6 @@ abstract class TranslationsEncointer {
   String get claimsScannedNOfM;
   String get claimsSubmitDetail;
   String get communities;
-  String get noCommunitiesFoundChooseLater;
   String get noCommunitiesAreYouOffline;
   String get encointer;
   String get meetupAttended;
@@ -53,8 +52,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   get claimsScannedNOfM => "Scanned SCANNED_COUNT / TOTAL_COUNT Claims";
   get claimsSubmitDetail => 'Submitting AMOUNT claims for the recent ceremony';
   get communities => 'Communities';
-  get noCommunitiesFoundChooseLater => 'No communities were found. You can choose later.';
-  get noCommunitiesAreYouOffline => 'No communities were found. Are you offline?.';
+  get noCommunitiesAreYouOffline => 'No communities were found. You can choose one later. Are you offline?.';
   get encointer => 'Encointer Ceremony';
   get meetupAttended => 'Attended last meetup';
   get meetupClaimantInvalid => 'This claimant is not part of the meetup. Claim is not stored.';
@@ -90,8 +88,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get claimsScannedNOfM => "SCANNED_COUNT / TOTAL_COUNT gescannte Behauptungen";
   get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';
   get communities => 'Gemeinschaften';
-  get noCommunitiesFoundChooseLater => 'Keine Gemeinschaftern gefunden. Du kannst später eine auswählen.';
-  get noCommunitiesAreYouOffline => 'Keine Gemeinschaftern gefunden. Bist du offline?';
+  get noCommunitiesAreYouOffline => 'Keine Gemeinschaftern gefunden, du kannst später eine auswählen. Bist du offline?';
   get encointer => 'Encointer Zeremonie';
   get meetupAttended => 'Am letzen Treffen teilgenommen';
   get meetupClaimantInvalid => 'Dieser Antragssteller gehört nicht zum Treffen. Behauptung wurde nicht gespeichert.';
@@ -134,7 +131,6 @@ class TranslationsZhEncointer implements TranslationsEncointer {
   get startCeremony => throw UnimplementedError();
   get youAreRegistered => '已经注册';
   get communities => throw UnimplementedError();
-  get noCommunitiesFoundChooseLater => throw UnimplementedError();
   get noCommunitiesAreYouOffline => throw UnimplementedError();
   get registerUntil => throw UnimplementedError();
   get showCeremonyLocation => throw UnimplementedError();

--- a/lib/utils/translations/translationsEncointer.dart
+++ b/lib/utils/translations/translationsEncointer.dart
@@ -17,6 +17,7 @@ abstract class TranslationsEncointer {
   String get claimsSubmitDetail;
   String get communities;
   String get noCommunitiesFoundChooseLater;
+  String get noCommunitiesAreYouOffline;
   String get encointer;
   String get meetupAttended;
   String get meetupClaimantInvalid;
@@ -53,6 +54,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   get claimsSubmitDetail => 'Submitting AMOUNT claims for the recent ceremony';
   get communities => 'Communities';
   get noCommunitiesFoundChooseLater => 'No communities were found. You can choose later.';
+  get noCommunitiesAreYouOffline => 'No communities were found. Are you offline?.';
   get encointer => 'Encointer Ceremony';
   get meetupAttended => 'Attended last meetup';
   get meetupClaimantInvalid => 'This claimant is not part of the meetup. Claim is not stored.';
@@ -89,6 +91,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   get claimsSubmitDetail => 'Reiche AMOUNT Behauptungen für die letzte Zeremonie ein';
   get communities => 'Gemeinschaften';
   get noCommunitiesFoundChooseLater => 'Keine Gemeinschaftern gefunden. Du kannst später eine auswählen.';
+  get noCommunitiesAreYouOffline => 'Keine Gemeinschaftern gefunden. Bist du offline?';
   get encointer => 'Encointer Zeremonie';
   get meetupAttended => 'Am letzen Treffen teilgenommen';
   get meetupClaimantInvalid => 'Dieser Antragssteller gehört nicht zum Treffen. Behauptung wurde nicht gespeichert.';
@@ -132,6 +135,7 @@ class TranslationsZhEncointer implements TranslationsEncointer {
   get youAreRegistered => '已经注册';
   get communities => throw UnimplementedError();
   get noCommunitiesFoundChooseLater => throw UnimplementedError();
+  get noCommunitiesAreYouOffline => throw UnimplementedError();
   get registerUntil => throw UnimplementedError();
   get showCeremonyLocation => throw UnimplementedError();
   get ceremonyIsOver => throw UnimplementedError();


### PR DESCRIPTION
The constructor of `CommunityChooserOnMap` does simply return when no communities are in the store. This was very unintuitive to debug in the onboarding process, as we seemed to skip the map. This PR introduces confirmation dialogue before proceeding to the homepage.

Other fixes:
- Closes #371 
- Closes #380. By fixing [#371](#371), we can now properly await the future of the account creation, so we will not proceed before it's finished.
- Resolve subtask of #330