### PR TITLE
[jsApi] better await webView initialisation

### DIFF
--- a/lib/service/substrate_api/core/jsApi.dart
+++ b/lib/service/substrate_api/core/jsApi.dart
@@ -22,6 +22,8 @@ class JSApi {
       closeWebView();
     }
 
+    bool webViewReady = false;
+
     _web = HeadlessInAppWebView(
       initialData: InAppWebViewInitialData(data: jSSourceHtmlContainer(jsServiceEncointer)),
       onConsoleMessage: (controller, message) => print("JS-Console: ${message.message}"),
@@ -51,10 +53,16 @@ class JSApi {
       },
       onLoadStop: (controller, _) async {
         await webViewPostInitCallback();
+        webViewReady = true;
       },
     );
 
     await _web!.run();
+
+    while (!webViewReady) {
+      _log("waiting until webView ready");
+      await Future.delayed(Duration(seconds: 2));
+    }
   }
 
   /// Evaluate javascript [code] in the webView.
@@ -148,4 +156,8 @@ String jSSourceHtmlContainer(String jSSource) {
     </body>
   </html>
   """;
+}
+
+void _log(String msg) {
+  print("[jsApi] $msg");
 }


### PR DESCRIPTION
This change will make the app startup a bit slower as we wait until the webView is properly initialized, but we will no longer call into js-before it is ready.