### PR TITLE
Disallow null account name

### DIFF
--- a/lib/common/components/encointerTextFormField.dart
+++ b/lib/common/components/encointerTextFormField.dart
@@ -39,32 +39,28 @@ class EncointerTextFormField extends StatelessWidget {
         color: ZurichLion.shade50,
         borderRadius: BorderRadius.circular(15),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8.0),
-        child: TextFormField(
-          key: textFormFieldKey,
-          style: textStyle,
-          decoration: InputDecoration(
-            labelText: labelText,
-            hintText: hintText,
-            labelStyle: Theme.of(context).textTheme.headline4,
-            // errorStyle: TextStyle(height: 0.3),
-            contentPadding: EdgeInsets.only(left: 25),
-            border: UnderlineInputBorder(
-              borderSide: BorderSide(
-                width: 0,
-                style: BorderStyle.none,
-              ),
+      child: TextFormField(
+        key: textFormFieldKey,
+        style: textStyle,
+        decoration: InputDecoration(
+          labelText: labelText,
+          hintText: hintText,
+          labelStyle: Theme.of(context).textTheme.headline4,
+          contentPadding: EdgeInsets.only(top: 16, bottom: 16, left: 25),
+          border: UnderlineInputBorder(
+            borderSide: BorderSide(
+              width: 0,
+              style: BorderStyle.none,
             ),
-            suffixIcon: suffixIcon,
           ),
-          inputFormatters: inputFormatters,
-          controller: controller,
-          keyboardType: keyboardType,
-          validator: validator,
-          onChanged: onChanged,
-          obscureText: obscureText,
+          suffixIcon: suffixIcon,
         ),
+        inputFormatters: inputFormatters,
+        controller: controller,
+        keyboardType: keyboardType,
+        validator: validator,
+        onChanged: onChanged,
+        obscureText: obscureText,
       ),
     );
   }

--- a/lib/common/components/encointerTextFormField.dart
+++ b/lib/common/components/encointerTextFormField.dart
@@ -6,6 +6,7 @@ import '../theme.dart';
 /// TextFormField styled for the encointer app
 class EncointerTextFormField extends StatelessWidget {
   final String labelText;
+  final String hintText;
   final TextStyle textStyle;
   final List<TextInputFormatter> inputFormatters;
   final TextEditingController controller;
@@ -18,6 +19,7 @@ class EncointerTextFormField extends StatelessWidget {
   const EncointerTextFormField({
     Key key,
     this.labelText,
+    this.hintText,
     this.textStyle,
     this.inputFormatters,
     this.controller,
@@ -40,6 +42,7 @@ class EncointerTextFormField extends StatelessWidget {
         style: textStyle,
         decoration: InputDecoration(
           labelText: labelText,
+          hintText: hintText,
           labelStyle: Theme.of(context).textTheme.headline4,
           contentPadding: EdgeInsets.symmetric(vertical: 16, horizontal: 25),
           border: UnderlineInputBorder(

--- a/lib/common/components/encointerTextFormField.dart
+++ b/lib/common/components/encointerTextFormField.dart
@@ -11,6 +11,7 @@ class EncointerTextFormField extends StatelessWidget {
   final List<TextInputFormatter> inputFormatters;
   final TextEditingController controller;
   final Key textFormFieldKey;
+  final TextInputType keyboardType;
   final String Function(String) validator;
   final Widget suffixIcon;
   final ValueChanged<String> onChanged;
@@ -27,6 +28,7 @@ class EncointerTextFormField extends StatelessWidget {
     this.validator,
     this.suffixIcon,
     this.onChanged,
+    this.keyboardType,
     this.obscureText = false,
   }) : super(key: key);
 
@@ -37,28 +39,32 @@ class EncointerTextFormField extends StatelessWidget {
         color: ZurichLion.shade50,
         borderRadius: BorderRadius.circular(15),
       ),
-      child: TextFormField(
-        key: textFormFieldKey,
-        style: textStyle,
-        decoration: InputDecoration(
-          labelText: labelText,
-          hintText: hintText,
-          labelStyle: Theme.of(context).textTheme.headline4,
-          contentPadding: EdgeInsets.symmetric(vertical: 16, horizontal: 25),
-          border: UnderlineInputBorder(
-            borderSide: BorderSide(
-              width: 0,
-              style: BorderStyle.none,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: TextFormField(
+          key: textFormFieldKey,
+          style: textStyle,
+          decoration: InputDecoration(
+            labelText: labelText,
+            hintText: hintText,
+            labelStyle: Theme.of(context).textTheme.headline4,
+            // errorStyle: TextStyle(height: 0.3),
+            contentPadding: EdgeInsets.only(left: 25),
+            border: UnderlineInputBorder(
+              borderSide: BorderSide(
+                width: 0,
+                style: BorderStyle.none,
+              ),
             ),
+            suffixIcon: suffixIcon,
           ),
-          suffixIcon: suffixIcon,
+          inputFormatters: inputFormatters,
+          controller: controller,
+          keyboardType: keyboardType,
+          validator: validator,
+          onChanged: onChanged,
+          obscureText: obscureText,
         ),
-        inputFormatters: inputFormatters,
-        controller: controller,
-        keyboardType: TextInputType.numberWithOptions(decimal: true),
-        validator: validator,
-        onChanged: onChanged,
-        obscureText: obscureText,
       ),
     );
   }

--- a/lib/page-encointer/meetup/ceremonyStep1Count.dart
+++ b/lib/page-encointer/meetup/ceremonyStep1Count.dart
@@ -103,6 +103,7 @@ class CeremonyStep1Count extends StatelessWidget {
                       labelText: dic.encointer.numberOfAttendees,
                       textStyle: Theme.of(context).textTheme.headline1.copyWith(color: encointerBlack),
                       controller: _attendeesCountController,
+                      keyboardType: TextInputType.numberWithOptions(decimal: true),
                       textFormFieldKey: Key('attendees-count'),
                     ),
                   ],

--- a/lib/page/account/create/addAccountForm.dart
+++ b/lib/page/account/create/addAccountForm.dart
@@ -90,7 +90,7 @@ class AddAccountForm extends StatelessWidget {
                 if (_formKey.currentState.validate()) {
                   var name = _nameCtrl.text.trim();
 
-                  store.account.setNewAccountName(name.isNotEmpty ? name : dic.account.createDefault);
+                  store.account.setNewAccountName(name);
                   store.account.setNewAccountPin(store.settings.cachedPin);
 
                   onSubmit();

--- a/lib/page/account/create/addAccountForm.dart
+++ b/lib/page/account/create/addAccountForm.dart
@@ -1,7 +1,9 @@
+import 'package:encointer_wallet/common/components/encointerTextFormField.dart';
 import 'package:encointer_wallet/common/components/gradientElements.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page/account/import/importAccountPage.dart';
 import 'package:encointer_wallet/store/app.dart';
+import 'package:encointer_wallet/utils/inputValidation.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
@@ -47,25 +49,12 @@ class AddAccountForm extends StatelessWidget {
                     ),
                   ),
                   SizedBox(height: 30),
-                  Column(
-                    children: <Widget>[
-                      TextFormField(
-                        key: Key('create-account-name'),
-                        decoration: InputDecoration(
-                          enabledBorder: const OutlineInputBorder(
-                            // width: 0.0 produces a thin "hairline" border
-                            borderSide: const BorderSide(color: Colors.transparent, width: 0.0),
-                            borderRadius:
-                                BorderRadius.horizontal(left: Radius.circular(15), right: Radius.circular(15)),
-                          ),
-                          filled: true,
-                          fillColor: ZurichLion.shade50,
-                          hintText: dic.account.createHint,
-                          labelText: I18n.of(context).translationsForLocale().profile.accountName,
-                        ),
-                        controller: _nameCtrl,
-                      ),
-                    ],
+                  EncointerTextFormField(
+                    key: Key('create-account-name'),
+                    hintText: dic.account.createHint,
+                    labelText: I18n.of(context).translationsForLocale().profile.accountName,
+                    controller: _nameCtrl,
+                    validator: (v) => InputValidation.validateAccountName(context, v, store.account.optionalAccounts),
                   ),
                 ],
               ),

--- a/lib/page/account/create/createAccountForm.dart
+++ b/lib/page/account/create/createAccountForm.dart
@@ -1,4 +1,5 @@
 import 'package:encointer_wallet/common/components/accountAdvanceOption.dart';
+import 'package:encointer_wallet/common/components/encointerTextFormField.dart';
 import 'package:encointer_wallet/common/components/gradientElements.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page/account/create/createPinPage.dart';
@@ -9,6 +10,7 @@ import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
+import 'package:encointer_wallet/utils/inputValidation.dart';
 
 class CreateAccountForm extends StatelessWidget {
   CreateAccountForm({this.store});
@@ -77,24 +79,12 @@ class CreateAccountForm extends StatelessWidget {
                   ),
                 ),
                 SizedBox(height: 50),
-                Column(
-                  children: <Widget>[
-                    TextFormField(
-                      key: Key('create-account-name'),
-                      decoration: InputDecoration(
-                        enabledBorder: const OutlineInputBorder(
-                          // width: 0.0 produces a thin "hairline" border
-                          borderSide: const BorderSide(color: Colors.transparent, width: 0.0),
-                          borderRadius: BorderRadius.horizontal(left: Radius.circular(15), right: Radius.circular(15)),
-                        ),
-                        filled: true,
-                        fillColor: ZurichLion.shade50,
-                        hintText: dic.account.createHint,
-                        labelText: I18n.of(context).translationsForLocale().profile.accountName,
-                      ),
-                      controller: _nameCtrl,
-                    ),
-                  ],
+                EncointerTextFormField(
+                  key: Key('create-account-name'),
+                  hintText: dic.account.createHint,
+                  labelText: I18n.of(context).translationsForLocale().profile.accountName,
+                  controller: _nameCtrl,
+                  validator: (v) => InputValidation.validateAccountName(context, v, store.account.optionalAccounts),
                 ),
               ],
             ),

--- a/lib/page/account/import/importAccountForm.dart
+++ b/lib/page/account/import/importAccountForm.dart
@@ -1,6 +1,7 @@
 import 'package:encointer_wallet/common/components/accountAdvanceOption.dart';
+import 'package:encointer_wallet/common/components/encointerTextFormField.dart';
 import 'package:encointer_wallet/common/components/gradientElements.dart';
-import 'package:encointer_wallet/common/theme.dart';
+import 'package:encointer_wallet/utils/inputValidation.dart';
 import 'package:encointer_wallet/store/account/account.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
@@ -98,20 +99,12 @@ class _ImportAccountFormState extends State<ImportAccountForm> {
                     ),
                   ),
                   SizedBox(height: 30),
-                  TextFormField(
+                  EncointerTextFormField(
                     key: Key('create-account-name'),
-                    decoration: InputDecoration(
-                      enabledBorder: const OutlineInputBorder(
-                        // width: 0.0 produces a thin "hairline" border
-                        borderSide: const BorderSide(color: Colors.transparent, width: 0.0),
-                        borderRadius: BorderRadius.horizontal(left: Radius.circular(15), right: Radius.circular(15)),
-                      ),
-                      filled: true,
-                      fillColor: ZurichLion.shade50,
-                      hintText: dic.account.createHint,
-                      labelText: I18n.of(context).translationsForLocale().profile.accountName,
-                    ),
+                    hintText: dic.account.createHint,
+                    labelText: I18n.of(context).translationsForLocale().profile.accountName,
                     controller: _nameCtrl,
+                    validator: (v) => InputValidation.validateAccountName(context, v, store.account.optionalAccounts),
                   ),
                   TextFormField(
                     key: Key('account-source'),

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -155,6 +155,7 @@ class _ReceivePageState extends State<ReceivePage> {
                           textStyle: Theme.of(context).textTheme.headline2.copyWith(color: encointerBlack),
                           inputFormatters: [UI.decimalInputFormatter()],
                           controller: _amountController,
+                          keyboardType: TextInputType.numberWithOptions(decimal: true),
                           textFormFieldKey: Key('invoice-amount-input'),
                           onChanged: (value) {
                             setState(() {

--- a/lib/page/assets/transfer/transferPage.dart
+++ b/lib/page/assets/transfer/transferPage.dart
@@ -120,6 +120,7 @@ class _TransferPageState extends State<TransferPage> {
                           labelText: dic.assets.amountToBeTransferred,
                           textStyle: Theme.of(context).textTheme.headline1.copyWith(color: encointerBlack),
                           inputFormatters: [UI.decimalInputFormatter(decimals: decimals)],
+                          keyboardType: TextInputType.numberWithOptions(decimal: true),
                           controller: _amountCtrl,
                           textFormFieldKey: Key('transfer-amount-input'),
                           validator: (String value) {

--- a/lib/page/profile/account/accountManagePage.dart
+++ b/lib/page/profile/account/accountManagePage.dart
@@ -10,6 +10,7 @@ import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/encointerBalanceData.dart';
 import 'package:encointer_wallet/utils/UI.dart';
 import 'package:encointer_wallet/utils/format.dart';
+import 'package:encointer_wallet/utils/inputValidation.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
@@ -176,17 +177,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
           title: _isEditingText
               ? TextFormField(
                   controller: _nameCtrl,
-                  validator: (v) {
-                    String name = v.trim();
-                    if (name.length == 0) {
-                      return dic.profile.contactNameError;
-                    }
-                    int exist = store.account.optionalAccounts.indexWhere((i) => i.name == name);
-                    if (exist > -1) {
-                      return dic.profile.contactNameAlreadyExists;
-                    }
-                    return null;
-                  },
+                  validator: (v) => InputValidation.validateAccountName(context, v, store.account.optionalAccounts),
                 )
               : Text(_nameCtrl.text),
           actions: <Widget>[

--- a/lib/page/profile/account/changePasswordPage.dart
+++ b/lib/page/profile/account/changePasswordPage.dart
@@ -147,6 +147,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
                           },
                           obscureText: true,
                           inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                          keyboardType: TextInputType.numberWithOptions(decimal: true),
                         ),
                         SizedBox(height: 20),
                         EncointerTextFormField(
@@ -157,6 +158,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
                           },
                           obscureText: true,
                           inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                          keyboardType: TextInputType.numberWithOptions(decimal: true),
                         ),
                         SizedBox(height: 20),
                         EncointerTextFormField(
@@ -167,6 +169,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
                           },
                           obscureText: true,
                           inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                          keyboardType: TextInputType.numberWithOptions(decimal: true),
                         ),
                       ],
                     ),

--- a/lib/utils/inputValidation.dart
+++ b/lib/utils/inputValidation.dart
@@ -1,0 +1,20 @@
+import 'package:encointer_wallet/store/account/types/accountData.dart';
+import 'package:encointer_wallet/utils/translations/index.dart';
+import 'package:flutter/material.dart';
+
+class InputValidation {
+
+  static String validateAccountName(BuildContext context, String input, List<AccountData> existingAccounts) {
+    final dic = I18n.of(context).translationsForLocale();
+
+      String name = input.trim();
+      if (name.length == 0) {
+        return dic.profile.contactNameError;
+      }
+      int exist = existingAccounts.indexWhere((i) => i.name == name);
+      if (exist > -1) {
+        return dic.profile.contactNameAlreadyExists;
+      }
+      return null;
+    }
+}

--- a/lib/utils/inputValidation.dart
+++ b/lib/utils/inputValidation.dart
@@ -3,18 +3,17 @@ import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:flutter/material.dart';
 
 class InputValidation {
-
   static String validateAccountName(BuildContext context, String input, List<AccountData> existingAccounts) {
     final dic = I18n.of(context).translationsForLocale();
 
-      String name = input.trim();
-      if (name.length == 0) {
-        return dic.profile.contactNameError;
-      }
-      int exist = existingAccounts.indexWhere((i) => i.name == name);
-      if (exist > -1) {
-        return dic.profile.contactNameAlreadyExists;
-      }
-      return null;
+    String name = input.trim();
+    if (name.length == 0) {
+      return dic.profile.contactNameError;
     }
+    int exist = existingAccounts.indexWhere((i) => i.name == name);
+    if (exist > -1) {
+      return dic.profile.contactNameAlreadyExists;
+    }
+    return null;
+  }
 }

--- a/lib/utils/translations/translationsAccount.dart
+++ b/lib/utils/translations/translationsAccount.dart
@@ -4,7 +4,6 @@ abstract class TranslationsAccount {
   String get advanced;
   String get backupError;
   String get create;
-  String get createDefault;
   String get createError;
   String get createHint;
   String get createPassword;
@@ -40,7 +39,6 @@ class TranslationsEnAccount implements TranslationsAccount {
   get backupError =>
       'This device does not support key type sr25519, you can select [Advanced Options -> Encrypt Type -> ed25519] to continue.';
   get create => 'Create Account';
-  get createDefault => 'My Account';
   get createError => 'There was an error creating your account';
   get createHint => '(Example: Alice)';
   get createPassword => 'PIN';
@@ -77,7 +75,6 @@ class TranslationsDeAccount implements TranslationsAccount {
   get backupError =>
       'Dieses Gerät unterstützt den key Typ sr25519 nicht, wähle [Erweiterte Optionen -> Verschlüsselungstyp -> ed225519] für den nächsten Schritt.';
   get create => 'Konto registrieren';
-  get createDefault => 'Mein Konto';
   get createError => 'Beim Erstellen deines Kontos ist ein Fehler aufgetreten';
   get createHint => '(Beispiel: Alice)';
   get createPassword => 'PIN';
@@ -113,7 +110,6 @@ class TranslationsZhAccount implements TranslationsAccount {
   get advanced => '高级选项';
   get backupError => '此设备不支持密钥类型 sr25519，您可以选择 [高级选项 -> 加密类型 -> ed25519] 继续。';
   get create => '创建帐户';
-  get createDefault => '我的帐户';
   get createError => '创建帐户时出错';
   get createHint => '（默认值：我的帐户）';
   get createPassword => 'PIN';

--- a/lib/utils/translations/translationsAccount.dart
+++ b/lib/utils/translations/translationsAccount.dart
@@ -42,7 +42,7 @@ class TranslationsEnAccount implements TranslationsAccount {
   get create => 'Create Account';
   get createDefault => 'My Account';
   get createError => 'There was an error creating your account';
-  get createHint => '(Default: My Account)';
+  get createHint => '(Example: Alice)';
   get createPassword => 'PIN';
   get createPassword2 => 'Confirm PIN';
   get createPassword2Error => 'Inconsistent PINs';
@@ -79,7 +79,7 @@ class TranslationsDeAccount implements TranslationsAccount {
   get create => 'Konto registrieren';
   get createDefault => 'Mein Konto';
   get createError => 'Beim Erstellen deines Kontos ist ein Fehler aufgetreten';
-  get createHint => '(Standard: Mein Konto)';
+  get createHint => '(Beispiel: Alice)';
   get createPassword => 'PIN';
   get createPassword2 => 'PIN Bestätigen';
   get createPassword2Error => 'Die PINs stimmen nicht überein';


### PR DESCRIPTION
* Closes #641

Changes:
* Disallow empty account name inputs whatsoever. Before we validated the input, and if it was empty, we used a default. Now the user is forced to actually enter a value.
* Fix: in in `createAccountForm` and `importAccountForm` the check to disallow empty inputs has been missing.