### PR TITLE
Fix Qr-Code scanner freezing upon showing a snackBar

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -32,6 +32,7 @@ import 'package:encointer_wallet/service/notification.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/localStorage.dart';
+import 'package:encointer_wallet/utils/snackBar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -141,6 +142,7 @@ class _WalletAppState extends State<WalletApp> {
           ],
           initialRoute: widget.config.initialRoute,
           theme: _theme,
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
 
           // we use onGenerateRoute with CupertinoPageRoute objects to get specific page transition animations (sliding in from the right if there's a back button, sliding from the bottom up if there's a close button)
           // it is preferable to use Navigator.pushNamed (rather than Navigator.push) for large projects

--- a/lib/page-encointer/meetup/ceremonyStep2Scan2.dart
+++ b/lib/page-encointer/meetup/ceremonyStep2Scan2.dart
@@ -117,7 +117,7 @@ class CeremonyStep2Scan extends StatelessWidget {
                 onPressed: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (BuildContext context) => ScanClaimQrCode(store, confirmedParticipantsCount),
+                      builder: (_) => ScanClaimQrCode(store, confirmedParticipantsCount),
                     ),
                   );
                 },

--- a/lib/page-encointer/meetup/scanClaimQrCode.dart
+++ b/lib/page-encointer/meetup/scanClaimQrCode.dart
@@ -55,6 +55,7 @@ class ScanClaimQrCode extends StatelessWidget {
               .then((c) => ClaimOfAttendance.fromJson(c));
 
           // pops the cupertino activity indicator.
+          // Should be called before showing the `SnackBar` otherwise it has an invalid `BuildContext`
           Navigator.of(context).pop();
 
           if (claim != null) {

--- a/lib/page-encointer/meetup/scanClaimQrCode.dart
+++ b/lib/page-encointer/meetup/scanClaimQrCode.dart
@@ -70,7 +70,6 @@ class ScanClaimQrCode extends StatelessWidget {
       }
 
       _qrViewKey.currentState.startScan();
-
     }
 
     return Scaffold(

--- a/lib/page-encointer/meetup/scanClaimQrCode.dart
+++ b/lib/page-encointer/meetup/scanClaimQrCode.dart
@@ -25,7 +25,7 @@ class ScanClaimQrCode extends StatelessWidget {
     List<String> registry = store.encointer.communityAccount.meetup.registry;
     if (!registry.contains(claim.claimantPublic)) {
       // this is important because the runtime checks if there are too many claims trying to be registered.
-      GlobalSnackBar.show(dic.encointer.meetupClaimantInvalid);
+      RootSnackBar.show(dic.encointer.meetupClaimantInvalid);
       print("[scanClaimQrCode] Claimant: ${claim.claimantPublic} is not part of registry: ${registry.toString()}");
     } else {
       String msg = store.encointer.communityAccount.containsClaim(claim)
@@ -33,7 +33,7 @@ class ScanClaimQrCode extends StatelessWidget {
           : dic.encointer.claimsScannedNew;
 
       store.encointer.communityAccount.addParticipantClaim(claim);
-      GlobalSnackBar.show(msg);
+      RootSnackBar.show(msg);
     }
   }
 
@@ -60,7 +60,7 @@ class ScanClaimQrCode extends StatelessWidget {
           }
         } catch (e) {
           _log("Error decoding claim: ${e.toString()}");
-          GlobalSnackBar.show(dic.encointer.claimsScannedDecodeFailed);
+          RootSnackBar.show(dic.encointer.claimsScannedDecodeFailed);
         }
       }
 

--- a/lib/page-encointer/meetup/scanClaimQrCode.dart
+++ b/lib/page-encointer/meetup/scanClaimQrCode.dart
@@ -45,28 +45,31 @@ class ScanClaimQrCode extends StatelessWidget {
       _showActivityIndicatorOverlay(context);
 
       if (base64Data != null) {
-        var data = base64.decode(base64Data);
-
         try {
+          var data = base64.decode(base64Data);
+
           // Todo: Not good to use the global webApi here, but I wanted to prevent big changes into the code for now.
           // Fix this when #132 is tackled.
           var claim = await webApi.codec
               .decodeBytes(ClaimOfAttendanceJSRegistryName, data)
               .then((c) => ClaimOfAttendance.fromJson(c));
 
+          // pops the cupertino activity indicator.
+          Navigator.of(context).pop();
+
           if (claim != null) {
             validateAndStoreClaim(context, claim, dic);
           }
         } catch (e) {
           _log("Error decoding claim: ${e.toString()}");
+          // pops the cupertino activity indicator.
+          Navigator.of(context).pop();
           _showSnackBar(context, dic.encointer.claimsScannedDecodeFailed);
         }
       }
 
       _qrViewKey.currentState.startScan();
 
-      // just pops the cupertino activity indicator.
-      Navigator.of(context).pop();
     }
 
     return Scaffold(

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -7,6 +7,7 @@ import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/store/encointer/types/communities.dart';
 import 'package:encointer_wallet/utils/UI.dart';
+import 'package:encointer_wallet/utils/snackBar.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
@@ -32,15 +33,6 @@ class _ReceivePageState extends State<ReceivePage> {
 
   PausableTimer paymentWatchdog;
   bool observedPendingExtrinsic = false;
-
-  static void _showSnackBar(BuildContext context, String msg) {
-    ScaffoldMessenger.of(context).removeCurrentSnackBar();
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      backgroundColor: Colors.lightBlue,
-      content: Text(msg, style: TextStyle(color: Colors.black)),
-      duration: Duration(milliseconds: 5000),
-    ));
-  }
 
   @override
   void initState() {
@@ -72,7 +64,7 @@ class _ReceivePageState extends State<ReceivePage> {
           if (((extrinsics?.length ?? 0) > 0) && (!observedPendingExtrinsic)) {
             extrinsics.forEach((xt) {
               if (xt.contains(widget.store.account.currentAccountPubKey.substring(2))) {
-                _showSnackBar(context, dic.profile.observedPendingExtrinsic);
+                RootSnackBar.show(dic.profile.observedPendingExtrinsic);
                 observedPendingExtrinsic = true;
               }
             });

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -64,7 +64,7 @@ class _ReceivePageState extends State<ReceivePage> {
           if (((extrinsics?.length ?? 0) > 0) && (!observedPendingExtrinsic)) {
             extrinsics.forEach((xt) {
               if (xt.contains(widget.store.account.currentAccountPubKey.substring(2))) {
-                RootSnackBar.show(dic.profile.observedPendingExtrinsic);
+                RootSnackBar.show(dic.profile.observedPendingExtrinsic, durationMillis: 5000);
                 observedPendingExtrinsic = true;
               }
             });

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -68,7 +68,7 @@ class _ReceivePageState extends State<ReceivePage> {
                   dic.profile.observedPendingExtrinsic,
                   durationMillis: 5000,
                   textColor: Colors.black,
-                  backgroundColor: Colors.blue,
+                  backgroundColor: Colors.lightBlue,
                 );
                 observedPendingExtrinsic = true;
               }

--- a/lib/page/assets/receive/receivePage.dart
+++ b/lib/page/assets/receive/receivePage.dart
@@ -64,7 +64,12 @@ class _ReceivePageState extends State<ReceivePage> {
           if (((extrinsics?.length ?? 0) > 0) && (!observedPendingExtrinsic)) {
             extrinsics.forEach((xt) {
               if (xt.contains(widget.store.account.currentAccountPubKey.substring(2))) {
-                RootSnackBar.show(dic.profile.observedPendingExtrinsic, durationMillis: 5000);
+                RootSnackBar.show(
+                  dic.profile.observedPendingExtrinsic,
+                  durationMillis: 5000,
+                  textColor: Colors.black,
+                  backgroundColor: Colors.blue,
+                );
                 observedPendingExtrinsic = true;
               }
             });

--- a/lib/page/qr_scan/qrScanPage.dart
+++ b/lib/page/qr_scan/qrScanPage.dart
@@ -1,4 +1,5 @@
 import 'package:encointer_wallet/store/app.dart';
+import 'package:encointer_wallet/utils/snackBar.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
 import 'package:flutter/cupertino.dart';
@@ -6,11 +7,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_qr_scan/qrcode_reader_view.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-import 'qr_codes/qrCodeBase.dart';
 import 'qrScanService.dart';
+import 'qr_codes/qrCodeBase.dart';
 
-export 'qr_codes/qrCodeBase.dart';
 export 'qrScanService.dart';
+export 'qr_codes/qrCodeBase.dart';
 
 class ScanPageParams {
   ScanPageParams({this.scannerContext});
@@ -31,15 +32,6 @@ class ScanPage extends StatelessWidget {
     return Permission.camera.request().isGranted;
   }
 
-  void _showSnackBar(BuildContext context, String msg) {
-    ScaffoldMessenger.of(context).removeCurrentSnackBar();
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      backgroundColor: Colors.white,
-      content: Text(msg, style: TextStyle(color: Colors.black54)),
-      duration: Duration(milliseconds: 2000),
-    ));
-  }
-
   @override
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context).translationsForLocale();
@@ -50,7 +42,7 @@ class ScanPage extends StatelessWidget {
         qrScanService.handleQrScan(context, params.scannerContext, qrCode);
       } catch (e) {
         print("[ScanPage]: ${e.toString()}");
-        _showSnackBar(context, e.toString());
+        RootSnackBar.show(e.toString());
 
         // If we don't wait, scans  of the same qr code are spammed.
         // My fairly recent cellphone gets too much load for duration < 500 ms. We might need to increase

--- a/lib/utils/UI.dart
+++ b/lib/utils/UI.dart
@@ -260,38 +260,3 @@ class UI {
     return RegExInputFormatter.withRegex('^[0-9]{0,$decimals}(\\.[0-9]{0,$decimals})?\$');
   }
 }
-
-// access the refreshIndicator globally
-// assets index page:
-final GlobalKey<RefreshIndicatorState> globalBalanceRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// asset page:
-final GlobalKey<RefreshIndicatorState> globalAssetRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// staking bond page:
-final GlobalKey<RefreshIndicatorState> globalBondingRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// staking nominate page:
-final GlobalKey<RefreshIndicatorState> globalNominatingRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// council & motions page:
-final GlobalKey<RefreshIndicatorState> globalCouncilRefreshKey = new GlobalKey<RefreshIndicatorState>();
-final GlobalKey<RefreshIndicatorState> globalMotionsRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// democracy page:
-final GlobalKey<RefreshIndicatorState> globalDemocracyRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// treasury proposals&tips page:
-final GlobalKey<RefreshIndicatorState> globalProposalsRefreshKey = new GlobalKey<RefreshIndicatorState>();
-final GlobalKey<RefreshIndicatorState> globalTipsRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// recovery settings page:
-final GlobalKey<RefreshIndicatorState> globalRecoverySettingsRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// recovery state page:
-final GlobalKey<RefreshIndicatorState> globalRecoveryStateRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// recovery vouch page:
-final GlobalKey<RefreshIndicatorState> globalRecoveryProofRefreshKey = new GlobalKey<RefreshIndicatorState>();
-
-// acala loan page:
-final GlobalKey<RefreshIndicatorState> globalLoanRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// acala dexLiquidity page:
-final GlobalKey<RefreshIndicatorState> globalDexLiquidityRefreshKey = new GlobalKey<RefreshIndicatorState>();
-// acala homa page:
-final GlobalKey<RefreshIndicatorState> globalHomaRefreshKey = new GlobalKey<RefreshIndicatorState>();
-
-// encointerCeremoniesPage
-final GlobalKey<RefreshIndicatorState> globalCeremonyPhaseChangeKey = new GlobalKey<RefreshIndicatorState>();
-final GlobalKey<RefreshIndicatorState> globalCeremonyRegistrationRefreshKey = new GlobalKey<RefreshIndicatorState>();

--- a/lib/utils/snackBar.dart
+++ b/lib/utils/snackBar.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey = new GlobalKey<ScaffoldMessengerState>();
 
-class GlobalSnackBar {
+class RootSnackBar {
 
   static void hideCurrent() {
     rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();

--- a/lib/utils/snackBar.dart
+++ b/lib/utils/snackBar.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey = new GlobalKey<ScaffoldMessengerState>();
+
+class GlobalSnackBar {
+
+  static void hideCurrent() {
+    rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
+  }
+
+  static void removeCurrent() {
+    rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
+  }
+
+  static void show(String msg) {
+    showSnackBar(msg);
+  }
+}
+
+void showSnackBar(String msg) {
+  rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
+  rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
+  rootScaffoldMessengerKey.currentState
+    ..showSnackBar(
+      SnackBar(
+        backgroundColor: Colors.white,
+        content: Text(msg, style: TextStyle(color: Colors.black54)),
+        duration: Duration(milliseconds: 1500),
+      ),
+    );
+}

--- a/lib/utils/snackBar.dart
+++ b/lib/utils/snackBar.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey = new GlobalKey<ScaffoldMessengerState>();
 
 class RootSnackBar {
-
   static void hideCurrent() {
     rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
   }

--- a/lib/utils/snackBar.dart
+++ b/lib/utils/snackBar.dart
@@ -11,12 +11,12 @@ class RootSnackBar {
     rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
   }
 
-  static void show(String msg) {
-    showSnackBar(msg);
+  static void show(String msg, {int durationMillis: 1500}) {
+    showSnackBar(msg, durationMillis: durationMillis);
   }
 }
 
-void showSnackBar(String msg) {
+void showSnackBar(String msg, {int durationMillis: 1500}) {
   rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
   rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
   rootScaffoldMessengerKey.currentState

--- a/lib/utils/snackBar.dart
+++ b/lib/utils/snackBar.dart
@@ -11,20 +11,35 @@ class RootSnackBar {
     rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
   }
 
-  static void show(String msg, {int durationMillis: 1500}) {
-    showSnackBar(msg, durationMillis: durationMillis);
+  static void show(
+    String msg, {
+    int durationMillis: 1500,
+    textColor: Colors.black54,
+    backgroundColor: Colors.white,
+  }) {
+    showSnackBar(
+      msg,
+      durationMillis: durationMillis,
+      textColor: textColor,
+      backgroundColor: backgroundColor,
+    );
   }
 }
 
-void showSnackBar(String msg, {int durationMillis: 1500}) {
+void showSnackBar(
+  String msg, {
+  int durationMillis: 1500,
+  textColor: Colors.black54,
+  backgroundColor: Colors.white,
+}) {
   rootScaffoldMessengerKey.currentState.hideCurrentSnackBar();
   rootScaffoldMessengerKey.currentState.removeCurrentSnackBar();
   rootScaffoldMessengerKey.currentState
     ..showSnackBar(
       SnackBar(
-        backgroundColor: Colors.white,
-        content: Text(msg, style: TextStyle(color: Colors.black54)),
-        duration: Duration(milliseconds: 1500),
+        content: Text(msg, style: TextStyle(color: textColor)),
+        backgroundColor: backgroundColor,
+        duration: Duration(milliseconds: durationMillis),
       ),
     );
 }


### PR DESCRIPTION
* Closes #664

I still lack the understanding why this suddenly became a problem, but I fixed it such that it should never occur again.

### Changes:
Instead of looking up the `ScaffoldMessenger` of in the `Scaffold` of a parent of the `context` we refer to the global instance of the `ScaffoldMessengerState` and use it in the newly introduced `RootSnackBar`. The documentation about this approach says:

* Global keys are, in general, more expensive than looking for the suitable instance in the widget's parent-tree.
* It is useful if one does navigate away from the current route while the snackbar is being displayed, therefore potentially removing the `Scaffold` from the widget tree, which will result in a failure of removing the snackbar after the timeout.

As we observed the latter before, I deemed this the suitable approach, and it also resolved the issue of the freezing QR-code.

### Tested
* scanClaimQrCode: Succesfully shows snackbar in success and also when the scan failed
* normal scanQrCode: Successfully shows snackbar in error case
* receivePage: successfully show qr code upon pending extrinsic observed