### PR TITLE
Update translations for meetups and ceremonies

### DIFF
--- a/lib/page-encointer/ceremony_box/ceremony_box_service.dart
+++ b/lib/page-encointer/ceremony_box/ceremony_box_service.dart
@@ -35,7 +35,7 @@ class CeremonyBoxService {
 
   static Event createCalendarEvent(DateTime nextCeremonyDate, Translations dic) {
     return Event(
-      title: dic.encointer.encointerCeremony,
+      title: dic.encointer.keySigningCycle,
       description: dic.encointer.calendarEntryDescription,
       location: 'yet unknown',
       startDate: DateTime.now(),

--- a/lib/page-encointer/ceremony_box/ceremony_info.dart
+++ b/lib/page-encointer/ceremony_box/ceremony_info.dart
@@ -55,7 +55,7 @@ class CeremonyInfo extends StatelessWidget {
                             languageCode: languageCode,
                           )
                         : Text(
-                            dic.encointer.ceremonySuccessfullyCompleted,
+                            dic.encointer.gatheringSuccessfullyCompleted,
                             style: Theme.of(context).textTheme.headline4!.copyWith(color: encointerBlack),
                           ),
                     CeremonyInfoAndCalendar(

--- a/lib/page-encointer/ceremony_box/components/ceremony_schedule.dart
+++ b/lib/page-encointer/ceremony_box/components/ceremony_schedule.dart
@@ -58,7 +58,7 @@ class CeremonyDateLabelAbsolute extends StatelessWidget {
 
     return RichText(
       text: TextSpan(
-        text: '${dic.encointer.nextCeremonyDateLabel} ',
+        text: '${dic.encointer.nextCycleDateLabel} ',
         style: Theme.of(context).textTheme.headline4!.copyWith(color: encointerGrey),
         children: [
           TextSpan(
@@ -90,7 +90,7 @@ class CeremonyDateLabelRelative extends StatelessWidget {
 
     return RichText(
       text: TextSpan(
-        text: '${dic.encointer.nextCeremonyTimeLeft} ',
+        text: '${dic.encointer.nextCycleTimeLeft} ',
         style: Theme.of(context).textTheme.headline4!.copyWith(color: encointerGrey),
         children: [
           TextSpan(

--- a/lib/page-encointer/ceremony_box/components/ceremony_start_button.dart
+++ b/lib/page-encointer/ceremony_box/components/ceremony_start_button.dart
@@ -21,7 +21,7 @@ class CeremonyStartButton extends StatelessWidget {
         children: [
           const Icon(Iconsax.login_1),
           const SizedBox(width: 6),
-          Text(dic.encointer.startCeremony),
+          Text(dic.encointer.startGathering),
         ],
       ),
       onPressed: onPressed,

--- a/lib/page-encointer/ceremony_box/meetup_info/components/ceremony_location_button.dart
+++ b/lib/page-encointer/ceremony_box/meetup_info/components/ceremony_location_button.dart
@@ -32,7 +32,7 @@ class CeremonyLocationButton extends StatelessWidget {
         children: [
           const Icon(Iconsax.location),
           const SizedBox(width: 6),
-          Text(dic.encointer.showCeremonyLocation),
+          Text(dic.encointer.meetingPoint),
         ],
       ),
       onPressed: onPressed,

--- a/lib/page-encointer/ceremony_box/meetup_info/meetup_info.dart
+++ b/lib/page-encointer/ceremony_box/meetup_info/meetup_info.dart
@@ -23,8 +23,10 @@ class MeetupInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dic = I18n.of(context)!.translationsForLocale();
-    var info =
-        dic.encointer.youAreAssignedToAMeetupWithNParticipants.replaceAll('P_COUNT', meetup.registry.length.toString());
+    var info = dic.encointer.youAreAssignedToAGatheringWithNParticipants.replaceAll(
+      'P_COUNT',
+      meetup.registry.length.toString(),
+    );
 
     return Column(
       children: [

--- a/lib/page-encointer/meetup/ceremony_step1_count.dart
+++ b/lib/page-encointer/meetup/ceremony_step1_count.dart
@@ -64,7 +64,7 @@ class CeremonyStep1Count extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.transparent,
-        title: Text(dic.encointer.encointerCeremony),
+        title: Text(dic.encointer.keySigningCycle),
         leading: Container(),
         actions: [
           IconButton(

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -38,7 +38,7 @@ class CeremonyStep2Scan extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.transparent,
-        title: Text(dic.encointer.encointerCeremony),
+        title: Text(dic.encointer.keySigningCycle),
       ),
       body: SafeArea(
         child: Column(
@@ -97,7 +97,7 @@ class CeremonyStep2Scan extends StatelessWidget {
                   children: [
                     const Icon(Iconsax.arrow_right_2),
                     const SizedBox(width: 12, height: 60),
-                    Text(dic.encointer.closeMeetup, style: Theme.of(context).textTheme.headline3),
+                    Text(dic.encointer.closeGathering, style: Theme.of(context).textTheme.headline3),
                   ],
                 ),
                 onPressed: () {

--- a/lib/page-encointer/meetup/ceremony_step3_finish.dart
+++ b/lib/page-encointer/meetup/ceremony_step3_finish.dart
@@ -27,7 +27,7 @@ class CeremonyStep3Finish extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.transparent,
-        title: Text(dic.encointer.encointerCeremony),
+        title: Text(dic.encointer.keySigningCycle),
       ),
       body: SafeArea(
         child: Padding(
@@ -53,7 +53,7 @@ class CeremonyStep3Finish extends StatelessWidget {
                     ),
                     Center(
                       child: Text(
-                        dic.encointer.weHopeToSeeYouAtTheNextMeetup,
+                        dic.encointer.weHopeToSeeYouAtTheNextGathering,
                         textAlign: TextAlign.center,
                         style: Theme.of(context).textTheme.headline2!.copyWith(color: Colors.black, height: 1.5),
                       ),

--- a/lib/utils/translations/translations_encointer.dart
+++ b/lib/utils/translations/translations_encointer.dart
@@ -6,10 +6,10 @@ abstract class TranslationsEncointer {
   String get claimsSubmitN;
   String get claimsPurge;
   String get claimsPurgeConfirm;
-  String get encointerCeremony;
+  String get keySigningCycle;
   String get countParticipants;
-  String get nextCeremonyTimeLeft;
-  String get nextCeremonyDateLabel;
+  String get nextCycleTimeLeft;
+  String get nextCycleDateLabel;
   String get claimQr;
   String get claimsScanned;
   String get claimsScannedAlready;
@@ -19,38 +19,36 @@ abstract class TranslationsEncointer {
   String get claimsSubmitDetail;
   String get communities;
   String get noCommunitiesAreYouOffline;
-  String get encointer;
   String get meetupAttended;
   String get meetupClaimantInvalid;
   String get meetupLocation;
-  String get timeUntilCeremonyStarts;
-  String get startCeremony;
+  String get startGathering;
   String get alreadyRegistered;
   String get registerUntil;
-  String get showCeremonyLocation;
-  String get ceremonyIsOver;
+  String get meetingPoint;
+  String get gatheringIsOver;
   String get today;
   String get tomorrow;
   String get calendarEntryDescription;
   String get youAreNotRegistered;
   String get howManyParticipantsShowedUp;
-  String get ceremonyWillTakePlaceOn;
-  String get ceremonySuccessfullyCompleted;
+  String get cycleWillTakePlaceOn;
+  String get gatheringSuccessfullyCompleted;
   String get fetchingReputations;
   String get youAreRegisteredAs;
   String get youAreNotRegisteredPleaseRegisterNextTime;
-  String get youAreAssignedToAMeetupWithNParticipants;
+  String get youAreAssignedToAGatheringWithNParticipants;
   String get successfullySentNAttestations;
   String get numberOfAttendees;
   String get next;
-  String get closeMeetup;
+  String get closeGathering;
   String get count;
   String get scan;
   String get scanDescriptionForMeetup;
   String get scanOthers;
   String get finish;
   String get thankYou;
-  String get weHopeToSeeYouAtTheNextMeetup;
+  String get weHopeToSeeYouAtTheNextGathering;
   String get goToLeuZurich;
 }
 
@@ -66,11 +64,11 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   get claimsPurgeConfirm => 'Are you sure, you want to purge all scanned claims?';
   @override
-  get encointerCeremony => 'Encointer Ceremony';
+  get keySigningCycle => 'Key-Signing Cycle';
   @override
-  get nextCeremonyTimeLeft => 'Next ceremony is in';
+  get nextCycleTimeLeft => 'Next cycle is in';
   @override
-  get nextCeremonyDateLabel => 'Next ceremony is on';
+  get nextCycleDateLabel => 'Next cycle is on';
   @override
   get claimQr => 'My Claim of Attendance';
   @override
@@ -84,13 +82,11 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   get claimsScannedNOfM => 'Scanned SCANNED_COUNT / TOTAL_COUNT Claims';
   @override
-  get claimsSubmitDetail => 'Submitting AMOUNT claims for the recent ceremony';
+  get claimsSubmitDetail => 'Submitting AMOUNT claims for the recent gathering';
   @override
   get communities => 'Communities';
   @override
   get noCommunitiesAreYouOffline => 'No communities were found. You can choose one later. Are you offline?.';
-  @override
-  get encointer => 'Encointer Ceremony';
   @override
   get meetupAttended => 'Attended last meetup';
   @override
@@ -98,40 +94,38 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   get meetupLocation => 'Meetup Location';
   @override
-  get timeUntilCeremonyStarts => 'Time to meetup:';
-  @override
-  get startCeremony => 'Start ceremony';
+  get startGathering => 'Start gathering';
   @override
   get alreadyRegistered => 'Already Registered';
   @override
   get registerUntil => 'Register before';
   @override
-  get showCeremonyLocation => 'Ceremony location';
+  get meetingPoint => 'Meeting Point';
   @override
-  get ceremonyIsOver => 'The ceremony is over';
+  get gatheringIsOver => 'The gathering is over';
   @override
   get today => 'Today';
   @override
   get tomorrow => 'Tomorrow';
   @override
-  get calendarEntryDescription => 'Meetup to get your community income';
+  get calendarEntryDescription => 'Gathering to get your community income';
   @override
-  get youAreNotRegistered => 'You are not registered for a ceremony for the selected community on:';
+  get youAreNotRegistered => 'You are not registered for a gathering for the selected community on:';
   @override
   get howManyParticipantsShowedUp => 'How many attendees are present including yourself?';
   @override
-  get ceremonyWillTakePlaceOn => 'The ceremony will take place on';
+  get cycleWillTakePlaceOn => 'The key-signing cycle will take place on';
   @override
-  get ceremonySuccessfullyCompleted => 'Ceremony successfully completed';
+  get gatheringSuccessfullyCompleted => 'Gathering successfully completed';
   @override
   get fetchingReputations => 'Checking if you have reputation';
   @override
-  get youAreRegisteredAs => 'You have registered for the next ceremony as PARTICIPANT_TYPE.';
+  get youAreRegisteredAs => 'You have registered for the next gathering as PARTICIPANT_TYPE.';
   @override
   get youAreNotRegisteredPleaseRegisterNextTime =>
-      'You haven\'t been assigned for this ceremony. Please join a later ceremony to receive your community income.';
+      'You haven\'t been assigned for this key-signing cycle. Please join the next cycle to receive your community income.';
   @override
-  get youAreAssignedToAMeetupWithNParticipants => 'You are assigned to a meetup with P_COUNT people.';
+  get youAreAssignedToAGatheringWithNParticipants => 'You are assigned to a gathering with P_COUNT people.';
   @override
   get successfullySentNAttestations => 'You have successfully submitted attestations for P_COUNT other people.';
   @override
@@ -141,7 +135,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   get next => 'Next';
   @override
-  get closeMeetup => 'Close meetup';
+  get closeGathering => 'Close meetup';
   @override
   get count => 'Count';
   @override
@@ -155,7 +149,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   get thankYou => 'Thank you';
   @override
-  get weHopeToSeeYouAtTheNextMeetup => 'We hope to see you at the next meetup.';
+  get weHopeToSeeYouAtTheNextGathering => 'We hope to see you at the next gathering.';
   @override
   get goToLeuZurich => 'Open leu.zuerich';
 }
@@ -172,11 +166,11 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get claimsPurgeConfirm => 'Bist du sicher, dass du alle gescannte Anträge löschen möchtest?';
   @override
-  get encointerCeremony => 'Encointer Zeremonie';
+  get keySigningCycle => 'Key-Signing Cycle';
   @override
-  get nextCeremonyTimeLeft => 'Nächste Zeremonie ist in';
+  get nextCycleTimeLeft => 'Nächster Cycle ist in';
   @override
-  get nextCeremonyDateLabel => 'Nächste Zeremonie:';
+  get nextCycleDateLabel => 'Nächster Cycle:';
   @override
   get claimQr => 'Mein Antrag auf Anwesenheitsbestätigung';
   @override
@@ -190,13 +184,11 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get claimsScannedNOfM => 'SCANNED_COUNT / TOTAL_COUNT gescannte Anträge';
   @override
-  get claimsSubmitDetail => 'Reiche AMOUNT Bezeugungen für die aktuelle Zeremonie ein';
+  get claimsSubmitDetail => 'Reiche AMOUNT Bezeugungen für diese Versammling ein';
   @override
   get communities => 'Gemeinschaften';
   @override
   get noCommunitiesAreYouOffline => 'Keine Gemeinschaften gefunden. Du kannst später eine auswählen. Bist du offline?';
-  @override
-  get encointer => 'Encointer Zeremonie';
   @override
   get meetupAttended => 'An der letzen Versammlung teilgenommen';
   @override
@@ -205,17 +197,15 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get meetupLocation => 'Treffpunkt';
   @override
-  get timeUntilCeremonyStarts => 'Zeit bis zur Versammlung:';
-  @override
-  get startCeremony => 'Versammlung starten';
+  get startGathering => 'Versammlung starten';
   @override
   get alreadyRegistered => 'Bereits registriert';
   @override
   get registerUntil => 'Registriere dich vor dem';
   @override
-  get showCeremonyLocation => 'Treffpunkt';
+  get meetingPoint => 'Treffpunkt';
   @override
-  get ceremonyIsOver => 'Die Zeremonie ist vorbei';
+  get gatheringIsOver => 'Die Versammung ist vorbei';
   @override
   get today => 'Heute';
   @override
@@ -227,18 +217,18 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get howManyParticipantsShowedUp => 'Wieviele Teilnehmende sind da inklusive dir?';
   @override
-  get ceremonyWillTakePlaceOn => 'Die Zeremonie wird stattfinden am';
+  get cycleWillTakePlaceOn => 'Der Key-Signing Cycle wird stattfinden am';
   @override
-  get ceremonySuccessfullyCompleted => 'Zeremonie erfolgreich durchgeführt';
+  get gatheringSuccessfullyCompleted => 'Versammlung erfolgreich durchgeführt';
   @override
   get fetchingReputations => 'Es wird überprüft, ob du bereits Reputation hast';
   @override
-  get youAreRegisteredAs => 'Du hast dich für die nächste Zeremonie als PARTICIPANT_TYPE registriert.';
+  get youAreRegisteredAs => 'Du hast dich für die nächste Versammlung als PARTICIPANT_TYPE registriert.';
   @override
   get youAreNotRegisteredPleaseRegisterNextTime =>
-      'Du wurdest nicht für diese Zeremonie zugewiesen. Bitte registriere dich für eine kommende Zeremonie um dein Gemeinschaftseinkommen zu erhalten.';
+      'Du wurdest nicht für diesen Key-Signing Cycle zugewiesen. Bitte registriere dich für den nächsten Cycle um dein Gemeinschaftseinkommen zu erhalten.';
   @override
-  get youAreAssignedToAMeetupWithNParticipants => 'Du bist einer Versammlung mit P_COUNT Leuten zugewiesen.';
+  get youAreAssignedToAGatheringWithNParticipants => 'Du bist einer Versammlung mit P_COUNT Leuten zugewiesen.';
   @override
   get successfullySentNAttestations => 'Du hast erfolgreich Bezeugungen für P_COUNT andere Leute eingereicht.';
   @override
@@ -248,7 +238,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get next => 'Weiter';
   @override
-  get closeMeetup => 'Treffen schliessen';
+  get closeGathering => 'Versammlung schliessen';
   @override
   get count => 'Zähle';
   @override
@@ -262,7 +252,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get thankYou => 'Danke';
   @override
-  get weHopeToSeeYouAtTheNextMeetup => 'Wir hoffen, dass wir dich am nächsten Treffen wieder sehen.';
+  get weHopeToSeeYouAtTheNextGathering => 'Wir hoffen dich an der nächsten Versammlung wiederzusehen.';
   @override
   get goToLeuZurich => 'leu.zuerich öffnen';
 }
@@ -279,11 +269,11 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get claimsPurgeConfirm => throw UnimplementedError();
   @override
-  get encointerCeremony => throw UnimplementedError();
+  get keySigningCycle => throw UnimplementedError();
   @override
-  get nextCeremonyTimeLeft => throw UnimplementedError();
+  get nextCycleTimeLeft => throw UnimplementedError();
   @override
-  get nextCeremonyDateLabel => throw UnimplementedError();
+  get nextCycleDateLabel => throw UnimplementedError();
   @override
   get claimQr => throw UnimplementedError();
   @override
@@ -299,7 +289,6 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get claimsSubmitDetail => throw UnimplementedError();
   @override
-  get encointer => throw UnimplementedError();
   @override
   get meetupAttended => throw UnimplementedError();
   @override
@@ -307,9 +296,7 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get meetupLocation => throw UnimplementedError();
   @override
-  get timeUntilCeremonyStarts => throw UnimplementedError();
-  @override
-  get startCeremony => throw UnimplementedError();
+  get startGathering => throw UnimplementedError();
   @override
   get alreadyRegistered => throw UnimplementedError();
   @override
@@ -319,9 +306,9 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get registerUntil => throw UnimplementedError();
   @override
-  get showCeremonyLocation => throw UnimplementedError();
+  get meetingPoint => throw UnimplementedError();
   @override
-  get ceremonyIsOver => throw UnimplementedError();
+  get gatheringIsOver => throw UnimplementedError();
   @override
   get today => throw UnimplementedError();
   @override
@@ -333,9 +320,9 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get howManyParticipantsShowedUp => throw UnimplementedError();
   @override
-  get ceremonyWillTakePlaceOn => throw UnimplementedError();
+  get cycleWillTakePlaceOn => throw UnimplementedError();
   @override
-  get ceremonySuccessfullyCompleted => throw UnimplementedError();
+  get gatheringSuccessfullyCompleted => throw UnimplementedError();
   @override
   get fetchingReputations => throw UnimplementedError();
   @override
@@ -343,7 +330,7 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get youAreNotRegisteredPleaseRegisterNextTime => throw UnimplementedError();
   @override
-  get youAreAssignedToAMeetupWithNParticipants => throw UnimplementedError();
+  get youAreAssignedToAGatheringWithNParticipants => throw UnimplementedError();
   @override
   get successfullySentNAttestations => throw UnimplementedError();
   @override
@@ -353,7 +340,7 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get next => throw UnimplementedError();
   @override
-  get closeMeetup => throw UnimplementedError();
+  get closeGathering => throw UnimplementedError();
   @override
   get count => throw UnimplementedError();
   @override
@@ -367,7 +354,7 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   @override
   get thankYou => throw UnimplementedError();
   @override
-  get weHopeToSeeYouAtTheNextMeetup => throw UnimplementedError();
+  get weHopeToSeeYouAtTheNextGathering => throw UnimplementedError();
   @override
   get goToLeuZurich => throw UnimplementedError();
 }

--- a/lib/utils/translations/translations_encointer.dart
+++ b/lib/utils/translations/translations_encointer.dart
@@ -184,7 +184,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get claimsScannedNOfM => 'SCANNED_COUNT / TOTAL_COUNT gescannte Anträge';
   @override
-  get claimsSubmitDetail => 'Reiche AMOUNT Bezeugungen für diese Versammling ein';
+  get claimsSubmitDetail => 'Reiche AMOUNT Bezeugungen für diese Versammlung ein';
   @override
   get communities => 'Gemeinschaften';
   @override

--- a/lib/utils/translations/translations_profile.dart
+++ b/lib/utils/translations/translations_profile.dart
@@ -73,7 +73,6 @@ abstract class TranslationsProfile {
   String get pinSecure;
   String get personalKey;
   String get recoveryProxy;
-  String get ceremonies;
   String get tokenSend;
   String get reputation;
   String get addContact;
@@ -241,8 +240,6 @@ class TranslationsEnProfile implements TranslationsProfile {
   get pinSecure => 'Secure your account with a PIN.';
   @override
   get recoveryProxy => 'recovery proxy';
-  @override
-  get ceremonies => 'Ceremonies';
   @override
   get reputation => 'Reputation';
   @override
@@ -424,8 +421,6 @@ class TranslationsDeProfile implements TranslationsProfile {
   @override
   get recoveryProxy => 'Wiederherstellungsproxy';
   @override
-  get ceremonies => 'Zeremonien';
-  @override
   get reputation => 'Reputation';
   @override
   get tokenSend => 'SYMBOL senden';
@@ -570,8 +565,6 @@ class TranslationsFrProfile implements TranslationsProfile {
   get addCommunity => throw UnimplementedError();
   @override
   get recoveryProxy => 'recovery proxy';
-  @override
-  get ceremonies => throw UnimplementedError();
   @override
   get reputation => throw UnimplementedError();
   @override


### PR DESCRIPTION
Change translations into terms, which are socially less problematic, i.e., they are less associated with other contexts. 

meetup -> Gathering/Versammlung
ceremony -> Key-Signing Cycle