### PR TITLE
Refresh ceremony data onfocus

### DIFF
--- a/lib/page-encointer/encointerEntry.dart
+++ b/lib/page-encointer/encointerEntry.dart
@@ -18,6 +18,7 @@ class EncointerEntry extends StatelessWidget {
   EncointerEntry(this.store);
 
   final AppStore store;
+  bool refreshing = false;
 
   @override
   Widget build(BuildContext context) {
@@ -28,8 +29,17 @@ class EncointerEntry extends StatelessWidget {
         },
         onFocusGained: () {
           print('[encointerCeremonyPage:FocusDetector] Focus Gained.');
-          store.encointer.updateState();
-          webApi.encointer.getCommunityData();
+          refreshing = true;
+          webApi.encointer.getCommunityMetadata().then((v) => webApi.encointer.getAllMeetupLocations().then((v) =>
+              webApi.encointer.getDemurrage().then((v) => webApi.encointer.getBootstrappers().then((v) => webApi
+                  .encointer
+                  .getReputations()
+                  .then((v) => webApi.encointer.getMeetupTime().then((v) => webApi.encointer
+                          .getAggregatedAccountData(store.encointer.chosenCid, store.account.currentAddress)
+                          .then((v) {
+                        print("[encointerCeremonyPage] state is current");
+                        refreshing = false;
+                      })))))));
         },
         child: Scaffold(
           backgroundColor: Colors.transparent,
@@ -52,7 +62,8 @@ class EncointerEntry extends StatelessWidget {
                     ],
                   ),
                 ),
-                PhaseAwareBox(store)
+                PhaseAwareBox(store),
+                // TODO with observer: refreshing ? Text("refreshing") : Text("refreshed")
               ],
             ),
           ),

--- a/lib/page-encointer/encointerEntry.dart
+++ b/lib/page-encointer/encointerEntry.dart
@@ -9,6 +9,7 @@ import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:focus_detector/focus_detector.dart';
 
 import '../models/index.dart';
 
@@ -21,32 +22,41 @@ class EncointerEntry extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context).translationsForLocale();
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: SafeArea(
-        child: Column(
-          children: <Widget>[
-            Padding(
-              padding: EdgeInsets.all(16),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Text(
-                    dic.encointer.encointer,
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Theme.of(context).cardColor,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  )
-                ],
-              ),
+    return FocusDetector(
+        onFocusLost: () {
+          print('[encointerCeremonyPage:FocusDetector] Focus Lost.');
+        },
+        onFocusGained: () {
+          print('[encointerCeremonyPage:FocusDetector] Focus Gained.');
+          store.encointer.updateState();
+          webApi.encointer.getCommunityData();
+        },
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          body: SafeArea(
+            child: Column(
+              children: <Widget>[
+                Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Text(
+                        dic.encointer.encointer,
+                        style: TextStyle(
+                          fontSize: 20,
+                          color: Theme.of(context).cardColor,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+                PhaseAwareBox(store)
+              ],
             ),
-            PhaseAwareBox(store)
-          ],
-        ),
-      ),
-    );
+          ),
+        ));
   }
 }
 

--- a/lib/page-encointer/encointerEntry.dart
+++ b/lib/page-encointer/encointerEntry.dart
@@ -28,9 +28,11 @@ class EncointerEntry extends StatelessWidget {
         },
         onFocusGained: () {
           print('[encointerCeremonyPage:FocusDetector] Focus Gained.');
-          webApi.encointer.getCommunityMetadata().then((v) => webApi.encointer.getAllMeetupLocations().then(
-              (v) => webApi.encointer.getDemurrage().then((v) => webApi.encointer.getBootstrappers().then((v) => webApi
-                  .encointer.getReputations().then((v) => webApi.encointer.getMeetupTime().then((v) => webApi.encointer
+          webApi.encointer.getCommunityMetadata().then((v) => webApi.encointer.getAllMeetupLocations().then((v) =>
+              webApi.encointer.getDemurrage().then((v) => webApi.encointer.getBootstrappers().then((v) => webApi
+                  .encointer
+                  .getReputations()
+                  .then((v) => webApi.encointer.getMeetupTime().then((v) => webApi.encointer
                           .getAggregatedAccountData(store.encointer.chosenCid, store.account.currentAddress)
                           .then((v) {
                         print("[encointerCeremonyPage] state is current");

--- a/lib/page-encointer/homePage.dart
+++ b/lib/page-encointer/homePage.dart
@@ -8,6 +8,7 @@ import 'package:encointer_wallet/service/notification.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:focus_detector/focus_detector.dart';
 import 'package:iconsax/iconsax.dart';
 
 import 'bazaar/0_main/bazaarMain.dart';

--- a/lib/page-encointer/homePage.dart
+++ b/lib/page-encointer/homePage.dart
@@ -8,7 +8,6 @@ import 'package:encointer_wallet/service/notification.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:focus_detector/focus_detector.dart';
 import 'package:iconsax/iconsax.dart';
 
 import 'bazaar/0_main/bazaarMain.dart';

--- a/lib/page-encointer/phases/assigning/assigningPage.dart
+++ b/lib/page-encointer/phases/assigning/assigningPage.dart
@@ -1,16 +1,9 @@
-import 'dart:async';
-
-import 'package:encointer_wallet/common/components/roundedButton.dart';
-import 'package:encointer_wallet/common/components/roundedCard.dart';
 import 'package:encointer_wallet/page-encointer/common/assignmentPanel.dart';
-import 'package:encointer_wallet/page-encointer/meetup/startMeetup.dart';
 import 'package:encointer_wallet/store/app.dart';
-import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:quiver/async.dart';
 
 class AssigningPage extends StatefulWidget {
   AssigningPage(this.store);
@@ -27,79 +20,12 @@ class _AssigningPageState extends State<AssigningPage> {
 
   final AppStore store;
 
-  int timeToMeetup;
-  StreamSubscription<CountdownTimer> sub;
-
-  @override
-  void initState() {
-    this.timeToMeetup = store.encointer.getTimeToMeetup();
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    sub.cancel();
-    super.dispose();
-  }
-
-  void startTimer() {
-    CountdownTimer countDownTimer = new CountdownTimer(
-      new Duration(seconds: timeToMeetup),
-      new Duration(seconds: 1),
-    );
-
-    sub = countDownTimer.listen(null);
-    sub.onData((duration) {
-      setState(() {
-        timeToMeetup = duration.remaining.inSeconds;
-      });
-    });
-
-    sub.onDone(() {
-      print("Done");
-      sub.cancel();
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context).translationsForLocale();
-
-    if (sub == null) {
-      startTimer();
-    }
-
     return SafeArea(
       child: Column(children: <Widget>[
         AssignmentPanel(store),
-        SizedBox(height: 16),
-        store.encointer.communityAccount.isAssigned
-            ? Container(
-                key: Key('start-meetup'),
-                child: Column(
-                  children: <Widget>[
-                    RoundedCard(
-                      padding: EdgeInsets.all(8),
-                      child: Container(
-                        width: double.infinity,
-                        child: Text(
-                          "${dic.encointer.timeUntilCeremonyStarts} ${Fmt.hhmmss(timeToMeetup)}",
-                          textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: 15),
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: 16),
-                    timeToMeetup < 60
-                        ? RoundedButton(
-                            text: dic.encointer.startCeremony,
-                            onPressed: () => startMeetup(context, store),
-                          )
-                        : Container(),
-                  ],
-                ),
-              )
-            : Container(),
       ]),
     );
   }

--- a/lib/page-encointer/phases/assigning/assigningPage.dart
+++ b/lib/page-encointer/phases/assigning/assigningPage.dart
@@ -22,7 +22,6 @@ class _AssigningPageState extends State<AssigningPage> {
 
   @override
   Widget build(BuildContext context) {
-    final Translations dic = I18n.of(context).translationsForLocale();
     return SafeArea(
       child: Column(children: <Widget>[
         AssignmentPanel(store),

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -302,17 +302,14 @@ abstract class _EncointerStore with Store {
     accountStores.forEach((cid, store) => store.purgeCeremonySpecificState());
   }
 
-  /// Calculates the remaining time until the next meetup starts. As Gesell and Cantillon currently implement timewarp
-  /// we cannot use the time received by the blockchain. Hence, we need to calculate it differently.
-  int getTimeToMeetup() {
-    var now = DateTime.now();
-    if (10 <= now.minute && now.minute < 20) {
-      return ((19 - now.minute) * 60 + 60 - now.second);
-    } else if (40 <= now.minute && now.minute < 50) {
-      return ((49 - now.minute) * 60 + 60 - now.second);
+  /// Calculates the remaining time until the next meetup starts.
+  Duration getTimeToMeetup() {
+    var start = communityAccount?.meetup?.time;
+    if (start == null) {
+      return null;
     } else {
-      _log("Warning: Invalid time to meetup");
-      return 0;
+      var now = DateTime.now();
+      return DateTime.fromMillisecondsSinceEpoch(start).difference(now);
     }
   }
 

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -274,6 +274,7 @@ abstract class _EncointerStore with Store {
 
   @action
   void updateState() {
+    print("[encointer store] updating state during $currentPhase");
     switch (currentPhase) {
       case CeremonyPhase.Registering:
         webApi.encointer.getMeetupTime();


### PR DESCRIPTION
fix the most annoying issues with the ceremony page:
* data now refreshes whenever ceremony page onFocus
* fix timeToMeetup calculation
* fix offline behaviour

Closes #605. However, as the app needs to work offline we still display possibly outdated content until refreshed

It would be better design to implement this refreshment in the store/api so we'd have an Observer we can use. However, I didn't want to intervene with the ceremonybox PR, so I consider this here temporary code that just fixes the issues. If the ceremony box solves this properly very soon, we don't need this PR