### PR TITLE
Use new `attestAttendees` extrinsic

### DIFF
--- a/lib/page-encointer/ceremony_box/ceremony_box.dart
+++ b/lib/page-encointer/ceremony_box/ceremony_box.dart
@@ -105,7 +105,7 @@ class CeremonyBox extends StatelessWidget {
                           Text(
                             dic.encointer.claimsSubmitN.replaceAll(
                               'N_COUNT',
-                              store.encointer.communityAccount!.scannedClaimsCount.toString(),
+                              store.encointer.communityAccount!.scannedAttendeesCount.toString(),
                             ),
                           ),
                         ],
@@ -174,7 +174,7 @@ Widget getMeetupInfoWidget(BuildContext context, AppStore store) {
           return CeremonyNotification(
             notificationIconData: Iconsax.tick_square,
             notification: dic.encointer.successfullySentNAttestations
-                .replaceAll('P_COUNT', store.encointer.communityAccount!.scannedClaimsCount.toString()),
+                .replaceAll('P_COUNT', store.encointer.communityAccount!.scannedAttendeesCount.toString()),
           );
         } else {
           var meetup = store.encointer.communityAccount!.meetup!;

--- a/lib/page-encointer/meetup/ceremony_step1_count.dart
+++ b/lib/page-encointer/meetup/ceremony_step1_count.dart
@@ -1,11 +1,9 @@
 import 'package:encointer_wallet/common/components/encointer_text_form_field.dart';
 import 'package:encointer_wallet/common/components/gradient_elements.dart';
-import 'package:encointer_wallet/common/components/password_input_dialog.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page-encointer/meetup/ceremony_progress_bar.dart';
 import 'package:encointer_wallet/page-encointer/meetup/ceremony_step2_scan2.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
-import 'package:encointer_wallet/service/substrate_api/codec_api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
@@ -26,36 +24,16 @@ class CeremonyStep1Count extends StatelessWidget {
   final TextEditingController _attendeesCountController = TextEditingController();
 
   Future<void> _pushStep2ScanPage(BuildContext context, int count) async {
-    if (store.settings.cachedPin.isEmpty) {
-      await showCupertinoDialog(
-        context: context,
-        builder: (context) {
-          final Translations dic = I18n.of(context)!.translationsForLocale();
-          return showPasswordInputDialog(
-              context,
-              store.account.currentAccount,
-              Text(dic.home.unlockAccount
-                  .replaceAll('CURRENT_ACCOUNT_NAME', store.account.currentAccount.name.toString())), (password) {
-            store.settings.setPin(password);
-          });
-        },
-      );
-    }
-
-    if (store.settings.cachedPin.isNotEmpty) {
-      Navigator.of(context).push(
-        CupertinoPageRoute(
-          builder: (BuildContext context) => CeremonyStep2Scan(
-            store,
-            api,
-            claim: webApi.encointer
-                .signClaimOfAttendance(count, store.settings.cachedPin)
-                .then((claim) => webApi.codec.encodeToBytes(ClaimOfAttendanceJSRegistryName, claim)),
-            confirmedParticipantsCount: count,
-          ),
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (BuildContext context) => CeremonyStep2Scan(
+          store,
+          api,
+          claimantPubKey: store.account.currentAddress,
+          confirmedParticipantsCount: count,
         ),
-      );
-    }
+      ),
+    );
   }
 
   @override

--- a/lib/page-encointer/meetup/ceremony_step1_count.dart
+++ b/lib/page-encointer/meetup/ceremony_step1_count.dart
@@ -29,7 +29,7 @@ class CeremonyStep1Count extends StatelessWidget {
         builder: (BuildContext context) => CeremonyStep2Scan(
           store,
           api,
-          claimantPubKey: store.account.currentAddress,
+          claimantAddress: store.account.currentAddress,
           confirmedParticipantsCount: count,
         ),
       ),

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -19,7 +22,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   const CeremonyStep2Scan(
     this.store,
     this.api, {
-    required this.claimantAddress,
+    required this.claim,
     required this.confirmedParticipantsCount,
     Key? key,
   }) : super(key: key);
@@ -27,7 +30,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   final AppStore store;
   final Api api;
 
-  final String claimantAddress;
+  final Future<Uint8List> claim;
   final int confirmedParticipantsCount;
 
   @override
@@ -70,9 +73,18 @@ class CeremonyStep2Scan extends StatelessWidget {
                   const SizedBox(height: 12),
                   // Enhance brightness for the QR-code
                   const WakeLockAndBrightnessEnhancer(brightness: 1),
-                  QrCodeImage(
-                    qrCode: claimantAddress,
-                    errorCorrectionLevel: QrErrorCorrectLevel.L,
+                  FutureBuilder<Uint8List>(
+                    future: claim,
+                    builder: (_, AsyncSnapshot<Uint8List> snapshot) {
+                      if (snapshot.hasData) {
+                        return QrCodeImage(
+                          qrCode: base64.encode(snapshot.data!),
+                          errorCorrectionLevel: QrErrorCorrectLevel.L,
+                        );
+                      } else {
+                        return const CupertinoActivityIndicator();
+                      }
+                    },
                   ),
                 ],
               ),
@@ -121,7 +133,7 @@ class CeremonyStep2Scan extends StatelessWidget {
             store.settings.developerMode
                 ? ElevatedButton(
                     child: const Text('DEV ONLY: attest all participants'),
-                    onPressed: () => attestAllParticipants(store, claimantAddress),
+                    onPressed: () => attestAllParticipants(store, store.account.currentAddress),
                   )
                 : Container(),
             const SizedBox(height: 12)

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -18,7 +18,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   const CeremonyStep2Scan(
     this.store,
     this.api, {
-    required this.claimantPubKey,
+    required this.claimantAddress,
     required this.confirmedParticipantsCount,
     Key? key,
   }) : super(key: key);
@@ -26,7 +26,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   final AppStore store;
   final Api api;
 
-  final String claimantPubKey;
+  final String claimantAddress;
   final int confirmedParticipantsCount;
 
   @override
@@ -70,7 +70,7 @@ class CeremonyStep2Scan extends StatelessWidget {
                   // Enhance brightness for the QR-code
                   const WakeLockAndBrightnessEnhancer(brightness: 1),
                   QrCodeImage(
-                    qrCode: claimantPubKey,
+                    qrCode: claimantAddress,
                     errorCorrectionLevel: QrErrorCorrectLevel.L,
                   ),
                 ],

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
@@ -21,7 +18,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   const CeremonyStep2Scan(
     this.store,
     this.api, {
-    required this.claim,
+    required this.claimantPubKey,
     required this.confirmedParticipantsCount,
     Key? key,
   }) : super(key: key);
@@ -29,7 +26,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   final AppStore store;
   final Api api;
 
-  final Future<Uint8List> claim;
+  final String claimantPubKey;
   final int confirmedParticipantsCount;
 
   @override
@@ -72,18 +69,9 @@ class CeremonyStep2Scan extends StatelessWidget {
                   const SizedBox(height: 12),
                   // Enhance brightness for the QR-code
                   const WakeLockAndBrightnessEnhancer(brightness: 1),
-                  FutureBuilder<Uint8List>(
-                    future: claim,
-                    builder: (_, AsyncSnapshot<Uint8List> snapshot) {
-                      if (snapshot.hasData) {
-                        return QrCodeImage(
-                          qrCode: base64.encode(snapshot.data!),
-                          errorCorrectionLevel: QrErrorCorrectLevel.L,
-                        );
-                      } else {
-                        return const CupertinoActivityIndicator();
-                      }
-                    },
+                  QrCodeImage(
+                    qrCode: claimantPubKey,
+                    errorCorrectionLevel: QrErrorCorrectLevel.L,
                   ),
                 ],
               ),

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
@@ -117,10 +118,27 @@ class CeremonyStep2Scan extends StatelessWidget {
                 },
               ),
             ),
-            const SizedBox(height: 24),
+            store.settings.developerMode
+                ? ElevatedButton(
+                    child: const Text('DEV ONLY: attest all participants'),
+                    onPressed: () => attestAllParticipants(store, claimantAddress),
+                  )
+                : const SizedBox(height: 24),
           ],
         ),
       ),
     );
   }
+}
+
+/// Attest all assigned meetup participants.
+///
+/// Only intended for development purposes.
+void attestAllParticipants(AppStore store, String claimantAddress) {
+  List<String> registry = store.encointer.communityAccount!.meetup!.registry;
+
+  registry.removeWhere((a) => a == claimantAddress);
+  registry.forEach((attendee) => store.encointer.communityAccount!.addAttendee(attendee));
+
+  RootSnackBar.showMsg('Added all meetup participants to attendees');
 }

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -123,7 +123,8 @@ class CeremonyStep2Scan extends StatelessWidget {
                     child: const Text('DEV ONLY: attest all participants'),
                     onPressed: () => attestAllParticipants(store, claimantAddress),
                   )
-                : const SizedBox(height: 24),
+                : Container(),
+            const SizedBox(height: 12)
           ],
         ),
       ),

--- a/lib/page-encointer/meetup/ceremony_step3_finish.dart
+++ b/lib/page-encointer/meetup/ceremony_step3_finish.dart
@@ -90,7 +90,7 @@ class CeremonyStep3Finish extends StatelessWidget {
                       Text(
                         dic.encointer.claimsSubmitN.replaceAll(
                           'N_COUNT',
-                          store.encointer.communityAccount!.scannedClaimsCount.toString(),
+                          store.encointer.communityAccount!.scannedAttendeesCount.toString(),
                         ),
                       ),
                     ],

--- a/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -31,6 +31,7 @@ class ScanClaimQrCode extends StatelessWidget {
         'Claimant: $attendee is equal to self',
         'ScanClaimQrCode',
       );
+      return;
     }
 
     if (!registry.contains(attendee)) {

--- a/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -28,8 +28,8 @@ class ScanClaimQrCode extends StatelessWidget {
       // this is important because the runtime checks if there are too many claims trying to be registered.
       RootSnackBar.showMsg(dic.encointer.meetupClaimantInvalid);
       Log.d(
-        '[scanClaimQrCode] Claimant: $attendee is not part of registry: $registry',
-        'CeremonyProgressBar',
+        'Claimant: $attendee is not part of registry: $registry',
+        'ScanClaimQrCode',
       );
     } else {
       String msg = store.encointer.communityAccount!.containsAttendee(attendee)
@@ -54,7 +54,7 @@ class ScanClaimQrCode extends StatelessWidget {
 
         validateAndStoreParticipant(context, address, dic);
       } catch (e, s) {
-        Log.e('Error decoding claim: $e', 'CeremonyProgressBar', s);
+        Log.e('Error decoding claim: $e', 'ScanClaimQrCode', s);
         RootSnackBar.showMsg(dic.encointer.claimsScannedDecodeFailed);
       }
 
@@ -78,7 +78,7 @@ class ScanClaimQrCode extends StatelessWidget {
         builder: (BuildContext context, AsyncSnapshot<PermissionStatus> snapshot) {
           if (snapshot.hasData) {
             if (snapshot.data != PermissionStatus.granted) {
-              Log.d('[scanPage] Permission Status: ${snapshot.data}', 'CeremonyProgressBar');
+              Log.d('[scanPage] Permission Status: ${snapshot.data}', 'ScanClaimQrCode');
               return permissionErrorDialog(context);
             }
 
@@ -88,7 +88,7 @@ class ScanClaimQrCode extends StatelessWidget {
                     allowDuplicates: false,
                     onDetect: (barcode, args) {
                       if (barcode.rawValue == null) {
-                        Log.e('Failed to scan Barcode', 'CeremonyProgressBar');
+                        Log.e('Failed to scan Barcode', 'ScanClaimQrCode');
                       } else {
                         _onScan(barcode.rawValue!);
                       }

--- a/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -24,6 +24,15 @@ class ScanClaimQrCode extends StatelessWidget {
 
   void validateAndStoreParticipant(BuildContext context, String attendee, Translations dic) {
     List<String> registry = store.encointer.communityAccount!.meetup!.registry;
+
+    if (attendee == store.account.currentAddress) {
+      RootSnackBar.showMsg(dic.encointer.meetupClaimantEqualToSelf);
+      Log.d(
+        'Claimant: $attendee is equal to self',
+        'ScanClaimQrCode',
+      );
+    }
+
     if (!registry.contains(attendee)) {
       // this is important because the runtime checks if there are too many claims trying to be registered.
       RootSnackBar.showMsg(dic.encointer.meetupClaimantInvalid);

--- a/lib/service/tx/lib/src/params.dart
+++ b/lib/service/tx/lib/src/params.dart
@@ -1,4 +1,3 @@
-import 'package:encointer_wallet/models/claim_of_attendance/claim_of_attendance.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/models/proof_of_attendance/proof_of_attendance.dart';
 
@@ -37,19 +36,19 @@ Map<String, dynamic> registerParticipantParams(
   };
 }
 
-Map<String, dynamic> attestClaimsParams(
+Map<String, dynamic> attestAttendeesParams(
   CommunityIdentifier chosenCid,
-  int scannedClaimsCount,
-  List<ClaimOfAttendance> claims,
+  int numberOfParticipantsVote,
+  List<String> attendees,
 ) {
   return {
     'title': 'attest_claims',
     'txInfo': {
       'module': 'encointerCeremonies',
-      'call': 'attestClaims',
+      'call': 'attestAttendees',
       'cid': chosenCid,
     },
-    'params': [claims],
+    'params': [numberOfParticipantsVote, attendees],
   };
 }
 

--- a/lib/service/tx/lib/src/params.dart
+++ b/lib/service/tx/lib/src/params.dart
@@ -48,7 +48,7 @@ Map<String, dynamic> attestAttendeesParams(
       'call': 'attestAttendees',
       'cid': chosenCid,
     },
-    'params': [numberOfParticipantsVote, attendees],
+    'params': [chosenCid, numberOfParticipantsVote, attendees],
   };
 }
 

--- a/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -127,10 +127,10 @@ Future<void> submitRegisterParticipant(BuildContext context, AppStore store, Api
 }
 
 Future<void> submitAttestClaims(BuildContext context, AppStore store, Api api) async {
-  final params = attestClaimsParams(
+  final params = attestAttendeesParams(
     store.encointer.chosenCid!,
-    store.encointer.communityAccount!.scannedClaimsCount,
-    store.encointer.communityAccount!.participantsClaims!.values.toList(),
+    store.encointer.communityAccount!.scannedAttendeesCount,
+    store.encointer.communityAccount!.attendees!.toList(),
   );
 
   return submitTx(

--- a/lib/store/encointer/encointer.dart
+++ b/lib/store/encointer/encointer.dart
@@ -546,7 +546,7 @@ abstract class _EncointerStore with Store {
   @computed
   bool get showSubmitClaimsButton {
     bool assigned = communityAccount?.isAssigned ?? false;
-    bool? hasClaims = (communityAccount?.scannedClaimsCount ?? 0) > 0;
+    bool? hasClaims = (communityAccount?.scannedAttendeesCount ?? 0) > 0;
     return (currentPhase == CeremonyPhase.Attesting && assigned && hasClaims!);
   }
 

--- a/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 
-import 'package:encointer_wallet/models/claim_of_attendance/claim_of_attendance.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/models/index.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
@@ -50,18 +49,16 @@ abstract class _CommunityAccountStore with Store {
   @observable
   Meetup? meetup;
 
-  /// `ClaimOfAttendances` that were scanned during a meetup.
-  ///
-  /// Map: claimantPublicKey -> ClaimOfAttendance
+  /// Meetup `attendees` scanned during a meetup.
   @observable
-  ObservableMap<String, ClaimOfAttendance>? participantsClaims = ObservableMap();
+  ObservableSet<String>? attendees = ObservableSet();
 
   /// This should be set to true once the attestations have been sent to chain.
   @observable
   bool? meetupCompleted = false;
 
   @computed
-  get scannedClaimsCount => participantsClaims?.length ?? 0;
+  get scannedAttendeesCount => attendees?.length ?? 0;
 
   @computed
   bool get isAssigned => meetup != null;
@@ -118,18 +115,25 @@ abstract class _CommunityAccountStore with Store {
   @action
   void purgeParticipantsClaims() {
     Log.d('Purging participantsClaims.', 'CommunityAccountStore');
-    participantsClaims!.clear();
+    attendees!.clear();
     writeToCache();
   }
 
-  bool containsClaim(ClaimOfAttendance claim) {
-    return participantsClaims![claim.claimantPublic] != null;
+  bool containsAttendee(String attendee) {
+    return attendees?.contains(attendee) ?? false;
   }
 
   @action
-  void addParticipantClaim(ClaimOfAttendance claim) {
+  void addAttendee(String attendee) {
     Log.d('adding participantsClaims.', 'CommunityAccountStore');
-    participantsClaims![claim.claimantPublic!] = claim;
+
+    if (attendees == null) {
+      attendees = ObservableSet();
+    }
+
+    // Is a noop if the attendee is already in the set.
+    attendees!.add(attendee);
+
     writeToCache();
   }
 

--- a/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
@@ -115,7 +115,7 @@ abstract class _CommunityAccountStore with Store {
   @action
   void purgeParticipantsClaims() {
     Log.d('Purging participantsClaims.', 'CommunityAccountStore');
-    attendees!.clear();
+    attendees = ObservableSet();
     writeToCache();
   }
 

--- a/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.g.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.g.dart
@@ -13,10 +13,8 @@ CommunityAccountStore _$CommunityAccountStoreFromJson(Map<String, dynamic> json)
     )
       ..participantType = $enumDecodeNullable(_$ParticipantTypeEnumMap, json['participantType'])
       ..meetup = json['meetup'] == null ? null : Meetup.fromJson(json['meetup'] as Map<String, dynamic>)
-      ..participantsClaims = json['participantsClaims'] != null
-          ? ObservableMap<String, ClaimOfAttendance>.of((json['participantsClaims'] as Map<String, dynamic>).map(
-              (k, e) => MapEntry(k, ClaimOfAttendance.fromJson(e as Map<String, dynamic>)),
-            ))
+      ..attendees = json['attendees'] != null
+          ? ObservableSet<String>.of((json['attendees'] as List).map((e) => e as String))
           : null
       ..meetupCompleted = json['meetupCompleted'] as bool?;
 
@@ -26,7 +24,7 @@ Map<String, dynamic> _$CommunityAccountStoreToJson(CommunityAccountStore instanc
       'address': instance.address,
       'participantType': _$ParticipantTypeEnumMap[instance.participantType],
       'meetup': instance.meetup?.toJson(),
-      'participantsClaims': instance.participantsClaims?.map((k, e) => MapEntry(k, e.toJson())),
+      'attendees': instance.attendees?.toList(),
       'meetupCompleted': instance.meetupCompleted,
     };
 
@@ -44,11 +42,11 @@ const _$ParticipantTypeEnumMap = {
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
-  Computed<dynamic>? _$scannedClaimsCountComputed;
+  Computed<dynamic>? _$scannedAttendeesCountComputed;
 
   @override
-  dynamic get scannedClaimsCount => (_$scannedClaimsCountComputed ??=
-          Computed<dynamic>(() => super.scannedClaimsCount, name: '_CommunityAccountStore.scannedClaimsCount'))
+  dynamic get scannedAttendeesCount => (_$scannedAttendeesCountComputed ??=
+          Computed<dynamic>(() => super.scannedAttendeesCount, name: '_CommunityAccountStore.scannedAttendeesCount'))
       .value;
   Computed<bool>? _$isAssignedComputed;
 
@@ -93,18 +91,18 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
     });
   }
 
-  late final _$participantsClaimsAtom = Atom(name: '_CommunityAccountStore.participantsClaims', context: context);
+  late final _$attendeesAtom = Atom(name: '_CommunityAccountStore.attendees', context: context);
 
   @override
-  ObservableMap<String, ClaimOfAttendance>? get participantsClaims {
-    _$participantsClaimsAtom.reportRead();
-    return super.participantsClaims;
+  ObservableSet<String>? get attendees {
+    _$attendeesAtom.reportRead();
+    return super.attendees;
   }
 
   @override
-  set participantsClaims(ObservableMap<String, ClaimOfAttendance>? value) {
-    _$participantsClaimsAtom.reportWrite(value, super.participantsClaims, () {
-      super.participantsClaims = value;
+  set attendees(ObservableSet<String>? value) {
+    _$attendeesAtom.reportWrite(value, super.attendees, () {
+      super.attendees = value;
     });
   }
 
@@ -203,11 +201,11 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
   }
 
   @override
-  void addParticipantClaim(ClaimOfAttendance claim) {
+  void addAttendee(String attendee) {
     final _$actionInfo =
-        _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.addParticipantClaim');
+        _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.addAttendee');
     try {
-      return super.addParticipantClaim(claim);
+      return super.addAttendee(attendee);
     } finally {
       _$_CommunityAccountStoreActionController.endAction(_$actionInfo);
     }
@@ -229,9 +227,9 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
     return '''
 participantType: ${participantType},
 meetup: ${meetup},
-participantsClaims: ${participantsClaims},
+attendees: ${attendees},
 meetupCompleted: ${meetupCompleted},
-scannedClaimsCount: ${scannedClaimsCount},
+scannedAttendeesCount: ${scannedAttendeesCount},
 isAssigned: ${isAssigned},
 isRegistered: ${isRegistered}
     ''';

--- a/lib/utils/translations/translations_encointer.dart
+++ b/lib/utils/translations/translations_encointer.dart
@@ -21,6 +21,7 @@ abstract class TranslationsEncointer {
   String get noCommunitiesAreYouOffline;
   String get meetupAttended;
   String get meetupClaimantInvalid;
+  String get meetupClaimantEqualToSelf;
   String get meetupLocation;
   String get startGathering;
   String get alreadyRegistered;
@@ -91,6 +92,8 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   get meetupAttended => 'Attended last meetup';
   @override
   get meetupClaimantInvalid => 'This claimant is not part of the meetup. Claim is not stored.';
+  @override
+  get meetupClaimantEqualToSelf => 'Error: Claimant is equal to self. Claim is not stored.';
   @override
   get meetupLocation => 'Meetup Location';
   @override
@@ -194,6 +197,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get meetupClaimantInvalid =>
       'Diese* Antragssteller*in gehört nicht zu deiner Versammlung. Antrag wurde nicht gespeichert.';
+  get meetupClaimantEqualToSelf => 'Fehler, Addresse ist aktueller account. Antrag wurde nicht gespeichert.';
   @override
   get meetupLocation => 'Treffpunkt';
   @override
@@ -293,6 +297,8 @@ class TranslationsFrEncointer implements TranslationsEncointer {
   get meetupAttended => throw UnimplementedError();
   @override
   get meetupClaimantInvalid => throw UnimplementedError();
+  @override
+  get meetupClaimantEqualToSelf => throw UnimplementedError();
   @override
   get meetupLocation => throw UnimplementedError();
   @override

--- a/lib/utils/translations/translations_encointer.dart
+++ b/lib/utils/translations/translations_encointer.dart
@@ -197,6 +197,7 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   get meetupClaimantInvalid =>
       'Diese* Antragssteller*in gehört nicht zu deiner Versammlung. Antrag wurde nicht gespeichert.';
+  @override
   get meetupClaimantEqualToSelf => 'Fehler, Addresse ist aktueller account. Antrag wurde nicht gespeichert.';
   @override
   get meetupLocation => 'Treffpunkt';

--- a/test/store/encointer/sub_stores/community_store/community_account_store_test.dart
+++ b/test/store/encointer/sub_stores/community_store/community_account_store_test.dart
@@ -27,7 +27,7 @@ void main() {
           'time': 10,
           'registry': [ALICE_ADDRESS, BOB_ADDRESS, CHARLIE_ADDRESS]
         },
-        'participantsClaims': {},
+        'attendees': [],
         'meetupCompleted': false
       };
 
@@ -46,7 +46,7 @@ void main() {
           'time': 10,
           'registry': [ALICE_ADDRESS, BOB_ADDRESS, CHARLIE_ADDRESS]
         },
-        'participantsClaims': Map<String, dynamic>.of({})
+        'attendees': []
       };
 
       var store = CommunityAccountStore.fromJson(sourceJson);
@@ -86,7 +86,7 @@ void main() {
           'time': 10,
           'registry': [ALICE_ADDRESS, BOB_ADDRESS, CHARLIE_ADDRESS]
         },
-        'participantsClaims': Map<String, dynamic>.of({}),
+        'attendees': [],
         'meetupCompleted': false
       };
 


### PR DESCRIPTION
Changes:
* Use the new `attestAttendees` extrinsic after a meetup
* QR-Scanner understands plain addresses at meetups, but it still shows the full `ClaimOfAttendance` for backwards compatibility
* Add dev button to attest all meetup participants.