### PR TITLE
Onboarding: automatically choose first community if there is only one.

### DIFF
--- a/lib/page/account/create/createPinPage.dart
+++ b/lib/page/account/create/createPinPage.dart
@@ -67,10 +67,14 @@ class _CreatePinPageState extends State<CreatePinPage> {
 
                   await onCreatePin();
 
-                  await Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
-                  );
+                  if (store.encointer.communityIdentifiers.length == 1) {
+                    store.encointer.setChosenCid(store.encointer.communityIdentifiers[0]);
+                  } else {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => CommunityChooserOnMap(store)),
+                    );
+                  }
 
                   setState(() {
                     _submitting = false;


### PR DESCRIPTION
Tested in onboarding process:
- [x] automatically choose leu zurich on kusama.
- [x] show community chooser map on rococo