### PR TITLE
Dynamic meetup overrides based on encointer feed

### DIFF
--- a/lib/config/consts.dart
+++ b/lib/config/consts.dart
@@ -91,6 +91,9 @@ const community_icon_name = "community_icon.svg";
 const String ipfs_gateway_encointer = "http://ipfs.encointer.org:8080"; // AVD: 10.0.2.2 = 127.0.0.1
 const String ipfs_gateway_local = 'http://10.0.2.2:8080';
 
+const String encointer_feed = "https://encointer.github.io/feed";
+const String encointer_feed_overrides = "$encointer_feed/overrides.json";
+
 const int ert_decimals = 12;
 const int encointer_currencies_decimals = 18;
 

--- a/lib/mocks/data/mockMeetupOverrides.dart
+++ b/lib/mocks/data/mockMeetupOverrides.dart
@@ -1,0 +1,9 @@
+import 'package:encointer_wallet/models/index.dart';
+
+final testMeetup1 = DateTime.parse("2022-06-26T11:30:00.00+00:00");
+final testMeetup2 = DateTime.parse("2022-06-26T16:30:00.00+00:00");
+
+// meetup override for `bootstrap_demo_community
+final testMeetupOverrides = [
+  MeetupOverrides("Test", "nctr-gsl-dev", ["sqm1v79dF6b"], [testMeetup1, testMeetup2]),
+];

--- a/lib/models/encointer_feed/meetupOverrides.dart
+++ b/lib/models/encointer_feed/meetupOverrides.dart
@@ -17,7 +17,7 @@ class MeetupOverrides {
   String overrideName;
   String network;
   List<String> communities;
-  List<String> meetupTimes;
+  List<DateTime> meetupTimes;
 
   @override
   String toString() {

--- a/lib/models/encointer_feed/meetupOverrides.dart
+++ b/lib/models/encointer_feed/meetupOverrides.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+
+// Run: `flutter pub run build_runner build` in order to create/update the *.g.dart
+part 'meetupOverrides.g.dart';
+
+@JsonSerializable(explicitToJson: true, fieldRename: FieldRename.kebab)
+class MeetupOverrides {
+  MeetupOverrides(
+    this.overrideName,
+    this.network,
+    this.communities,
+    this.meetupTimes,
+  );
+
+  String overrideName;
+  String network;
+  List<String> communities;
+  List<String> meetupTimes;
+
+  @override
+  String toString() {
+    return jsonEncode(this);
+  }
+
+  factory MeetupOverrides.fromJson(Map<String, dynamic> json) => _$MeetupOverridesFromJson(json);
+  Map<String, dynamic> toJson() => _$MeetupOverridesToJson(this);
+}

--- a/lib/models/encointer_feed/meetupOverrides.dart
+++ b/lib/models/encointer_feed/meetupOverrides.dart
@@ -24,6 +24,10 @@ class MeetupOverrides {
     return jsonEncode(this);
   }
 
+  DateTime getNextMeetupTime(DateTime time) {
+    return meetupTimes.firstWhere((mt) => time.isBefore(mt), orElse: () => null);
+  }
+
   factory MeetupOverrides.fromJson(Map<String, dynamic> json) => _$MeetupOverridesFromJson(json);
   Map<String, dynamic> toJson() => _$MeetupOverridesToJson(this);
 }

--- a/lib/models/encointer_feed/meetupOverrides.dart
+++ b/lib/models/encointer_feed/meetupOverrides.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:encointer_wallet/models/ceremonies/ceremonies.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 // Run: `flutter pub run build_runner build` in order to create/update the *.g.dart
@@ -24,8 +25,17 @@ class MeetupOverrides {
     return jsonEncode(this);
   }
 
-  DateTime getNextMeetupTime(DateTime time) {
-    return meetupTimes.firstWhere((mt) => time.isBefore(mt), orElse: () => null);
+  /// Returns the next meetup time.
+  ///
+  /// If it is in the `Attesting` phase it returns the meetup time of the currently ongoing meetup.
+  DateTime getNextMeetupTime(DateTime time, CeremonyPhase phase) {
+    meetupTimes.sort();
+
+    if (phase != CeremonyPhase.Attesting) {
+      return meetupTimes.firstWhere((mt) => time.isBefore(mt), orElse: () => null);
+    } else {
+      return meetupTimes.reversed.firstWhere((mt) => time.isAfter(mt), orElse: () => null);
+    }
   }
 
   factory MeetupOverrides.fromJson(Map<String, dynamic> json) => _$MeetupOverridesFromJson(json);

--- a/lib/models/encointer_feed/meetupOverrides.g.dart
+++ b/lib/models/encointer_feed/meetupOverrides.g.dart
@@ -11,7 +11,7 @@ MeetupOverrides _$MeetupOverridesFromJson(Map<String, dynamic> json) {
     json['override-name'] as String,
     json['network'] as String,
     (json['communities'] as List)?.map((e) => e as String)?.toList(),
-    (json['meetup-times'] as List)?.map((e) => e as String)?.toList(),
+    (json['meetup-times'] as List)?.map((e) => e == null ? null : DateTime.parse(e as String))?.toList(),
   );
 }
 
@@ -19,5 +19,5 @@ Map<String, dynamic> _$MeetupOverridesToJson(MeetupOverrides instance) => <Strin
       'override-name': instance.overrideName,
       'network': instance.network,
       'communities': instance.communities,
-      'meetup-times': instance.meetupTimes,
+      'meetup-times': instance.meetupTimes?.map((e) => e?.toIso8601String())?.toList(),
     };

--- a/lib/models/encointer_feed/meetupOverrides.g.dart
+++ b/lib/models/encointer_feed/meetupOverrides.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'meetupOverrides.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MeetupOverrides _$MeetupOverridesFromJson(Map<String, dynamic> json) {
+  return MeetupOverrides(
+    json['override-name'] as String,
+    json['network'] as String,
+    (json['communities'] as List)?.map((e) => e as String)?.toList(),
+    (json['meetup-times'] as List)?.map((e) => e as String)?.toList(),
+  );
+}
+
+Map<String, dynamic> _$MeetupOverridesToJson(MeetupOverrides instance) => <String, dynamic>{
+      'override-name': instance.overrideName,
+      'network': instance.network,
+      'communities': instance.communities,
+      'meetup-times': instance.meetupTimes,
+    };

--- a/lib/models/index.dart
+++ b/lib/models/index.dart
@@ -5,3 +5,4 @@ library models;
 
 export 'ceremonies/ceremonies.dart';
 export 'commons/commons.dart';
+export 'encointer_feed/meetupOverrides.dart';

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -68,7 +68,7 @@ class CeremonyBox extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(top: 12),
                     child: CeremonyRegisterButton(
-                      registerUntil: store.encointer?.assigningPhaseStart,
+                      registerUntil: assigningPhaseStart,
                       onPressed: (context) => submitRegisterParticipant(context, store, api),
                     ),
                   ),

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -3,7 +3,6 @@ import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/models/index.dart';
 import 'package:encointer_wallet/page-encointer/common/encointerMap.dart';
 import 'package:encointer_wallet/page-encointer/meetup/ceremonyStep1Count.dart';
-import 'package:encointer_wallet/service/encointer_feed/feed.dart' as feed;
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
@@ -39,29 +38,9 @@ class _CeremonyBoxState extends State<CeremonyBox> {
   final AppStore store;
   final Api api;
 
-  DateTime meetupTimeOverride;
-
   @override
   void initState() {
     super.initState();
-    getMeetupOverride();
-  }
-
-  Future<void> getMeetupOverride() async {
-    final overrides = await feed.getMeetupOverrides();
-
-    final networkOverride = overrides.firstWhere(
-      (o) => o.network == store.encointer.network,
-      orElse: () => null,
-    );
-
-    if (networkOverride == null) {
-      return Future.value(null);
-    }
-
-    if (networkOverride.communities.contains(store.encointer.chosenCid.toFmtString())) {
-      meetupTimeOverride = networkOverride.getNextMeetupTime(DateTime.now(), store.encointer.currentPhase);
-    }
   }
 
   @override
@@ -69,7 +48,7 @@ class _CeremonyBoxState extends State<CeremonyBox> {
     var dic = I18n.of(context).translationsForLocale();
 
     return Observer(builder: (BuildContext context) {
-      int meetupTime = meetupTimeOverride?.millisecondsSinceEpoch ??
+      int meetupTime = store.encointer.community?.meetupTimeOverride ??
           store.encointer?.community?.meetupTime ??
           store.encointer.attestingPhaseStart;
 

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -50,8 +50,17 @@ class _CeremonyBoxState extends State<CeremonyBox> {
   Future<void> getMeetupOverride() async {
     final overrides = await feed.getMeetupOverrides();
 
-    if (overrides.communities.contains(store.encointer.chosenCid.toFmtString())) {
-      meetupTimeOverride = overrides.getNextMeetupTime(DateTime.now());
+    final networkOverride = overrides.firstWhere(
+      (o) => o.network == store.encointer.network,
+      orElse: () => null,
+    );
+
+    if (networkOverride == null) {
+      return Future.value(null);
+    }
+
+    if (networkOverride.communities.contains(store.encointer.chosenCid.toFmtString())) {
+      meetupTimeOverride = networkOverride.getNextMeetupTime(DateTime.now(), store.encointer.currentPhase);
     }
   }
 

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -65,7 +65,8 @@ class _CeremonyBoxState extends State<CeremonyBox> {
               children: [
                 CeremonyInfo(
                   currentTime: DateTime.now().millisecondsSinceEpoch,
-                  assigningPhaseStart: store.encointer?.assigningPhaseStart,
+                  assigningPhaseStart:
+                      store.encointer.community?.meetupTimeOverride ?? store.encointer?.assigningPhaseStart,
                   meetupTime: meetupTime,
                   ceremonyPhaseDurations: store.encointer.phaseDurations,
                   meetupCompleted: store.encointer?.communityAccount?.meetupCompleted,

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -18,7 +18,7 @@ import 'components/lowerCeremonyBoxContainer.dart';
 import 'meetup_info/components/ceremonyNotification.dart';
 import 'meetup_info/meetupInfo.dart';
 
-class CeremonyBox extends StatefulWidget {
+class CeremonyBox extends StatelessWidget {
   CeremonyBox(
     this.store,
     this.api, {
@@ -27,21 +27,6 @@ class CeremonyBox extends StatefulWidget {
 
   final AppStore store;
   final Api api;
-
-  @override
-  _CeremonyBoxState createState() => _CeremonyBoxState(store, api);
-}
-
-class _CeremonyBoxState extends State<CeremonyBox> {
-  _CeremonyBoxState(this.store, this.api);
-
-  final AppStore store;
-  final Api api;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page-encointer/ceremony_box/ceremonyBox.dart
+++ b/lib/page-encointer/ceremony_box/ceremonyBox.dart
@@ -37,6 +37,14 @@ class CeremonyBox extends StatelessWidget {
           store.encointer?.community?.meetupTime ??
           store.encointer.attestingPhaseStart;
 
+      // I decided to not introduce anymore degrees of freedom for the demo overrides, otherwise
+      // we want to do too much again. So I hardcode the assigning phase duration to 30 minutes
+      // if we have meetup time overrides. Before we do something more complex here, I want to
+      // think some more, of what we want to do with the feed in the future.
+      int assigningPhaseStart = store.encointer.community?.meetupTimeOverride != null
+          ? store.encointer.community.meetupTimeOverride - Duration(minutes: 30).inMilliseconds
+          : store.encointer?.assigningPhaseStart;
+
       return Column(
         children: [
           Container(
@@ -50,8 +58,7 @@ class CeremonyBox extends StatelessWidget {
               children: [
                 CeremonyInfo(
                   currentTime: DateTime.now().millisecondsSinceEpoch,
-                  assigningPhaseStart:
-                      store.encointer.community?.meetupTimeOverride ?? store.encointer?.assigningPhaseStart,
+                  assigningPhaseStart: assigningPhaseStart,
                   meetupTime: meetupTime,
                   ceremonyPhaseDurations: store.encointer.phaseDurations,
                   meetupCompleted: store.encointer?.communityAccount?.meetupCompleted,

--- a/lib/page-encointer/ceremony_box/components/ceremonyRegisterButton.dart
+++ b/lib/page-encointer/ceremony_box/components/ceremonyRegisterButton.dart
@@ -46,7 +46,7 @@ class _CeremonyRegisterButtonState extends State<CeremonyRegisterButton> {
                 Icon(Iconsax.login_1),
                 SizedBox(width: 6),
                 Text('${dic.encointer.registerUntil} '),
-                MaybeDateTime(widget.registerUntil, dateFormat: DateFormat.yMd(languageCode))
+                MaybeDateTime(widget.registerUntil, dateFormat: DateFormat.yMd(languageCode).add_Hm())
               ],
             )
           : CupertinoActivityIndicator(),

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
 import 'package:encointer_wallet/config/consts.dart';
-import 'package:encointer_wallet/models/encointer_feed/meetupOverrides.dart';
+import 'package:encointer_wallet/models/index.dart';
+import 'package:encointer_wallet/store/encointer/types/communities.dart';
 import 'package:http/http.dart' as http;
 
 Future<List<MeetupOverrides>> getMeetupOverrides() async {
@@ -13,4 +14,31 @@ Future<List<MeetupOverrides>> getMeetupOverrides() async {
   } else {
     throw Exception('Failed to get meetup overrides.');
   }
+}
+
+Future<DateTime> getMeetupTimeOverride(String network, CommunityIdentifier cid, CeremonyPhase phase) async {
+  final overrides = await getMeetupOverrides();
+
+  final networkOverride = overrides.firstWhere(
+        (o) => o.network == network,
+    orElse: () => null,
+  );
+
+  if (networkOverride == null) {
+    _log("No network specific override found");
+    return Future.value(null);
+  }
+
+  if (networkOverride.communities.contains(cid.toFmtString())) {
+    final meetupTimeOverride = networkOverride.getNextMeetupTime(DateTime.now(), phase);
+    _log("Found meetupTimeOverride: $meetupTimeOverride");
+    return meetupTimeOverride;
+  } else {
+    _log("No community specific override found");
+    return Future.value(null);
+  }
+}
+
+void _log(String feed) {
+  print("[EncointerFeed] ");
 }

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -39,6 +39,6 @@ Future<DateTime> getMeetupTimeOverride(String network, CommunityIdentifier cid, 
   }
 }
 
-void _log(String feed) {
-  print("[EncointerFeed] ");
+void _log(String msg) {
+  print("[EncointerFeed] $msg");
 }

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -20,7 +20,7 @@ Future<DateTime> getMeetupTimeOverride(String network, CommunityIdentifier cid, 
   final overrides = await getMeetupOverrides();
 
   final networkOverride = overrides.firstWhere(
-        (o) => o.network == network,
+    (o) => o.network == network,
     orElse: () => null,
   );
 

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -1,0 +1,15 @@
+import 'dart:convert';
+
+import 'package:encointer_wallet/config/consts.dart';
+import 'package:encointer_wallet/models/encointer_feed/meetupOverrides.dart';
+import 'package:http/http.dart' as http;
+
+Future<MeetupOverrides> getMeetupOverrides() async {
+  final response = await http.get(Uri.parse(encointer_feed_overrides));
+
+  if (response.statusCode == 200) {
+    return MeetupOverrides.fromJson(jsonDecode(response.body));
+  } else {
+    throw Exception('Failed to get meetup overrides.');
+  }
+}

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -4,11 +4,12 @@ import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/models/encointer_feed/meetupOverrides.dart';
 import 'package:http/http.dart' as http;
 
-Future<MeetupOverrides> getMeetupOverrides() async {
+Future<List<MeetupOverrides>> getMeetupOverrides() async {
   final response = await http.get(Uri.parse(encointer_feed_overrides));
 
   if (response.statusCode == 200) {
-    return MeetupOverrides.fromJson(jsonDecode(response.body));
+    List<dynamic> list = jsonDecode(response.body);
+    return list.map((e) => MeetupOverrides.fromJson(e)).toList();
   } else {
     throw Exception('Failed to get meetup overrides.');
   }

--- a/lib/service/encointer_feed/feed.dart
+++ b/lib/service/encointer_feed/feed.dart
@@ -17,6 +17,8 @@ Future<List<MeetupOverrides>> getMeetupOverrides() async {
 }
 
 Future<DateTime> getMeetupTimeOverride(String network, CommunityIdentifier cid, CeremonyPhase phase) async {
+  // For testing that it works.
+  // final overrides = testMeetupOverrides;
   final overrides = await getMeetupOverrides();
 
   final networkOverride = overrides.firstWhere(

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -11,6 +11,7 @@ import 'package:encointer_wallet/store/encointer/types/encointerBalanceData.dart
 import 'package:encointer_wallet/store/encointer/types/location.dart';
 import 'package:encointer_wallet/store/encointer/types/proofOfAttendance.dart';
 import 'package:encointer_wallet/utils/format.dart';
+import 'package:encointer_wallet/service/encointer_feed/feed.dart' as feed;
 
 import '../../../models/index.dart';
 import '../core/dartApi.dart';
@@ -79,6 +80,7 @@ class EncointerApi {
     getDemurrage();
     getBootstrappers();
     getReputations();
+    getMeetupOverride();
   }
 
   /// Queries the Scheduler pallet: encointerScheduler.currentPhase().
@@ -253,6 +255,19 @@ class EncointerApi {
 
     store.encointer.community.setMeetupTime(time);
     return DateTime.fromMillisecondsSinceEpoch(time);
+  }
+
+  Future<void> getMeetupOverride() async {
+    CommunityIdentifier cid = store.encointer.chosenCid;
+    if (cid == null) {
+      return;
+    }
+
+    final meetupTimeOverride = await feed.getMeetupTimeOverride(store.encointer.network, cid, store.encointer.currentPhase);
+
+    if (meetupTimeOverride != null) {
+      store.encointer.community.setMeetupTimeOverride(meetupTimeOverride.millisecondsSinceEpoch);
+    }
   }
 
   Future<bool> hasPendingIssuance() async {

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -264,7 +264,8 @@ class EncointerApi {
       return;
     }
 
-    final meetupTimeOverride = await feed.getMeetupTimeOverride(store.encointer.network, cid, store.encointer.currentPhase);
+    final meetupTimeOverride =
+        await feed.getMeetupTimeOverride(store.encointer.network, cid, store.encointer.currentPhase);
 
     if (meetupTimeOverride != null) {
       store.encointer.community.setMeetupTimeOverride(meetupTimeOverride.millisecondsSinceEpoch);

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/mocks/data/mockBazaarData.dart';
+import 'package:encointer_wallet/service/encointer_feed/feed.dart' as feed;
 import 'package:encointer_wallet/service/substrate_api/core/jsApi.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/bazaar.dart';
@@ -11,7 +12,6 @@ import 'package:encointer_wallet/store/encointer/types/encointerBalanceData.dart
 import 'package:encointer_wallet/store/encointer/types/location.dart';
 import 'package:encointer_wallet/store/encointer/types/proofOfAttendance.dart';
 import 'package:encointer_wallet/utils/format.dart';
-import 'package:encointer_wallet/service/encointer_feed/feed.dart' as feed;
 
 import '../../../models/index.dart';
 import '../core/dartApi.dart';
@@ -264,11 +264,15 @@ class EncointerApi {
       return;
     }
 
-    final meetupTimeOverride =
-        await feed.getMeetupTimeOverride(store.encointer.network, cid, store.encointer.currentPhase);
+    try {
+      final meetupTimeOverride =
+          await feed.getMeetupTimeOverride(store.encointer.network, cid, store.encointer.currentPhase);
 
-    if (meetupTimeOverride != null) {
-      store.encointer.community.setMeetupTimeOverride(meetupTimeOverride.millisecondsSinceEpoch);
+      if (meetupTimeOverride != null) {
+        store.encointer.community.setMeetupTimeOverride(meetupTimeOverride.millisecondsSinceEpoch);
+      }
+    } catch (e) {
+      print("api: exception: ${e.toString()}");
     }
   }
 

--- a/lib/service/substrate_api/encointer/encointerApi.dart
+++ b/lib/service/substrate_api/encointer/encointerApi.dart
@@ -80,7 +80,7 @@ class EncointerApi {
     getDemurrage();
     getBootstrappers();
     getReputations();
-    getMeetupOverride();
+    getMeetupTimeOverride();
   }
 
   /// Queries the Scheduler pallet: encointerScheduler.currentPhase().
@@ -257,7 +257,8 @@ class EncointerApi {
     return DateTime.fromMillisecondsSinceEpoch(time);
   }
 
-  Future<void> getMeetupOverride() async {
+  Future<void> getMeetupTimeOverride() async {
+    print("api: Check if there are meetup time overrides");
     CommunityIdentifier cid = store.encointer.chosenCid;
     if (cid == null) {
       return;

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -298,7 +298,7 @@ abstract class _EncointerStore with Store {
       webApi.encointer.getBootstrappers(),
       webApi.encointer.getReputations(),
       webApi.encointer.getMeetupTime(),
-      webApi.encointer.getMeetupOverride(),
+      webApi.encointer.getMeetupTimeOverride(),
       updateAggregatedAccountData(),
     ]).then((_) => _log("[updateState] finished"));
   }

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -317,17 +317,6 @@ abstract class _EncointerStore with Store {
     accountStores.forEach((cid, store) => store.purgeCeremonySpecificState());
   }
 
-  /// Calculates the remaining time until the next meetup starts.
-  Duration getTimeToMeetup() {
-    var start = communityAccount?.meetup?.time;
-    if (start == null) {
-      return null;
-    } else {
-      var now = DateTime.now();
-      return DateTime.fromMillisecondsSinceEpoch(start).difference(now);
-    }
-  }
-
   /// Initialize the store and the sub-stores.
   ///
   /// Should always be called after creating a store to ensure full functionality.

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -231,9 +231,7 @@ abstract class _EncointerStore with Store {
     }
 
     // update depending values without awaiting
-    if (!_rootStore.settings.loading) {
-      webApi.encointer.getCommunityData();
-    }
+    updateState();
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -231,7 +231,9 @@ abstract class _EncointerStore with Store {
     }
 
     // update depending values without awaiting
-    updateState();
+    if (!_rootStore.settings.loading) {
+      webApi.encointer.getCommunityData();
+    }
   }
 
   @action

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -298,6 +298,7 @@ abstract class _EncointerStore with Store {
       webApi.encointer.getBootstrappers(),
       webApi.encointer.getReputations(),
       webApi.encointer.getMeetupTime(),
+      webApi.encointer.getMeetupOverride(),
       updateAggregatedAccountData(),
     ]).then((_) => _log("[updateState] finished"));
   }

--- a/lib/store/encointer/encointer.g.dart
+++ b/lib/store/encointer/encointer.g.dart
@@ -399,6 +399,17 @@ mixin _$EncointerStore on _EncointerStore, Store {
   }
 
   @override
+  void setAggregatedAccountData(CommunityIdentifier cid, String address, AggregatedAccountData accountData) {
+    final _$actionInfo =
+        _$_EncointerStoreActionController.startAction(name: '_EncointerStore.setAggregatedAccountData');
+    try {
+      return super.setAggregatedAccountData(cid, address, accountData);
+    } finally {
+      _$_EncointerStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   void purgeCeremonySpecificState() {
     final _$actionInfo =
         _$_EncointerStoreActionController.startAction(name: '_EncointerStore.purgeCeremonySpecificState');

--- a/lib/store/encointer/sub_stores/community_store/communityStore.dart
+++ b/lib/store/encointer/sub_stores/community_store/communityStore.dart
@@ -61,6 +61,10 @@ abstract class _CommunityStore with Store {
   @observable
   int meetupTime;
 
+  /// Override set by the encointer feed.
+  @observable
+  int meetupTimeOverride;
+
   @observable
   List<String> bootstrappers;
 
@@ -113,6 +117,15 @@ abstract class _CommunityStore with Store {
     _log("set meetupTime to $time");
     if (meetupTime != time) {
       meetupTime = time;
+      writeToCache();
+    }
+  }
+
+  @action
+  void setMeetupTimeOverride([int time]) {
+    _log("set meetupTimeOverride to $time");
+    if (meetupTimeOverride != time) {
+      meetupTimeOverride = time;
       writeToCache();
     }
   }

--- a/lib/store/encointer/sub_stores/community_store/communityStore.g.dart
+++ b/lib/store/encointer/sub_stores/community_store/communityStore.g.dart
@@ -14,6 +14,7 @@ CommunityStore _$CommunityStoreFromJson(Map<String, dynamic> json) {
     ..metadata = json['metadata'] == null ? null : CommunityMetadata.fromJson(json['metadata'] as Map<String, dynamic>)
     ..demurrage = (json['demurrage'] as num)?.toDouble()
     ..meetupTime = json['meetupTime'] as int
+    ..meetupTimeOverride = json['meetupTimeOverride'] as int
     ..bootstrappers = (json['bootstrappers'] as List)?.map((e) => e as String)?.toList()
     ..meetupLocations = json['meetupLocations'] != null
         ? ObservableList<Location>.of((json['meetupLocations'] as List)
@@ -32,6 +33,7 @@ Map<String, dynamic> _$CommunityStoreToJson(CommunityStore instance) => <String,
       'metadata': instance.metadata?.toJson(),
       'demurrage': instance.demurrage,
       'meetupTime': instance.meetupTime,
+      'meetupTimeOverride': instance.meetupTimeOverride,
       'bootstrappers': instance.bootstrappers,
       'meetupLocations': instance.meetupLocations?.map((e) => e?.toJson())?.toList(),
       'communityAccountStores': instance.communityAccountStores?.map((k, e) => MapEntry(k, e?.toJson())),
@@ -101,6 +103,21 @@ mixin _$CommunityStore on _CommunityStore, Store {
   set meetupTime(int value) {
     _$meetupTimeAtom.reportWrite(value, super.meetupTime, () {
       super.meetupTime = value;
+    });
+  }
+
+  final _$meetupTimeOverrideAtom = Atom(name: '_CommunityStore.meetupTimeOverride');
+
+  @override
+  int get meetupTimeOverride {
+    _$meetupTimeOverrideAtom.reportRead();
+    return super.meetupTimeOverride;
+  }
+
+  @override
+  set meetupTimeOverride(int value) {
+    _$meetupTimeOverrideAtom.reportWrite(value, super.meetupTimeOverride, () {
+      super.meetupTimeOverride = value;
     });
   }
 
@@ -203,6 +220,16 @@ mixin _$CommunityStore on _CommunityStore, Store {
   }
 
   @override
+  void setMeetupTimeOverride([int time]) {
+    final _$actionInfo = _$_CommunityStoreActionController.startAction(name: '_CommunityStore.setMeetupTimeOverride');
+    try {
+      return super.setMeetupTimeOverride(time);
+    } finally {
+      _$_CommunityStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   void setMeetupLocations([List<Location> locations]) {
     final _$actionInfo = _$_CommunityStoreActionController.startAction(name: '_CommunityStore.setMeetupLocations');
     try {
@@ -229,6 +256,7 @@ mixin _$CommunityStore on _CommunityStore, Store {
 metadata: ${metadata},
 demurrage: ${demurrage},
 meetupTime: ${meetupTime},
+meetupTimeOverride: ${meetupTimeOverride},
 bootstrappers: ${bootstrappers},
 meetupLocations: ${meetupLocations},
 communityAccountStores: ${communityAccountStores},

--- a/test/models/encointer_feed/meetupOverrides_test.dart
+++ b/test/models/encointer_feed/meetupOverrides_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:encointer_wallet/models/ceremonies/ceremonies.dart';
+import 'package:encointer_wallet/models/encointer_feed/meetupOverrides.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('meetupOverrides', () {
+    test('Parses Response', () async {
+      String response = '''
+      [
+        {
+          "override-name": "Polkadot Decoded Demo 2022",
+          "network": "nctr-gsl",
+          "communities": [
+            "u33e0719fDB",
+            "69y7j4ZEXmy"
+          ],
+          "meetup-times": [
+            "2022-06-29T11:30:00.00+00:00",
+            "2022-06-29T16:30:00.00+00:00",
+            "2022-06-29T21:00:00.00+00:00",
+            "2022-06-30T11:30:00.00+00:00",
+            "2022-06-30T16:30:00.00+00:00",
+            "2022-06-30T20:00:00.00+00:00"
+          ]
+        }
+      ]''';
+
+      List<dynamic> list = jsonDecode(response);
+
+      List<MeetupOverrides> meetupOverrides = list.map((e) => MeetupOverrides.fromJson(e)).toList();
+      var override = meetupOverrides[0];
+
+      expect(override.overrideName, "Polkadot Decoded Demo 2022");
+      expect(override.communities, ["u33e0719fDB", "69y7j4ZEXmy"]);
+      expect(override.meetupTimes[0].isAtSameMomentAs(DateTime.parse("2022-06-29T11:30:00.00+00:00")), true);
+    });
+
+    test('getNextMeetupTimeWorks', () async {
+      // meetup times from decoded demos.
+
+      final beforeAll = DateTime.parse("2022-06-29T11:20:00.00+00:00");
+      final meetup1 = DateTime.parse("2022-06-29T11:30:00.00+00:00");
+      final between1And2 = DateTime.parse("2022-06-29T12:20:00.00+00:00");
+      final meetup2 = DateTime.parse("2022-06-29T16:30:00.00+00:00");
+      final between2And3 = DateTime.parse("2022-06-29T17:20:00.00+00:00");
+      final meetup3 = DateTime.parse("2022-06-29T21:00:00.00+00:00");
+      final between3And4 = DateTime.parse("2022-06-30T10:20:00.00+00:00");
+      final meetup4 = DateTime.parse("2022-06-30T11:30:00.00+00:00");
+      final between4And5 = DateTime.parse("2022-06-30T11:31:00.00+00:00");
+      final meetup5 = DateTime.parse("2022-06-30T16:30:00.00+00:00");
+      final between5And6 = DateTime.parse("2022-06-30T17:10:00.00+00:00");
+      final meetup6 = DateTime.parse("2022-06-30T20:00:00.00+00:00");
+      final afterAll = DateTime.parse("2022-06-31T17:10:00.00+00:00");
+
+      // shuffle to test the internal sorting
+      final testMeetups = [
+        meetup6,
+        meetup1,
+        meetup4,
+        meetup3,
+        meetup2,
+        meetup5,
+      ];
+
+      final meetupOverrides = MeetupOverrides("hello", "world", [], testMeetups);
+
+      // get next meetup time if we are in registering or assigning phase
+      expect(meetupOverrides.getNextMeetupTime(beforeAll, CeremonyPhase.Assigning).isAtSameMomentAs(meetup1), true);
+      expect(
+          meetupOverrides.getNextMeetupTime(between1And2, CeremonyPhase.Registering).isAtSameMomentAs(meetup2), true);
+      expect(meetupOverrides.getNextMeetupTime(between2And3, CeremonyPhase.Assigning).isAtSameMomentAs(meetup3), true);
+      expect(
+          meetupOverrides.getNextMeetupTime(between3And4, CeremonyPhase.Registering).isAtSameMomentAs(meetup4), true);
+      expect(meetupOverrides.getNextMeetupTime(between4And5, CeremonyPhase.Assigning).isAtSameMomentAs(meetup5), true);
+      expect(
+          meetupOverrides.getNextMeetupTime(between5And6, CeremonyPhase.Registering).isAtSameMomentAs(meetup6), true);
+      expect(meetupOverrides.getNextMeetupTime(afterAll, CeremonyPhase.Registering), null);
+
+      // get meetup time of the current meetup if we are in attesting phase
+      expect(meetupOverrides.getNextMeetupTime(beforeAll, CeremonyPhase.Attesting), null);
+      expect(meetupOverrides.getNextMeetupTime(between1And2, CeremonyPhase.Attesting).isAtSameMomentAs(meetup1), true);
+      expect(meetupOverrides.getNextMeetupTime(between2And3, CeremonyPhase.Attesting).isAtSameMomentAs(meetup2), true);
+      expect(meetupOverrides.getNextMeetupTime(between3And4, CeremonyPhase.Attesting).isAtSameMomentAs(meetup3), true);
+      expect(meetupOverrides.getNextMeetupTime(between4And5, CeremonyPhase.Attesting).isAtSameMomentAs(meetup4), true);
+      expect(meetupOverrides.getNextMeetupTime(between5And6, CeremonyPhase.Attesting).isAtSameMomentAs(meetup5), true);
+      expect(meetupOverrides.getNextMeetupTime(afterAll, CeremonyPhase.Attesting).isAtSameMomentAs(meetup6), true);
+    });
+  });
+}

--- a/test/store/encointer/sub_stores/community_store/communityStore_test.dart
+++ b/test/store/encointer/sub_stores/community_store/communityStore_test.dart
@@ -48,6 +48,7 @@ void main() {
         "metadata": testMetadata.toJson(),
         "demurrage": 1.1,
         "meetupTime": 10,
+        "meetupTimeOverride": null,
         "bootstrappers": bootstrappers,
         "meetupLocations": testLocations.map((l) => l.toJson()).toList(),
         'communityAccountStores': Map<String, dynamic>.of({


### PR DESCRIPTION
* Closes #656 

### Other changes:
* Show hours and minutes in `RegisterParticipant` button, before it was only the day. I think this change makes sense outside the demo context too. [image](https://user-images.githubusercontent.com/37865735/175818240-1b053e19-59a7-4815-901e-3bce7a4afa8b.png)



## Tested:
* Shows first date of meetup overrides if Berlin or Buenos Aires test community is chosen.
* Did some tedious manual testing:
   * Created meetup time overrides with two meetups for the `bootstrap_demo_community.py`
   * Tested that demo community follows meetup time overrides, see below.

### CeremonyBox Tests:
These tests were a bit tedious, I basically create some mock data such the `now()` is somewhere in between the meetup constellations, and then I played with the ceremony phases in the blockchain to see that everything works 

Registering:
* Shows first meetup if `now()` is before both meetups, correctly display the countdown in registering phase 👍
* Shows second meetup if `now()` is in between the meetings.👍

Assigning:
* Same 👍

Attesting:
* Shows first meetup if `now()` is in between both meetups 👍
* Shows second meetup if `now()` after the second meetup 👍


