### PR TITLE
bump flutter to v3.3.5

### DIFF
--- a/.github/action-config.json
+++ b/.github/action-config.json
@@ -1,5 +1,5 @@
 {
-  "flutter-version": "3.3.4",
+  "flutter-version": "3.3.5",
   "flutter-channel": "stable",
   "java-version": "12.x",
   "node-version": "14.17.1",

--- a/scripts/install_flutter.sh
+++ b/scripts/install_flutter.sh
@@ -12,7 +12,7 @@ cd flutter
 # `precache` ensures that the correct Dart SDK and binaries for IOS and android exist.
 #
 # Version should match the version from the CI.
-git checkout 3.3.4 && flutter precache
+git checkout 3.3.5 && flutter precache
 
 flutter doctor
 


### PR DESCRIPTION
bump flutter to v3.3.5
Just change [.github/action-config.json](https://github.com/encointer/encointer-wallet-flutter/compare/bump-flutter-to-v3.3.5?expand=1#diff-15dfed428ba169dae5cff4d0596f570781351221c4eac61dea0f5343f77eaf69) and [scripts/install_flutter.sh](https://github.com/encointer/encointer-wallet-flutter/compare/bump-flutter-to-v3.3.5?expand=1#diff-50f077c0b529b9684d950c9fbfb0e88edc31152d07d8dbf57b0a29d0caf888e3)