### PR TITLE
upgraded flutter in app web view package version

### DIFF
--- a/lib/service/substrate_api/core/js_api.dart
+++ b/lib/service/substrate_api/core/js_api.dart
@@ -119,8 +119,8 @@ class JSApi {
         })''';
 
     try {
-    // ignore: unused_local_variable
-    final v = await _web!.webViewController.evaluateJavascript(source: script);
+      // ignore: unused_local_variable
+      final v = await _web!.webViewController.evaluateJavascript(source: script);
     } catch (e, s) {
       // Executing a background task with the workmanager when the app is in
       // foreground kills the platform channel and we get a `MissingPluginException`

--- a/lib/service/substrate_api/core/js_api.dart
+++ b/lib/service/substrate_api/core/js_api.dart
@@ -119,8 +119,8 @@ class JSApi {
         })''';
 
     try {
-      // ignore: unused_local_variable
-      final v = await _web!.webViewController.evaluateJavascript(source: script);
+    // ignore: unused_local_variable
+    final v = await _web!.webViewController.evaluateJavascript(source: script);
     } catch (e, s) {
       // Executing a background task with the workmanager when the app is in
       // foreground kills the platform channel and we get a `MissingPluginException`

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.4"
+    version: "7.2.6"
   built_collection:
     dependency: transitive
     description:
@@ -346,7 +346,7 @@ packages:
       name: flutter_inappwebview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.4+3"
+    version: "5.7.1"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -407,7 +407,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -464,7 +464,7 @@ packages:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   hex:
     dependency: transitive
     description:
@@ -478,7 +478,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: "direct main"
     description:
@@ -597,21 +597,21 @@ packages:
       name: json_serializable_mobx
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.2"
+    version: "0.10.3"
   json_serializable_mobx_typehelpers:
     dependency: transitive
     description:
       name: json_serializable_mobx_typehelpers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   json_serializable_type_helper_utils:
     dependency: transitive
     description:
       name: json_serializable_type_helper_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.1"
+    version: "5.1.2"
   latlong2:
     dependency: transitive
     description:
@@ -625,7 +625,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   lists:
     dependency: transitive
     description:
@@ -863,7 +863,7 @@ packages:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.0"
   permission_handler_android:
     dependency: transitive
     description:
@@ -898,7 +898,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   photo_view:
     dependency: "direct main"
     description:
@@ -1082,7 +1082,7 @@ packages:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   share_plus_web:
     dependency: transitive
     description:
@@ -1213,14 +1213,14 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
@@ -1332,7 +1332,7 @@ packages:
       name: upgrader
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1500,7 +1500,7 @@ packages:
       name: workmanager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   shared_preferences: ^2.0.4
   get_storage: ^2.0.3
   http: ^0.13.1
-  flutter_inappwebview: 5.4.4+3
+  flutter_inappwebview: ^5.7.1
   rxdart: ^0.27.5
   flutter_local_notifications: ^9.7.0
   flutter:


### PR DESCRIPTION
I can say that the [flutter_inappwebview](https://pub.dev/packages/flutter_inappwebview) package got better after upgrading its version, but I realized that our error 
```
E/flutter (17528): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: MissingPluginException(No implementation found for method evaluateJavascript on channel com.pichillilorenzo/flutter_inappwebview_1214122967374174233124163190134233129107185174)
E/flutter (17528): #0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:294:7)
E/flutter (17528): <asynchronous suspension>
E/flutter (17528): #1      InAppWebViewController.evaluateJavascript (package:flutter_inappwebview/src/in_app_webview/in_app_webview_controller.dart:1420:16)
E/flutter (17528): <asynchronous suspension>
E/flutter (17528): 
```
 was not completely fixed.
```dart
    try {
      // ignore: unused_local_variable
      final v = await _web!.webViewController.evaluateJavascript(source: script);
    } catch (e, s) {
      // Executing a background task with the workmanager when the app is in
      // foreground kills the platform channel and we get a `MissingPluginException`
      // error. Hence, we must recreate the platform channel.
      //
      // See: https://github.com/encointer/encointer-wallet-flutter/issues/801.

      Log.e(' $e', 'js_api', s);
      Log.d('Re-initializing webView because the platform channel broke down', 'js_api');
      await webApi.init().timeout(
            const Duration(seconds: 20),
            onTimeout: () => Log.d('webApi.init() has run into a timeout. We might be offline.'),
          );

      final v = await _web!.webViewController.evaluateJavascript(source: script);
      Log.d('EvaluateJavascript result after re-init of webView: $v', 'js_api');
    }
 ```
 
 So I did not change the codes.