### PR TITLE
improve readability and narrow frame for qr code scanner

### DIFF
--- a/lib/page-encointer/meetup/scanClaimQrCode.dart
+++ b/lib/page-encointer/meetup/scanClaimQrCode.dart
@@ -94,8 +94,8 @@ class ScanClaimQrCode extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Container(
-                        width: MediaQuery.of(context).size.width * 0.9,
-                        height: MediaQuery.of(context).size.width * 0.9,
+                        width: MediaQuery.of(context).size.width * 0.7,
+                        height: MediaQuery.of(context).size.width * 0.7,
                         decoration: BoxDecoration(
                           color: Colors.transparent,
                           border: Border.all(color: Colors.white38, width: 2.0),
@@ -110,7 +110,8 @@ class ScanClaimQrCode extends StatelessWidget {
                               'TOTAL_COUNT',
                               (confirmedParticipantsCount - 1).toString(),
                             );
-                        return Text(txt, style: TextStyle(color: Colors.white38));
+                        return Text(txt,
+                            style: TextStyle(color: Colors.white, backgroundColor: Colors.black38, fontSize: 16));
                       }),
                     ],
                   ),

--- a/lib/page/qr_scan/qrScanPage.dart
+++ b/lib/page/qr_scan/qrScanPage.dart
@@ -80,8 +80,8 @@ class ScanPage extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Container(
-                        width: MediaQuery.of(context).size.width * 0.9,
-                        height: MediaQuery.of(context).size.width * 0.9,
+                        width: MediaQuery.of(context).size.width * 0.7,
+                        height: MediaQuery.of(context).size.width * 0.7,
                         decoration: BoxDecoration(
                           color: Colors.transparent,
                           border: Border.all(color: Colors.white38, width: 2.0),
@@ -90,7 +90,7 @@ class ScanPage extends StatelessWidget {
                       ),
                       Text(
                         I18n.of(context)!.translationsForLocale().account.qrScan,
-                        style: TextStyle(color: Colors.white38),
+                        style: TextStyle(color: Colors.white, backgroundColor: Colors.black38, fontSize: 16),
                       ),
                     ],
                   ),


### PR DESCRIPTION
depending on camera-observed background I found it hard to read the text in the QR scanner page. this makes it more readable. 
Also scanning performance showed to be better if the QR code doesn't fill the screen, so I narrowed the guiding frame. this also makes it more obvious for users that the scanner is different (better) now ;-)