### PR TITLE
minor but nice UX tweaks

### DIFF
--- a/lib/page-encointer/phases/registering/registerParticipantPanel.dart
+++ b/lib/page-encointer/phases/registering/registerParticipantPanel.dart
@@ -85,10 +85,19 @@ class _RegisterParticipantPanel extends State<RegisterParticipantPanel> {
                   ],
                 ),
           store.encointer.communityAccount.isRegistered
-              ? RoundedButton(
-                  text: dic.encointer.youAreRegistered, onPressed: null, color: Theme.of(context).disabledColor)
+              ? Column(children: <Widget>[
+                  RoundedButton(
+                      text: dic.encointer.youAreRegistered, onPressed: null, color: Theme.of(context).disabledColor),
+                  Text("as " + store.encointer.communityAccount.participantType.toString().split('.').last)
+                ])
               : store.encointer.account.reputations != null
-                  ? RoundedButton(text: dic.encointer.registerParticipant, onPressed: () => _submit())
+                  ? Column(children: <Widget>[
+                      RoundedButton(
+                          text: dic.encointer.registerParticipant + ": " + store.account.currentAccount.name.toString(),
+                          onPressed: () => _submit()),
+                      // skipping dic here because it's throwaway code anyway
+                      Text("reputation: " + store.encointer.account.reputations.length.toString())
+                    ])
                   : RoundedButton(
                       text: dic.encointer.fetchingReputations,
                       onPressed: null,

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -53,8 +53,6 @@ class _ReceivePageState extends State<ReceivePage> {
       child: QrImage(
         size: MediaQuery.of(context).copyWith().size.height / 2,
         data: invoice.join('\n'),
-        embeddedImage: AssetImage('assets/images/public/app.png'),
-        embeddedImageStyle: QrEmbeddedImageStyle(size: Size(40, 40)),
       ),
     );
   }

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -22,11 +22,12 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:iconsax/iconsax.dart';
 
 class TransferPageParams {
-  TransferPageParams({this.cid, this.communitySymbol, this.recipient, this.amount, this.redirect});
+  TransferPageParams({this.cid, this.communitySymbol, this.recipient, this.label, this.amount, this.redirect});
 
   final CommunityIdentifier cid;
   final String communitySymbol;
   final String recipient;
+  final String label;
   final double amount;
   final String redirect;
 }
@@ -236,6 +237,7 @@ class _TransferPageState extends State<TransferPage> {
       if (args.recipient != null) {
         final AccountData acc = AccountData();
         acc.address = args.recipient;
+        acc.name = args.label;
         setState(() {
           _accountTo = acc;
         });

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -8,6 +8,7 @@ import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/page-encointer/common/communityChooserPanel.dart';
 import 'package:encointer_wallet/page/account/txConfirmPage.dart';
 import 'package:encointer_wallet/page/qr_scan/qrScanPage.dart';
+import 'package:encointer_wallet/page/qr_scan/qrScanService.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/account/types/accountData.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -108,8 +109,10 @@ class _TransferPageState extends State<TransferPage> {
                         IconButton(
                           iconSize: 48,
                           icon: Icon(Iconsax.scan_barcode),
-                          onPressed: () => Navigator.of(context)
-                              .pushNamed(ScanPage.route), // same as for clicking the scan button in the bottom bar
+                          onPressed: () => Navigator.of(context).popAndPushNamed(ScanPage.route,
+                              arguments: ScanPageParams(
+                                  forceContext:
+                                      QrScanContext.invoice)), // same as for clicking the scan button in the bottom bar
                         ),
                         SizedBox(height: 24),
                         EncointerTextFormField(

--- a/lib/page/profile/contacts/contactDetailPage.dart
+++ b/lib/page/profile/contacts/contactDetailPage.dart
@@ -80,12 +80,14 @@ class ContactDetailPage extends StatelessWidget {
                 child: ListView(
                   children: <Widget>[
                     SizedBox(height: 30),
-                    AddressIcon(
-                      account.address,
-                      account.pubKey,
-                      size: 130,
-                      tapToCopy: true,
-                    ),
+                    Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                      AddressIcon(
+                        account.address,
+                        account.pubKey,
+                        size: 130,
+                        tapToCopy: true,
+                      )
+                    ]),
                     SizedBox(height: 20),
                     // The below is duplicate code of `accountManagePage`, but according to figma the design will
                     // change here.

--- a/lib/page/profile/contacts/contactPage.dart
+++ b/lib/page/profile/contacts/contactPage.dart
@@ -1,5 +1,6 @@
 import 'package:encointer_wallet/common/components/TapTooltip.dart';
 import 'package:encointer_wallet/common/components/roundedButton.dart';
+import 'package:encointer_wallet/page/qr_scan/qrScanPage.dart';
 import 'package:encointer_wallet/page/qr_scan/qrScanService.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -8,6 +9,7 @@ import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
 
 class ContactPage extends StatefulWidget {
   ContactPage(this.store);
@@ -198,7 +200,15 @@ class _Contact extends State<ContactPage> {
                               ),
                             ],
                           )
-                        : Container()
+                        : Container(),
+                    SizedBox(height: 24),
+                    IconButton(
+                      iconSize: 48,
+                      icon: Icon(Iconsax.scan_barcode),
+                      onPressed: () => Navigator.of(context)
+                          .popAndPushNamed(ScanPage.route), // same as for clicking the scan button in the bottom bar
+                    ),
+                    SizedBox(height: 24),
                   ],
                 ),
               ),

--- a/lib/page/profile/contacts/contactPage.dart
+++ b/lib/page/profile/contacts/contactPage.dart
@@ -205,8 +205,10 @@ class _Contact extends State<ContactPage> {
                     IconButton(
                       iconSize: 48,
                       icon: Icon(Iconsax.scan_barcode),
-                      onPressed: () => Navigator.of(context)
-                          .popAndPushNamed(ScanPage.route), // same as for clicking the scan button in the bottom bar
+                      onPressed: () => Navigator.of(context).popAndPushNamed(ScanPage.route,
+                          arguments: ScanPageParams(
+                              forceContext:
+                                  QrScanContext.contact)), // same as for clicking the scan button in the bottom bar
                     ),
                     SizedBox(height: 24),
                   ],

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -183,6 +183,11 @@ class _ProfileState extends State<Profile> {
                         }),
                   ),
                   ListTile(
+                      title: Text(dic.profile.reputationOverall, style: h3Grey),
+                      trailing: store.encointer.account.reputations != null
+                          ? Text(store.encointer.account.reputations.length.toString())
+                          : Text(dic.encointer.fetchingReputations)),
+                  ListTile(
                     title: Text(dic.profile.about, style: Theme.of(context).textTheme.headline3),
                     trailing: Icon(Icons.arrow_forward_ios, size: 18),
                     onTap: () => Navigator.pushNamed(context, AboutPage.route),

--- a/lib/page/qr_scan/qrScanPage.dart
+++ b/lib/page/qr_scan/qrScanPage.dart
@@ -9,6 +9,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_qr_scan/qrcode_reader_view.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+class ScanPageParams {
+  ScanPageParams({this.forceContext});
+  final QrScanContext forceContext;
+}
+
 class ScanPage extends StatelessWidget {
   ScanPage(this.store);
 
@@ -35,10 +40,11 @@ class ScanPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context).translationsForLocale();
+    ScanPageParams params = ModalRoute.of(context).settings.arguments;
     Future onScan(String data, String rawData) {
       try {
         QrScanData qrScanData = qrScanService.parse(data);
-        switch (qrScanData.context) {
+        switch (params?.forceContext ?? qrScanData.context) {
           case QrScanContext.contact:
             // show add contact and auto-fill data
             Navigator.of(context).popAndPushNamed(

--- a/lib/page/qr_scan/qrScanPage.dart
+++ b/lib/page/qr_scan/qrScanPage.dart
@@ -3,11 +3,11 @@ import 'package:encointer_wallet/page/profile/contacts/contactPage.dart';
 import 'package:encointer_wallet/page/qr_scan/qrScanService.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_qr_scan/qrcode_reader_view.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:encointer_wallet/utils/translations/translations.dart';
 
 class ScanPage extends StatelessWidget {
   ScanPage(this.store);
@@ -51,7 +51,11 @@ class ScanPage extends StatelessWidget {
             Navigator.of(context).popAndPushNamed(
               TransferPage.route,
               arguments: TransferPageParams(
-                  cid: qrScanData.cid, recipient: qrScanData.account, amount: qrScanData.amount, redirect: '/'),
+                  cid: qrScanData.cid,
+                  recipient: qrScanData.account,
+                  label: qrScanData.label,
+                  amount: qrScanData.amount,
+                  redirect: '/'),
             );
             break;
           default:


### PR DESCRIPTION
a few minor things that bugged me for a while 

If a user wants to add a contact, but accidentally scans an invoice QR, that is now treated more intuitively by following the intention of the scanning user (not of the QRcode presenting user)