### PR TITLE
add correct vote to new `attestAttendees` extrinsic and remove backwards compatibility with old claims as the chain can't handle mixed setups.

### DIFF
--- a/lib/page-encointer/meetup/ceremony_step1_count.dart
+++ b/lib/page-encointer/meetup/ceremony_step1_count.dart
@@ -24,6 +24,7 @@ class CeremonyStep1Count extends StatelessWidget {
   final TextEditingController _attendeesCountController = TextEditingController();
 
   Future<void> _pushStep2ScanPage(BuildContext context, int count) async {
+    store.encointer.communityAccount!.setParticipantCountVote(count);
     Navigator.of(context).push(
       CupertinoPageRoute(
         builder: (BuildContext context) => CeremonyStep2Scan(

--- a/lib/page-encointer/meetup/ceremony_step1_count.dart
+++ b/lib/page-encointer/meetup/ceremony_step1_count.dart
@@ -1,11 +1,9 @@
 import 'package:encointer_wallet/common/components/encointer_text_form_field.dart';
 import 'package:encointer_wallet/common/components/gradient_elements.dart';
-import 'package:encointer_wallet/common/components/password_input_dialog.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/page-encointer/meetup/ceremony_progress_bar.dart';
 import 'package:encointer_wallet/page-encointer/meetup/ceremony_step2_scan2.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
-import 'package:encointer_wallet/service/substrate_api/codec_api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
@@ -26,36 +24,16 @@ class CeremonyStep1Count extends StatelessWidget {
   final TextEditingController _attendeesCountController = TextEditingController();
 
   Future<void> _pushStep2ScanPage(BuildContext context, int count) async {
-    if (store.settings.cachedPin.isEmpty) {
-      await showCupertinoDialog(
-        context: context,
-        builder: (context) {
-          final Translations dic = I18n.of(context)!.translationsForLocale();
-          return showPasswordInputDialog(
-              context,
-              store.account.currentAccount,
-              Text(dic.home.unlockAccount
-                  .replaceAll('CURRENT_ACCOUNT_NAME', store.account.currentAccount.name.toString())), (password) {
-            store.settings.setPin(password);
-          });
-        },
-      );
-    }
-
-    if (store.settings.cachedPin.isNotEmpty) {
-      Navigator.of(context).push(
-        CupertinoPageRoute(
-          builder: (BuildContext context) => CeremonyStep2Scan(
-            store,
-            api,
-            claim: webApi.encointer
-                .signClaimOfAttendance(count, store.settings.cachedPin)
-                .then((claim) => webApi.codec.encodeToBytes(ClaimOfAttendanceJSRegistryName, claim)),
-            confirmedParticipantsCount: count,
-          ),
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (BuildContext context) => CeremonyStep2Scan(
+          store,
+          api,
+          claimantAddress: store.account.currentAddress,
+          confirmedParticipantsCount: count,
         ),
-      );
-    }
+      ),
+    );
   }
 
   @override

--- a/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -22,7 +19,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   const CeremonyStep2Scan(
     this.store,
     this.api, {
-    required this.claim,
+    required this.claimantAddress,
     required this.confirmedParticipantsCount,
     Key? key,
   }) : super(key: key);
@@ -30,7 +27,7 @@ class CeremonyStep2Scan extends StatelessWidget {
   final AppStore store;
   final Api api;
 
-  final Future<Uint8List> claim;
+  final String claimantAddress;
   final int confirmedParticipantsCount;
 
   @override
@@ -73,18 +70,9 @@ class CeremonyStep2Scan extends StatelessWidget {
                   const SizedBox(height: 12),
                   // Enhance brightness for the QR-code
                   const WakeLockAndBrightnessEnhancer(brightness: 1),
-                  FutureBuilder<Uint8List>(
-                    future: claim,
-                    builder: (_, AsyncSnapshot<Uint8List> snapshot) {
-                      if (snapshot.hasData) {
-                        return QrCodeImage(
-                          qrCode: base64.encode(snapshot.data!),
-                          errorCorrectionLevel: QrErrorCorrectLevel.L,
-                        );
-                      } else {
-                        return const CupertinoActivityIndicator();
-                      }
-                    },
+                  QrCodeImage(
+                    qrCode: claimantAddress,
+                    errorCorrectionLevel: QrErrorCorrectLevel.L,
                   ),
                 ],
               ),

--- a/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -7,10 +5,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-import 'package:encointer_wallet/models/claim_of_attendance/claim_of_attendance.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
-import 'package:encointer_wallet/service/substrate_api/api.dart';
-import 'package:encointer_wallet/service/substrate_api/codec_api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
@@ -132,17 +127,6 @@ class ScanClaimQrCode extends StatelessWidget {
       ),
     );
   }
-}
-
-void _showActivityIndicatorOverlay(BuildContext context) {
-  showCupertinoDialog(
-    context: context,
-    builder: (_) => Container(
-        height: Size.infinite.height,
-        width: Size.infinite.width,
-        color: Colors.grey.withOpacity(0.5),
-        child: const CupertinoActivityIndicator()),
-  );
 }
 
 Future<PermissionStatus> canOpenCamera() async {

--- a/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -129,7 +129,7 @@ Future<void> submitRegisterParticipant(BuildContext context, AppStore store, Api
 Future<void> submitAttestClaims(BuildContext context, AppStore store, Api api) async {
   final params = attestAttendeesParams(
     store.encointer.chosenCid!,
-    store.encointer.communityAccount!.scannedAttendeesCount,
+    store.encointer.communityAccount!.participantCountVote!,
     store.encointer.communityAccount!.attendees!.toList(),
   );
 

--- a/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.dart
@@ -53,6 +53,10 @@ abstract class _CommunityAccountStore with Store {
   @observable
   ObservableSet<String>? attendees = ObservableSet();
 
+  /// Our vote on the number of meetup attendees
+  @observable
+  int? participantCountVote;
+
   /// This should be set to true once the attestations have been sent to chain.
   @observable
   bool? meetupCompleted = false;
@@ -68,8 +72,15 @@ abstract class _CommunityAccountStore with Store {
 
   @action
   void setParticipantType([ParticipantType? type]) {
-    Log.d('Set participant type: $participantType', 'CommunityAccountStore');
+    Log.d('Set participant type: $type', 'CommunityAccountStore');
     participantType = type;
+    writeToCache();
+  }
+
+  @action
+  void setParticipantCountVote(int vote) {
+    Log.d('Set participantCountVote: $vote', 'CommunityAccountStore');
+    participantCountVote = vote;
     writeToCache();
   }
 
@@ -101,6 +112,15 @@ abstract class _CommunityAccountStore with Store {
     Log.d('clearing meetupCompleted', 'CommunityAccountStore');
     meetupCompleted = false;
     writeToCache();
+  }
+
+  @action
+  void purgeParticipantCountVote() {
+    if (participantCountVote != null) {
+      Log.d('Purging participantCountVote.', 'CommunityAccountStore');
+      participantCountVote = null;
+      writeToCache();
+    }
   }
 
   @action

--- a/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.g.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_account_store/community_account_store.g.dart
@@ -16,6 +16,7 @@ CommunityAccountStore _$CommunityAccountStoreFromJson(Map<String, dynamic> json)
       ..attendees = json['attendees'] != null
           ? ObservableSet<String>.of((json['attendees'] as List).map((e) => e as String))
           : null
+      ..participantCountVote = json['participantCountVote'] as int?
       ..meetupCompleted = json['meetupCompleted'] as bool?;
 
 Map<String, dynamic> _$CommunityAccountStoreToJson(CommunityAccountStore instance) => <String, dynamic>{
@@ -25,6 +26,7 @@ Map<String, dynamic> _$CommunityAccountStoreToJson(CommunityAccountStore instanc
       'participantType': _$ParticipantTypeEnumMap[instance.participantType],
       'meetup': instance.meetup?.toJson(),
       'attendees': instance.attendees?.toList(),
+      'participantCountVote': instance.participantCountVote,
       'meetupCompleted': instance.meetupCompleted,
     };
 
@@ -106,6 +108,21 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
     });
   }
 
+  late final _$participantCountVoteAtom = Atom(name: '_CommunityAccountStore.participantCountVote', context: context);
+
+  @override
+  int? get participantCountVote {
+    _$participantCountVoteAtom.reportRead();
+    return super.participantCountVote;
+  }
+
+  @override
+  set participantCountVote(int? value) {
+    _$participantCountVoteAtom.reportWrite(value, super.participantCountVote, () {
+      super.participantCountVote = value;
+    });
+  }
+
   late final _$meetupCompletedAtom = Atom(name: '_CommunityAccountStore.meetupCompleted', context: context);
 
   @override
@@ -130,6 +147,17 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
         _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.setParticipantType');
     try {
       return super.setParticipantType(type);
+    } finally {
+      _$_CommunityAccountStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void setParticipantCountVote(int vote) {
+    final _$actionInfo =
+        _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.setParticipantCountVote');
+    try {
+      return super.setParticipantCountVote(vote);
     } finally {
       _$_CommunityAccountStoreActionController.endAction(_$actionInfo);
     }
@@ -173,6 +201,17 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
         _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.clearMeetupCompleted');
     try {
       return super.clearMeetupCompleted();
+    } finally {
+      _$_CommunityAccountStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void purgeParticipantCountVote() {
+    final _$actionInfo =
+        _$_CommunityAccountStoreActionController.startAction(name: '_CommunityAccountStore.purgeParticipantCountVote');
+    try {
+      return super.purgeParticipantCountVote();
     } finally {
       _$_CommunityAccountStoreActionController.endAction(_$actionInfo);
     }
@@ -228,6 +267,7 @@ mixin _$CommunityAccountStore on _CommunityAccountStore, Store {
 participantType: ${participantType},
 meetup: ${meetup},
 attendees: ${attendees},
+participantCountVote: ${participantCountVote},
 meetupCompleted: ${meetupCompleted},
 scannedAttendeesCount: ${scannedAttendeesCount},
 isAssigned: ${isAssigned},

--- a/lib/utils/translations/translations_encointer.dart
+++ b/lib/utils/translations/translations_encointer.dart
@@ -77,7 +77,7 @@ class TranslationsEnEncointer implements TranslationsEncointer {
   @override
   String get claimsScannedAlready => 'Updated previously scanned claim';
   @override
-  String get claimsScannedDecodeFailed => 'Could not decode scanned claim.';
+  String get claimsScannedDecodeFailed => 'Could not decode scanned claim. The other party needs to update the App.';
   @override
   String get claimsScannedNew => 'Scanned new claim';
   @override
@@ -181,7 +181,8 @@ class TranslationsDeEncointer implements TranslationsEncointer {
   @override
   String get claimsScannedAlready => 'bereits gescannter Antrag wurde aktualisiert';
   @override
-  String get claimsScannedDecodeFailed => 'Gescannter Antrag konnte nicht dekodiert werden.';
+  String get claimsScannedDecodeFailed =>
+      'Gescannter Antrag konnte nicht dekodiert werden. Dein Gegenüber muss die App updaten.';
   @override
   String get claimsScannedNew => 'Neuer Antrag gescannt';
   @override

--- a/test/store/encointer/sub_stores/community_store/community_account_store_test.dart
+++ b/test/store/encointer/sub_stores/community_store/community_account_store_test.dart
@@ -28,6 +28,7 @@ void main() {
           'registry': [ALICE_ADDRESS, BOB_ADDRESS, CHARLIE_ADDRESS]
         },
         'attendees': [],
+        'participantCountVote': null,
         'meetupCompleted': false
       };
 
@@ -87,6 +88,7 @@ void main() {
           'registry': [ALICE_ADDRESS, BOB_ADDRESS, CHARLIE_ADDRESS]
         },
         'attendees': [],
+        'participantCountVote': null,
         'meetupCompleted': false
       };
 


### PR DESCRIPTION
Changes:

### Send Correct Vote with `attestAttendees`
In v1.8.9 a change was introduced when submitting the claim of attendances. This change introduced an error: Instead of the `vote` on how many participants are attending the meetup, we simply sent the number of scanned claims of attendance to the chain, which is `vote -1`. This does not lead to an invalid meetup, the checks allow for this discrepancy of one. However, this does not suffice as a condition for the early payout. So the early payout was broken with the version v1.8.9 and v1.8.10. This PR fixes that: Closes #866 

### Display ClaimV2 and remove backwards compatibility
Show the new ClaimV2 instead of the old claim: This removes backwards compatibility with app versions ≤ v1.8.10. However, the blockchain fails to handle meetups with mixed app versions where one submit claims with `attestClaims` the other with `attestAttendees`. Hence, it is better to fail on the client side. If a ClaimV2-phone scans a ClaimV1, a Snack Bar is shown, saying that the user providing the QR-code needs to update the app. If a ClaimV1 phone scans a ClaimV2, it will just show that the claim can't be decoded. Unfortunately, we can't do this one better. However, this way we can ensure that the meetup will not fail silently.