### PR TITLE
[GA] update ios runtimes for ipad simulator creation

### DIFF
--- a/.github/workflows/ios_integration_test.yaml
+++ b/.github/workflows/ios_integration_test.yaml
@@ -56,11 +56,11 @@ jobs:
 
       - name: "Create Simulator if iPad Pro 2nd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-15-2"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
 
       - name: "Create Simulator if iPad Pro 3rd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-15-2"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
 
       - name: "Start Simulator"
         working-directory: ./scripts


### PR DESCRIPTION
You can see the available runtimes with this command: https://github.com/encointer/encointer-wallet-flutter/blob/bd260ad6db6206793dc3adc1b697aecc2e68aebc/scripts/ios_init_env.sh#L10

We print the available runtimes in the CI in the prepare environment for IOS stage.