### PR TITLE
Fix use the app config 02

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
 
 import 'package:encointer_wallet/common/theme.dart';
-import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/router/app_router.dart';
+import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 
 class WalletApp extends StatefulWidget {
-  const WalletApp(this.config, {Key? key}) : super(key: key);
-
-  final Config config;
+  const WalletApp({Key? key}) : super(key: key);
 
   @override
   State<WalletApp> createState() => _WalletAppState();
@@ -42,7 +41,7 @@ class _WalletAppState extends State<WalletApp> {
           const Locale('en', ''),
           const Locale('de', ''),
         ],
-        initialRoute: widget.config.initialRoute,
+        initialRoute: context.watch<AppStore>().config.initialRoute,
         theme: appThemeEncointer,
         scaffoldMessengerKey: rootScaffoldMessengerKey,
         onGenerateRoute: AppRoute.onGenerateRoute,

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,24 +1,36 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'package:encointer_wallet/modules/modules.dart';
-import 'package:encointer_wallet/store/app.dart';
 
 part 'config.g.dart';
 
 @JsonSerializable()
-class Config {
-  const Config({
+class AppConfig {
+  const AppConfig({
     this.initialRoute = SplashView.route,
-    this.mockLocalStorage = false,
     this.mockSubstrateApi = false,
-    this.appStoreConfig = StoreConfig.Normal,
+    this.isTest = false,
   });
 
   final String initialRoute;
-  final bool mockLocalStorage;
   final bool mockSubstrateApi;
-  final StoreConfig appStoreConfig;
+  final bool isTest;
 
-  factory Config.fromJson(Map<String, dynamic> json) => _$ConfigFromJson(json);
-  Map<String, dynamic> toJson() => _$ConfigToJson(this);
+  factory AppConfig.fromJson(Map<String, dynamic> json) => _$AppConfigFromJson(json);
+  Map<String, dynamic> toJson() => _$AppConfigToJson(this);
 }
+
+// enum StoreConfig {
+//   Normal,
+//   Test,
+// }
+
+// extension StoreConfigExtensions on StoreConfig {
+//   bool isTest() {
+//     return this == StoreConfig.Test;
+//   }
+
+//   bool isNormal() {
+//     return this == StoreConfig.Normal;
+//   }
+// }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -19,18 +19,3 @@ class AppConfig {
   factory AppConfig.fromJson(Map<String, dynamic> json) => _$AppConfigFromJson(json);
   Map<String, dynamic> toJson() => _$AppConfigToJson(this);
 }
-
-// enum StoreConfig {
-//   Normal,
-//   Test,
-// }
-
-// extension StoreConfigExtensions on StoreConfig {
-//   bool isTest() {
-//     return this == StoreConfig.Test;
-//   }
-
-//   bool isNormal() {
-//     return this == StoreConfig.Normal;
-//   }
-// }

--- a/lib/config.g.dart
+++ b/lib/config.g.dart
@@ -6,21 +6,14 @@ part of 'config.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-Config _$ConfigFromJson(Map<String, dynamic> json) => Config(
+AppConfig _$AppConfigFromJson(Map<String, dynamic> json) => AppConfig(
       initialRoute: json['initialRoute'] as String? ?? SplashView.route,
-      mockLocalStorage: json['mockLocalStorage'] as bool? ?? false,
       mockSubstrateApi: json['mockSubstrateApi'] as bool? ?? false,
-      appStoreConfig: $enumDecodeNullable(_$StoreConfigEnumMap, json['appStoreConfig']) ?? StoreConfig.Normal,
+      isTest: json['isTest'] as bool? ?? false,
     );
 
-Map<String, dynamic> _$ConfigToJson(Config instance) => <String, dynamic>{
+Map<String, dynamic> _$AppConfigToJson(AppConfig instance) => <String, dynamic>{
       'initialRoute': instance.initialRoute,
-      'mockLocalStorage': instance.mockLocalStorage,
       'mockSubstrateApi': instance.mockSubstrateApi,
-      'appStoreConfig': _$StoreConfigEnumMap[instance.appStoreConfig]!,
+      'isTest': instance.isTest,
     };
-
-const _$StoreConfigEnumMap = {
-  StoreConfig.Normal: 'Normal',
-  StoreConfig.Test: 'Test',
-};

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,8 +52,8 @@ Future<void> main() async {
   runApp(
     Provider(
       // On test mode instead of LocalStorage() must be use MockLocalStorage()
-      create: (context) => AppStore(util.LocalStorage()),
-      child: const WalletApp(Config()),
+      create: (context) => AppStore(util.LocalStorage(), config: const AppConfig()),
+      child: const WalletApp(),
     ),
   );
 }

--- a/lib/modules/splash/view/splash_view.dart
+++ b/lib/modules/splash/view/splash_view.dart
@@ -35,7 +35,7 @@ class _SplashViewState extends State<SplashView> {
     await initWebApi(context, store);
 
     // We don't poll updates in tests because we mock the backend anyhow.
-    if (store.config.isNormal()) {
+    if (store.config.mockSubstrateApi) {
       // must be set after api is initialized.
       store.dataUpdate.setupUpdateReaction(() async {
         await store.encointer.updateState();
@@ -90,7 +90,7 @@ Future<void> initWebApi(BuildContext context, AppStore store) async {
   final js = await DefaultAssetBundle.of(context).loadString('lib/js_service_encointer/dist/main.js');
 
   // Todo: don't use the `StoreConfig` here: #783.
-  webApi = store.config.isNormal()
+  webApi = store.config.mockSubstrateApi
       ? Api.create(store, JSApi(), SubstrateDartApi(), js)
       : MockApi(store, MockJSApi(), MockSubstrateDartApi(), js, withUi: true);
 

--- a/lib/modules/splash/view/splash_view.dart
+++ b/lib/modules/splash/view/splash_view.dart
@@ -89,7 +89,7 @@ class _SplashViewState extends State<SplashView> {
 Future<void> initWebApi(BuildContext context, AppStore store) async {
   final js = await DefaultAssetBundle.of(context).loadString('lib/js_service_encointer/dist/main.js');
 
-  webApi = !store.config.isTest
+  webApi = !store.config.mockSubstrateApi
       ? Api.create(store, JSApi(), SubstrateDartApi(), js)
       : MockApi(store, MockJSApi(), MockSubstrateDartApi(), js, withUi: true);
 

--- a/lib/modules/splash/view/splash_view.dart
+++ b/lib/modules/splash/view/splash_view.dart
@@ -35,7 +35,7 @@ class _SplashViewState extends State<SplashView> {
     await initWebApi(context, store);
 
     // We don't poll updates in tests because we mock the backend anyhow.
-    if (store.config.mockSubstrateApi) {
+    if (!store.config.isTest) {
       // must be set after api is initialized.
       store.dataUpdate.setupUpdateReaction(() async {
         await store.encointer.updateState();
@@ -89,8 +89,7 @@ class _SplashViewState extends State<SplashView> {
 Future<void> initWebApi(BuildContext context, AppStore store) async {
   final js = await DefaultAssetBundle.of(context).loadString('lib/js_service_encointer/dist/main.js');
 
-  // Todo: don't use the `StoreConfig` here: #783.
-  webApi = store.config.mockSubstrateApi
+  webApi = !store.config.isTest
       ? Api.create(store, JSApi(), SubstrateDartApi(), js)
       : MockApi(store, MockJSApi(), MockSubstrateDartApi(), js, withUi: true);
 

--- a/lib/store/app.dart
+++ b/lib/store/app.dart
@@ -1,3 +1,7 @@
+import 'package:mobx/mobx.dart';
+import 'package:upgrader/upgrader.dart';
+
+import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/account/account.dart';
@@ -7,8 +11,6 @@ import 'package:encointer_wallet/store/data_update/data_update.dart';
 import 'package:encointer_wallet/store/encointer/encointer.dart';
 import 'package:encointer_wallet/store/settings.dart';
 import 'package:encointer_wallet/utils/local_storage.dart';
-import 'package:mobx/mobx.dart';
-import 'package:upgrader/upgrader.dart';
 
 part 'app.g.dart';
 
@@ -31,24 +33,19 @@ const encointerCacheVersion = 'v1.0';
 class AppStore extends _AppStore with _$AppStore {
   AppStore(
     LocalStorage localStorage, {
-    StoreConfig config = StoreConfig.Normal,
+    required AppConfig config,
     AppcastConfiguration? appcastConfiguration,
   }) : super(localStorage, config: config, appcastConfiguration: appcastConfiguration);
-}
-
-enum StoreConfig {
-  Normal,
-  Test,
 }
 
 abstract class _AppStore with Store {
   _AppStore(
     this.localStorage, {
-    this.config = StoreConfig.Normal,
+    required this.config,
     this.appcastConfiguration,
   });
 
-  final StoreConfig config;
+  final AppConfig config;
   final AppcastConfiguration? appcastConfiguration;
 
   // Note, following pattern of a nullable field with a non-nullable getter
@@ -143,7 +140,7 @@ abstract class _AppStore with Store {
   /// the real cache with (unit-)test runs.
   String getCacheKey(String key) {
     var cacheKey = '${settings.endpoint.info}_$key';
-    return config == StoreConfig.Test ? 'test-$cacheKey' : cacheKey;
+    return config.isTest ? 'test-$cacheKey' : cacheKey;
   }
 
   /// Returns the cache key for the encointer-storage.
@@ -152,7 +149,7 @@ abstract class _AppStore with Store {
   /// the real cache with (unit-)test runs.
   String encointerCacheKey(String networkInfo) {
     var key = '$encointerCachePrefix-$networkInfo';
-    return config == StoreConfig.Test ? 'test-$key' : key;
+    return config.isTest ? 'test-$key' : key;
   }
 
   Future<bool> purgeEncointerCache(String networkInfo) async {
@@ -258,15 +255,5 @@ abstract class _AppStore with Store {
   /// E.g. not awaiting this call was the cause of #357.
   Future<List<void>> loadAccountCache() async {
     return Future.wait([assets.clearTxs(), assets.loadAccountCache()]);
-  }
-}
-
-extension StoreConfigExtensions on StoreConfig {
-  bool isTest() {
-    return this == StoreConfig.Test;
-  }
-
-  bool isNormal() {
-    return this == StoreConfig.Normal;
   }
 }

--- a/test/store/account_test.dart
+++ b/test/store/account_test.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:encointer_wallet/mocks/data/mock_account_data.dart';
@@ -8,7 +9,10 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AccountStore test', () {
-    final AppStore root = AppStore(MockLocalStorage());
+    final AppStore root = AppStore(
+      MockLocalStorage(),
+      config: const AppConfig(isTest: true, mockSubstrateApi: true),
+    );
 
     test('account store test', () async {
       accList = [testAcc];

--- a/test/store/app_test.dart
+++ b/test/store/app_test.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:encointer_wallet/mocks/data/mock_account_data.dart';
@@ -6,7 +7,10 @@ import 'package:encointer_wallet/store/app.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final AppStore store = AppStore(MockLocalStorage(), config: StoreConfig.Test);
+  final AppStore store = AppStore(
+    MockLocalStorage(),
+    config: const AppConfig(isTest: true, mockSubstrateApi: true),
+  );
   accList = [testAcc];
   currentAccountPubKey = accList[0]['pubKey'];
 

--- a/test/store/encointer/encointer_test.dart
+++ b/test/store/encointer/encointer_test.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/mocks/data/mock_account_data.dart';
 import 'package:encointer_wallet/mocks/data/mock_encointer_data.dart';
 import 'package:encointer_wallet/mocks/storage/mock_local_storage.dart';
@@ -12,7 +13,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final AppStore root = AppStore(MockLocalStorage(), config: StoreConfig.Test);
+  final AppStore root = AppStore(
+    MockLocalStorage(),
+    config: const AppConfig(isTest: true, mockSubstrateApi: true),
+  );
 
   group('EncointerStore test', () {
     test('encointer store initialization, serialization and cache works', () async {

--- a/test/store/encointer/sub_stores/community_store/community_store_test.dart
+++ b/test/store/encointer/sub_stores/community_store/community_store_test.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:encointer_wallet/mocks/data/mock_encointer_data.dart';
@@ -16,7 +17,10 @@ void main() {
       var communityStoreCacheKey = 'communityStore-test-cache';
 
       // Only to not get null errors in tests
-      webApi = getMockApi(AppStore(MockLocalStorage()), withUI: false);
+      webApi = getMockApi(
+        AppStore(MockLocalStorage(), config: const AppConfig()),
+        withUI: false,
+      );
       webApi.init();
 
       var communityStore = CommunityStore(

--- a/test/store/settings_test.dart
+++ b/test/store/settings_test.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:encointer_wallet/config/consts.dart';
@@ -9,7 +10,10 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('SettingsStore test', () {
-    final AppStore root = AppStore(MockLocalStorage());
+    final AppStore root = AppStore(
+      MockLocalStorage(),
+      config: const AppConfig(isTest: true, mockSubstrateApi: true),
+    );
     final store = SettingsStore(root);
 
     test('settings store created', () {

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -1,22 +1,23 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:provider/provider.dart';
+import 'package:upgrader/upgrader.dart';
+
 import 'package:encointer_wallet/app.dart';
 import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/mocks/storage/mock_local_storage.dart';
 import 'package:encointer_wallet/mocks/storage/mock_storage_setup.dart';
 import 'package:encointer_wallet/mocks/storage/prepare_mock_storage.dart';
 import 'package:encointer_wallet/store/app.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_driver/driver_extension.dart';
-import 'package:provider/provider.dart';
-import 'package:upgrader/upgrader.dart';
 
 void main() async {
   final _appcastURL = 'https://encointer.github.io/feed/app_cast/testappcast.xml';
   final _cfg = AppcastConfiguration(url: _appcastURL, supportedOS: ['android']);
   final _globalAppStore = AppStore(
     MockLocalStorage(),
-    config: StoreConfig.Test,
+    config: const AppConfig(isTest: true, mockSubstrateApi: true),
     appcastConfiguration: _cfg,
   );
 
@@ -59,9 +60,7 @@ void main() async {
   runApp(
     Provider(
       create: (context) => _globalAppStore,
-      child: const WalletApp(
-        Config(mockLocalStorage: true, mockSubstrateApi: true, appStoreConfig: StoreConfig.Test),
-      ),
+      child: const WalletApp(),
     ),
   );
 }


### PR DESCRIPTION
I tried to fix #783  and #830 it as I understand it.

- [x] Rename `Config` to `AppConfig`.
- [x] Add it as a field to the `AppStore` 
- [x] Use the `AppConfig` in the splash view to properly initialize it.
- [x] remove `mockLocalStorage`.
---------------------------------------------------------------------
1. Deleted StoreConfigExtensions.
2. Deleted constructor field `Config` from `WalletApp`. Use  `store.config`.