### PR TITLE
deleted unused package charts_flutter

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,20 +148,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
-  charts_common:
-    dependency: transitive
-    description:
-      name: charts_common
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0"
-  charts_flutter:
-    dependency: "direct main"
-    description:
-      name: charts_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0"
   checked_yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,6 @@ dependencies:
   flutter_svg: ^1.1.1+1
   url_launcher: ^6.1.5
   dropdown_search: ^5.0.2
-  charts_flutter: ^0.12.0
   material_floating_search_bar: ^0.3.7
   provider: ^6.0.3
   flutter_map_marker_popup: ^3.1.0+1


### PR DESCRIPTION
Deleted unused package [charts_flutter](https://pub.dev/packages/charts_flutter).
This package is very old and `DISCONTINUED`.