### PR TITLE
Fix inconsistent data fetches upon ceremony phase transitions

### DIFF
--- a/lib/js_service_encointer/src/service/encointer.js
+++ b/lib/js_service_encointer/src/service/encointer.js
@@ -51,17 +51,6 @@ export async function subscribeCurrentPhase (msgChannel) {
 }
 
 /**
- * Subscribes to the current ceremony index
- * @param msgChannel channel that the message handler uses on the dart side
- * @returns {Promise<void>}
- */
-export async function subscribeCurrentCeremonyIndex (msgChannel) {
-  return await api.query.encointerScheduler.currentCeremonyIndex((cIndex) => {
-    send(msgChannel, cIndex);
-  }).then((unsub) => unsubscribe(unsub, msgChannel));
-}
-
-/**
  * Subscribes to the currencies registry
  * @param msgChannel channel that the message handler uses on the dart side
  * @returns {Promise<void>}
@@ -380,7 +369,6 @@ export default {
   getParticipantReputation,
   getBootstrappers,
   subscribeCurrentPhase,
-  subscribeCurrentCeremonyIndex,
   subscribeBalance,
   subscribeCommunityIdentifiers,
   subscribeBusinessRegistry,

--- a/lib/js_service_encointer/src/service/encointer.js
+++ b/lib/js_service_encointer/src/service/encointer.js
@@ -51,6 +51,17 @@ export async function subscribeCurrentPhase (msgChannel) {
 }
 
 /**
+ * Subscribes to the current ceremony index
+ * @param msgChannel channel that the message handler uses on the dart side
+ * @returns {Promise<void>}
+ */
+export async function subscribeCurrentCeremonyIndex (msgChannel) {
+  return await api.query.encointerScheduler.currentCeremonyIndex((cIndex) => {
+    send(msgChannel, cIndex);
+  }).then((unsub) => unsubscribe(unsub, msgChannel));
+}
+
+/**
  * Subscribes to the currencies registry
  * @param msgChannel channel that the message handler uses on the dart side
  * @returns {Promise<void>}
@@ -369,6 +380,7 @@ export default {
   getParticipantReputation,
   getBootstrappers,
   subscribeCurrentPhase,
+  subscribeCurrentCeremonyIndex,
   subscribeBalance,
   subscribeCommunityIdentifiers,
   subscribeBusinessRegistry,

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -82,6 +82,12 @@ class _AssetsState extends State<Assets> {
   double _panelHeightClosed = 0;
   Translations dic;
 
+  Future<void> _refreshEncointerState() async {
+    await webApi.encointer.getCurrentPhase();
+    await webApi.encointer.getCurrentCeremonyIndex();
+    await store.encointer.updateState();
+  }
+
   @override
   Widget build(BuildContext context) {
     dic = I18n.of(context).translationsForLocale();
@@ -133,7 +139,7 @@ class _AssetsState extends State<Assets> {
                   // Should be tackled in #607
                   EdgeInsets.only(bottom: 60 + appBar.preferredSize.height + MediaQuery.of(context).viewPadding.top),
               child: RefreshIndicator(
-                onRefresh: store.encointer.updateState,
+                onRefresh: _refreshEncointerState,
                 child: ListView(
                   padding: EdgeInsets.fromLTRB(16, 4, 16, 4),
                   children: [

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -83,9 +83,8 @@ class _AssetsState extends State<Assets> {
   Translations dic;
 
   Future<void> _refreshEncointerState() async {
+    // getCurrentPhase is the root of all state updates.
     await webApi.encointer.getCurrentPhase();
-    await webApi.encointer.getCurrentCeremonyIndex();
-    await store.encointer.updateState();
   }
 
   @override

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -98,7 +98,7 @@ class EncointerApi {
   ///
   /// This is on-chain in Cantillon.
   Future<int> getNextPhaseTimestamp() async {
-    print("api: getCurrentPhase");
+    print("api: getNextPhaseTimestamp");
     int timestamp = await jsApi.evalJavascript('encointer.getNextPhaseTimestamp()').then((time) => int.parse(time));
 
     print("api: next phase timestamp: $timestamp");

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -128,17 +128,6 @@ class EncointerApi {
       print(
           "[EncointerApi]: AggregatedAccountData for ${cid.toFmtString()} and ${address.substring(0, 7)}...: ${accountData.toString()}");
 
-      var encointerAccountStore = store.encointer.communityStores[cid.toFmtString()].communityAccountStores[address];
-
-      accountData.personal?.meetup != null
-          ? encointerAccountStore.setMeetup(accountData.personal.meetup)
-          : encointerAccountStore.purgeMeetup();
-
-      accountData.personal?.participantType != null
-          ? encointerAccountStore.setParticipantType(accountData.personal.participantType)
-          : encointerAccountStore.purgeParticipantType();
-
-      print("[EncointerApi]: " + encointerAccountStore.toString());
       return accountData;
     } catch (e) {
       throw Exception("[EncointerApi]: Error getting aggregated account data ${e.toString()}");

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -39,7 +39,6 @@ class EncointerApi {
 
   final store = globalAppStore;
   final String _currentPhaseSubscribeChannel = 'currentPhase';
-  final String _ceremonyIndexSubscribeChannel = 'currentCeremonyIndex';
   final String _communityIdentifiersChannel = 'communityIdentifiers';
   final String _encointerBalanceChannel = 'encointerBalance';
   final String _businessRegistryChannel = 'businessRegistry';
@@ -51,7 +50,6 @@ class EncointerApi {
     print("api: starting encointer subscriptions");
     this.getPhaseDurations();
     this.subscribeCurrentPhase();
-    this.subscribeCurrentCeremonyIndex();
     this.subscribeCommunityIdentifiers();
     if (store.settings.endpointIsNoTee) {
       this.subscribeBusinessRegistry();
@@ -61,7 +59,6 @@ class EncointerApi {
   Future<void> stopSubscriptions() async {
     print("api: stopping encointer subscriptions");
     jsApi.unsubscribeMessage(_currentPhaseSubscribeChannel);
-    jsApi.unsubscribeMessage(_ceremonyIndexSubscribeChannel);
     jsApi.unsubscribeMessage(_communityIdentifiersChannel);
     jsApi.unsubscribeMessage(_businessRegistryChannel);
 
@@ -314,25 +311,14 @@ class EncointerApi {
 
   Future<void> subscribeCurrentPhase() async {
     jsApi.subscribeMessage(
-        'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel, (data) async {
+        'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel,
+        (data) async {
       var phase = ceremonyPhaseFromString(data.toUpperCase());
 
       await Future.delayed(Duration(seconds: 5));
 
       store.encointer.setCurrentPhase(phase);
       getNextPhaseTimestamp();
-    });
-  }
-
-  Future<void> subscribeCurrentCeremonyIndex() async {
-    jsApi.subscribeMessage(
-        'encointer.subscribeCurrentCeremonyIndex("$_ceremonyIndexSubscribeChannel")', _ceremonyIndexSubscribeChannel,
-        (data) async {
-      var index = int.parse(data);
-
-      await Future.delayed(Duration(seconds: 5));
-
-      store.encointer.setCurrentCeremonyIndex(index);
     });
   }
 
@@ -490,8 +476,4 @@ class EncointerApi {
     // Todo: @armin you'd probably extend the encointer store and also set the store here.
     return business1MockOfferings;
   }
-}
-
-void _log(String msg) {
-  print("[EncointerApi]: $msg");
 }

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -243,8 +243,12 @@ abstract class _EncointerStore with Store {
       currentPhase = phase;
       writeToCache();
     }
-    // update depending values without awaiting
-    webApi.encointer.getCurrentCeremonyIndex();
+    if (phase == CeremonyPhase.Registering) {
+      // This is a hack due to: https://github.com/encointer/encointer-wallet-flutter/issues/632
+      _log("setCurrentPhase: Skip updating state, will be done in setCurrentCeremonyIndex");
+    } else {
+      updateState();
+    }
   }
 
   @action
@@ -259,7 +263,7 @@ abstract class _EncointerStore with Store {
   @action
   void setCurrentCeremonyIndex(index) {
     print("store: set currentCeremonyIndex to $index");
-    if (currentCeremonyIndex != index && currentPhase == CeremonyPhase.Registering) {
+    if (currentCeremonyIndex != index) {
       purgeCeremonySpecificState();
     }
 

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -249,7 +249,7 @@ abstract class _EncointerStore with Store {
 
   @action
   void setNextPhaseTimestamp(int timestamp) {
-    _log("set currentPhase to $timestamp");
+    _log("set nextPhaseTimestamp to $timestamp");
     if (nextPhaseTimestamp != timestamp) {
       nextPhaseTimestamp = timestamp;
       writeToCache();

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -243,12 +243,8 @@ abstract class _EncointerStore with Store {
       currentPhase = phase;
       writeToCache();
     }
-    if (phase == CeremonyPhase.Registering) {
-      // This is a hack due to: https://github.com/encointer/encointer-wallet-flutter/issues/632
-      _log("setCurrentPhase: Skip updating state, will be done in setCurrentCeremonyIndex");
-    } else {
-      updateState();
-    }
+    // update depending values without awaiting
+    webApi.encointer.getCurrentCeremonyIndex();
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -270,6 +270,21 @@ abstract class _EncointerStore with Store {
     updateState();
   }
 
+  @action
+  void setAggregatedAccountData(CommunityIdentifier cid, String address, AggregatedAccountData accountData) {
+    var encointerAccountStore = communityStores[cid.toFmtString()].communityAccountStores[address];
+
+    accountData.personal?.meetup != null
+        ? encointerAccountStore.setMeetup(accountData.personal.meetup)
+        : encointerAccountStore.purgeMeetup();
+
+    accountData.personal?.participantType != null
+        ? encointerAccountStore.setParticipantType(accountData.personal.participantType)
+        : encointerAccountStore.purgeParticipantType();
+
+    print("[EncointerStore]: " + encointerAccountStore.toString());
+  }
+
   // -- other helpers
 
   @action
@@ -283,8 +298,17 @@ abstract class _EncointerStore with Store {
       webApi.encointer.getBootstrappers(),
       webApi.encointer.getReputations(),
       webApi.encointer.getMeetupTime(),
-      webApi.encointer.getAggregatedAccountData(chosenCid, _rootStore.account.currentAddress),
+      updateAggregatedAccountData(),
     ]).then((_) => _log("[updateState] finished"));
+  }
+
+  Future<void> updateAggregatedAccountData() async {
+    try {
+      var data = await webApi.encointer.getAggregatedAccountData(chosenCid, _rootStore.account.currentAddress);
+      setAggregatedAccountData(chosenCid, _rootStore.account.currentAddress, data);
+    } catch (e) {
+      print(e.toString());
+    }
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -275,23 +275,16 @@ abstract class _EncointerStore with Store {
   @action
   Future<void> updateState() async {
     _log("[updateState] updating state...");
-    webApi.encointer.getCommunityMetadata().then(
-          (v) => webApi.encointer.getAllMeetupLocations().then(
-                (v) => webApi.encointer.getDemurrage().then(
-                      (v) => webApi.encointer.getBootstrappers().then(
-                            (v) => webApi.encointer.getReputations().then(
-                                  (v) => webApi.encointer.getMeetupTime().then(
-                                        (v) => webApi.encointer
-                                            .getAggregatedAccountData(chosenCid, _rootStore.account.currentAddress)
-                                            .then((v) {
-                                          _log("[updateState] finished");
-                                        }),
-                                      ),
-                                ),
-                          ),
-                    ),
-              ),
-        );
+
+    return Future.wait([
+      webApi.encointer.getCommunityMetadata(),
+      webApi.encointer.getAllMeetupLocations(),
+      webApi.encointer.getDemurrage(),
+      webApi.encointer.getBootstrappers(),
+      webApi.encointer.getReputations(),
+      webApi.encointer.getMeetupTime(),
+      webApi.encointer.getAggregatedAccountData(chosenCid, _rootStore.account.currentAddress),
+    ]).then((_) => _log("[updateState] finished"));
   }
 
   @action

--- a/lib/utils/tx.dart
+++ b/lib/utils/tx.dart
@@ -159,7 +159,7 @@ Future<void> submitRegisterParticipant(BuildContext context, AppStore store, Api
     store,
     registerParticipantParams(store.encointer.chosenCid, proof: await api.encointer.getProofOfAttendance()),
     onFinish: (BuildContext txPageContext, Map res) {
-      api.encointer.getAggregatedAccountData(store.encointer.chosenCid, store.account.currentAddress);
+      store.encointer.updateAggregatedAccountData();
       Navigator.popUntil(
         txPageContext,
         ModalRoute.withName('/'),


### PR DESCRIPTION
This introduces a poll in the callback to the ceremony phase subscription to make sure we get updated values from subsequent data fetches. See #632.

Before, we sometimes got outdated values for:
* ceremony index (reason for occasionally wrong ceremony indexes in claims, in fast-testing)
* aggregated account data
   *  Reason for occasionally null meetup times in claims, n fast-testing
   * Reason for showing participant as registered when transitioning from attesting -> registering.

With this change, I was able to test on rococo, without manually triggering state updates. (we just need to be a bit patient wait for ca. 9 seconds until the values are updated, this waiting time is currently not shown in the UX)