### PR TITLE
[JS/settings]  hardcode SS58-prefix to 42.

### DIFF
--- a/lib/config/consts.dart
+++ b/lib/config/consts.dart
@@ -26,7 +26,7 @@ EndpointData networkEndpointEncointerLietaer = EndpointData.fromJson({
 
 EndpointData networkEndpointEncointerMainnet = EndpointData.fromJson({
   'info': 'nctr-k',
-  'ss58': 2,
+  'ss58': 42, // Fixme: #567
   'text': 'Encointer Network on Kusama (Hosted by Encointer Association)',
   'value': 'wss://kusama.api.encointer.org',
   'overrideConfig': GesellConfig.toJson(),
@@ -77,7 +77,7 @@ const network_ss58_map = {
   'encointer': 42,
   'nctr-gsl': 42,
   'nctr-r': 42,
-  'nctr-k': 2,
+  'nctr-k': 42, // Fixme: #567
   'nctr-cln': 42,
   'nctr-gsl-dev': 42,
   'nctr-cln-dev': 42,

--- a/lib/js_service_encointer/src/service/settings.js
+++ b/lib/js_service_encointer/src/service/settings.js
@@ -42,6 +42,11 @@ async function connectAll (nodes, configs) {
   });
 }
 
+/***
+ * Connects to a substrate-node endpoint.
+ *
+ * Throws an exception if the connection failed.
+ */
 async function _connect (endpoint, configOverride) {
   const provider = new WsProvider(endpoint);
 
@@ -60,6 +65,7 @@ async function _connect (endpoint, configOverride) {
     const chainProperties = api.registry.getChainProperties();
     window.send('log', `chain properties: ${chainProperties}`);
 
+    // Hardcode SS58-prefix to 42, see https://github.com/encointer/encointer-wallet-flutter/issues/567
     const properties = {
       ss58Format: 42,
       tokenDecimals: chainProperties.tokenDecimals,

--- a/lib/js_service_encointer/src/service/settings.js
+++ b/lib/js_service_encointer/src/service/settings.js
@@ -11,29 +11,11 @@ const { w3cwebsocket: WebSocket } = WS;
 async function connect (endpoint, configOverride) {
   return new Promise(async (resolve, reject) => {
     console.log(`configOverride: ${JSON.stringify(configOverride)}`);
-    const provider = new WsProvider(endpoint);
     try {
-      const api = await ApiPromise.create({
-        ...options({
-          types: configOverride.types !== null ? configOverride.types : {}
-        }),
-        provider: provider
-      });
-      if (configOverride.pallets !== null) {
-        Object.assign(pallets, configOverride.pallets);
-      }
-      window.send('log', `overwritten pallet config: ${JSON.stringify(pallets)}`);
-      if (!window.api) {
-        window.api = api;
-        window.send('log', `${endpoint} wss connected success`);
-        resolve(endpoint);
-      } else {
-        window.send('log', `${endpoint} wss connected and ignored`);
-        api.disconnect();
-      }
+      await _connect(endpoint, configOverride);
+      resolve(endpoint);
     } catch (err) {
       window.send('log', `connect ${endpoint} failed. Error ${err.message}`);
-      provider.disconnect();
       resolve(null);
     }
   });
@@ -47,29 +29,10 @@ async function connectAll (nodes, configs) {
       const configOverride = configs[i];
       console.log(`Config override for node ${endpoint}: ${JSON.stringify(configOverride)}`);
       i++;
-      const provider = new WsProvider(endpoint);
       try {
-        const api = await ApiPromise.create({
-          ...options({
-            types: configOverride.types !== null ? configOverride.types : {}
-          }),
-          provider: provider
-        });
-        if (configOverride.pallets !== null) {
-          Object.assign(pallets, configOverride.pallets);
-        }
-        window.send('log', `overwritten pallet config: ${JSON.stringify(pallets)}`);
-        if (!window.api) {
-          window.api = api;
-          window.send('log', `${endpoint} wss connected success`);
-          resolve(endpoint);
-        } else {
-          window.send('log', `${endpoint} wss connected and ignored`);
-          api.disconnect();
-        }
+        await _connect(endpoint, configOverride);
       } catch (err) {
         window.send('log', `connect ${endpoint} failed. Error ${err}`);
-        provider.disconnect();
         failCount += 1;
         if (failCount >= nodes.length) {
           resolve(null);
@@ -77,6 +40,47 @@ async function connectAll (nodes, configs) {
       }
     });
   });
+}
+
+async function _connect (endpoint, configOverride) {
+  const provider = new WsProvider(endpoint);
+
+  try {
+    const api = await ApiPromise.create({
+      ...options({
+        types: configOverride.types !== null ? configOverride.types : {}
+      }),
+      provider: provider
+    });
+    if (configOverride.pallets !== null) {
+      Object.assign(pallets, configOverride.pallets);
+    }
+    window.send('log', `overwritten pallet config: ${JSON.stringify(pallets)}`);
+
+    const chainProperties = api.registry.getChainProperties();
+    window.send('log', `chain properties: ${chainProperties}`);
+
+    const properties = {
+      ss58Format: 42,
+      tokenDecimals: chainProperties.tokenDecimals,
+      tokenSymbol: chainProperties.tokenSymbol
+    };
+
+    window.send('log', `ss58 overwritten chain properties: ${JSON.stringify(properties)}`);
+    api.registry.setChainProperties(properties);
+
+    if (!window.api) {
+      window.api = api;
+      window.send('log', `${endpoint} wss connected success`);
+    } else {
+      window.send('log', `${endpoint} wss connected and ignored`);
+      api.disconnect();
+    }
+
+  } catch (e) {
+    provider.disconnect();
+    throw (e);
+  }
 }
 
 async function setWorkerEndpoint (endpoint, mrenclave) {


### PR DESCRIPTION
Hardcode the SS58-prefix to 42 on the JS-side. This overwrites the SS58-prefix 2 for Kusama and Rococo.

* Closes #562 

* We should solve this properly in the future: See #567 

Tested that meetup registry contains the claimantPublic:
```
[EncointerApi]: AggregatedAccountData for sqm1v79dF6b and 5GrwvaE...: {
    "global": {
        "ceremonyPhase": "Attesting",
        "ceremonyIndex": 2
    },
    "personal": {
        "participantType": "Bootstrapper",
        "meetupIndex": 1,
        "meetupLocationIndex": 3,
        "meetupTime": 1651142880000,
        "meetupRegistry": ["5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y", "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
    }
}
```

```
{
    "path": "uid=5;encointer.signClaimOfAttendance",
    "data": {
        "claimantPublic": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
        "ceremonyIndex": 2,
        "communityIdentifier": {
            "geohash": "0x73716d3176",
            "digest": "0xf08c911c"
        },
        "meetupIndex": 1,
        "location": {
            "lat": "0x0000d2f239d0157b2300000000000000",
            "lon": "0x000000000000a4671200000000000000"
        },
        "timestamp": 1651142880000,
        "numberOfParticipantsConfirmed": 3,
        "claimantSignature": {
            "sr25519": "0xb455d9f78367f926aafe93d3f4b3a74f07f2df04a55a75b35dc6b1f93fb8bf2f71a69f8ae1205bf60925fe02e2ced1dd850602225c97e4174952d416a36d1d84"
        }
    }
}
```