### PR TITLE
Fix localization

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,22 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 
 import 'package:encointer_wallet/common/theme.dart';
+import 'package:encointer_wallet/modules/modules.dart';
 import 'package:encointer_wallet/router/app_router.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/snack_bar.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 
-class WalletApp extends StatefulWidget {
+class WalletApp extends StatelessWidget {
   const WalletApp({Key? key}) : super(key: key);
-
-  @override
-  State<WalletApp> createState() => _WalletAppState();
-}
-
-class _WalletAppState extends State<WalletApp> {
-  final Locale _locale = const Locale('en', '');
 
   @override
   Widget build(BuildContext context) {
@@ -29,23 +24,23 @@ class _WalletAppState extends State<WalletApp> {
           FocusManager.instance.primaryFocus!.unfocus();
         }
       },
-      child: MaterialApp(
-        title: 'EncointerWallet',
-        localizationsDelegates: [
-          AppLocalizationsDelegate(_locale),
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        supportedLocales: [
-          const Locale('en', ''),
-          const Locale('de', ''),
-        ],
-        initialRoute: context.watch<AppStore>().config.initialRoute,
-        theme: appThemeEncointer,
-        scaffoldMessengerKey: rootScaffoldMessengerKey,
-        onGenerateRoute: AppRoute.onGenerateRoute,
-      ),
+      child: Observer(builder: (_) {
+        return MaterialApp(
+          title: 'EncointerWallet',
+          locale: context.watch<SettingsStore2>().locale,
+          localizationsDelegates: [
+            AppLocalizationsDelegate(context.watch<SettingsStore2>().locale),
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          supportedLocales: context.watch<SettingsStore2>().locales,
+          initialRoute: context.watch<AppStore>().config.initialRoute,
+          theme: appThemeEncointer,
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          onGenerateRoute: AppRoute.onGenerateRoute,
+        );
+      }),
     );
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -27,14 +27,14 @@ class WalletApp extends StatelessWidget {
       child: Observer(builder: (_) {
         return MaterialApp(
           title: 'EncointerWallet',
-          locale: context.watch<SettingsStore2>().locale,
+          locale: context.watch<AppSettings>().locale,
           localizationsDelegates: [
-            AppLocalizationsDelegate(context.watch<SettingsStore2>().locale),
+            AppLocalizationsDelegate(context.watch<AppSettings>().locale),
             GlobalMaterialLocalizations.delegate,
             GlobalCupertinoLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
           ],
-          supportedLocales: context.watch<SettingsStore2>().locales,
+          supportedLocales: context.watch<AppSettings>().locales,
           initialRoute: context.watch<AppStore>().config.initialRoute,
           theme: appThemeEncointer,
           scaffoldMessengerKey: rootScaffoldMessengerKey,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,8 +56,8 @@ Future<void> main() async {
   runApp(
     MultiProvider(
       providers: [
-        Provider<SettingsStore2>(
-          create: (context) => SettingsStore2(localService)..init(),
+        Provider<AppSettings>(
+          create: (context) => AppSettings(localService)..init(),
         ),
         Provider<AppStore>(
           // On test mode instead of LocalStorage() must be use MockLocalStorage()

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,11 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:encointer_wallet/app.dart';
 import 'package:encointer_wallet/config.dart';
+import 'package:encointer_wallet/modules/modules.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/notification.dart';
 import 'package:encointer_wallet/service/subscan.dart';
@@ -49,10 +51,19 @@ Future<void> main() async {
 
   HttpOverrides.global = MyHttpOverrides();
 
+  final localService = LangService(await SharedPreferences.getInstance());
+
   runApp(
-    Provider(
-      // On test mode instead of LocalStorage() must be use MockLocalStorage()
-      create: (context) => AppStore(util.LocalStorage(), config: const AppConfig()),
+    MultiProvider(
+      providers: [
+        Provider<SettingsStore2>(
+          create: (context) => SettingsStore2(localService)..init(),
+        ),
+        Provider<AppStore>(
+          // On test mode instead of LocalStorage() must be use MockLocalStorage()
+          create: (context) => AppStore(util.LocalStorage(), config: const AppConfig()),
+        )
+      ],
       child: const WalletApp(),
     ),
   );

--- a/lib/modules/modules.dart
+++ b/lib/modules/modules.dart
@@ -1,2 +1,3 @@
 export 'instruction/instruction.dart';
 export 'splash/splash.dart';
+export 'settings/settings.dart';

--- a/lib/modules/settings/logic/app_settings_store.dart
+++ b/lib/modules/settings/logic/app_settings_store.dart
@@ -6,12 +6,12 @@ import 'package:mobx/mobx.dart';
 
 import 'package:encointer_wallet/modules/settings/settings.dart';
 
-part 'settings_store.g.dart';
+part 'app_settings_store.g.dart';
 
-class SettingsStore2 = _SettingsStore2Base with _$SettingsStore2;
+class AppSettings = _AppSettingsBase with _$AppSettings;
 
-abstract class _SettingsStore2Base with Store {
-  _SettingsStore2Base(this._service);
+abstract class _AppSettingsBase with Store {
+  _AppSettingsBase(this._service);
 
   final LangService _service;
 

--- a/lib/modules/settings/logic/app_settings_store.g.dart
+++ b/lib/modules/settings/logic/app_settings_store.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'settings_store.dart';
+part of 'app_settings_store.dart';
 
 // **************************************************************************
 // StoreGenerator
@@ -8,14 +8,14 @@ part of 'settings_store.dart';
 
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
-mixin _$SettingsStore2 on _SettingsStore2Base, Store {
+mixin _$AppSettings on _AppSettingsBase, Store {
   Computed<Locale>? _$localeComputed;
 
   @override
   Locale get locale =>
-      (_$localeComputed ??= Computed<Locale>(() => super.locale, name: '_SettingsStore2Base.locale')).value;
+      (_$localeComputed ??= Computed<Locale>(() => super.locale, name: '_AppSettingsBase.locale')).value;
 
-  late final _$_localeAtom = Atom(name: '_SettingsStore2Base._locale', context: context);
+  late final _$_localeAtom = Atom(name: '_AppSettingsBase._locale', context: context);
 
   @override
   Locale get _locale {
@@ -30,22 +30,22 @@ mixin _$SettingsStore2 on _SettingsStore2Base, Store {
     });
   }
 
-  late final _$setLocaleAsyncAction = AsyncAction('_SettingsStore2Base.setLocale', context: context);
+  late final _$setLocaleAsyncAction = AsyncAction('_AppSettingsBase.setLocale', context: context);
 
   @override
   Future<void> setLocale(int index) {
     return _$setLocaleAsyncAction.run(() => super.setLocale(index));
   }
 
-  late final _$_SettingsStore2BaseActionController = ActionController(name: '_SettingsStore2Base', context: context);
+  late final _$_AppSettingsBaseActionController = ActionController(name: '_AppSettingsBase', context: context);
 
   @override
   void init() {
-    final _$actionInfo = _$_SettingsStore2BaseActionController.startAction(name: '_SettingsStore2Base.init');
+    final _$actionInfo = _$_AppSettingsBaseActionController.startAction(name: '_AppSettingsBase.init');
     try {
       return super.init();
     } finally {
-      _$_SettingsStore2BaseActionController.endAction(_$actionInfo);
+      _$_AppSettingsBaseActionController.endAction(_$actionInfo);
     }
   }
 

--- a/lib/modules/settings/logic/settings_store.dart
+++ b/lib/modules/settings/logic/settings_store.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: library_private_types_in_public_api
+
+import 'dart:ui';
+
+import 'package:mobx/mobx.dart';
+
+import 'package:encointer_wallet/modules/settings/settings.dart';
+
+part 'settings_store.g.dart';
+
+class SettingsStore2 = _SettingsStore2Base with _$SettingsStore2;
+
+abstract class _SettingsStore2Base with Store {
+  _SettingsStore2Base(this._service);
+
+  final LangService _service;
+
+  @observable
+  Locale _locale = const Locale('en');
+
+  final locales = const <Locale>[
+    Locale('en', ''),
+    Locale('de', ''),
+    // Locale('fr', ''),
+    Locale('ru', ''),
+  ];
+
+  @computed
+  Locale get locale => _locale;
+
+  @action
+  void init() => _locale = _service.init();
+
+  @action
+  Future<void> setLocale(int index) async {
+    _locale = await _service.setLocale(index, locales);
+  }
+
+  String getName(String code) => _service.getName(code);
+}

--- a/lib/modules/settings/logic/settings_store.g.dart
+++ b/lib/modules/settings/logic/settings_store.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settings_store.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
+
+mixin _$SettingsStore2 on _SettingsStore2Base, Store {
+  Computed<Locale>? _$localeComputed;
+
+  @override
+  Locale get locale =>
+      (_$localeComputed ??= Computed<Locale>(() => super.locale, name: '_SettingsStore2Base.locale')).value;
+
+  late final _$_localeAtom = Atom(name: '_SettingsStore2Base._locale', context: context);
+
+  @override
+  Locale get _locale {
+    _$_localeAtom.reportRead();
+    return super._locale;
+  }
+
+  @override
+  set _locale(Locale value) {
+    _$_localeAtom.reportWrite(value, super._locale, () {
+      super._locale = value;
+    });
+  }
+
+  late final _$setLocaleAsyncAction = AsyncAction('_SettingsStore2Base.setLocale', context: context);
+
+  @override
+  Future<void> setLocale(int index) {
+    return _$setLocaleAsyncAction.run(() => super.setLocale(index));
+  }
+
+  late final _$_SettingsStore2BaseActionController = ActionController(name: '_SettingsStore2Base', context: context);
+
+  @override
+  void init() {
+    final _$actionInfo = _$_SettingsStore2BaseActionController.startAction(name: '_SettingsStore2Base.init');
+    try {
+      return super.init();
+    } finally {
+      _$_SettingsStore2BaseActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  String toString() {
+    return '''
+locale: ${locale}
+    ''';
+  }
+}

--- a/lib/modules/settings/service/lang_service.dart
+++ b/lib/modules/settings/service/lang_service.dart
@@ -1,0 +1,46 @@
+import 'dart:ui';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LangService {
+  const LangService(this.storage);
+
+  final SharedPreferences storage;
+
+  static const String localStorageLocaleKey = 'locale';
+
+  Locale init() {
+    final code = storage.getString(localStorageLocaleKey);
+    if (code != null) {
+      return Locale(code);
+    } else {
+      final deviceLocal = window.locale.languageCode;
+      if (deviceLocal == 'en' || deviceLocal == 'de' || deviceLocal == 'ru') {
+        return Locale(deviceLocal);
+      } else {
+        return const Locale('en');
+      }
+    }
+  }
+
+  Future<Locale> setLocale(int index, List<Locale> locales) async {
+    await storage.remove(localStorageLocaleKey);
+    await storage.setString(localStorageLocaleKey, locales[index].languageCode);
+    return locales[index];
+  }
+
+  String getName(String code) {
+    switch (code) {
+      case 'en':
+        return 'English';
+      case 'de':
+        return 'Deutch';
+      case 'fr':
+        return 'Français';
+      case 'ru':
+        return 'Русский';
+      default:
+        return '';
+    }
+  }
+}

--- a/lib/modules/settings/settings.dart
+++ b/lib/modules/settings/settings.dart
@@ -1,3 +1,3 @@
-export 'logic/settings_store.dart';
+export 'logic/app_settings_store.dart';
 export 'service/lang_service.dart';
 export 'view/lang_page.dart';

--- a/lib/modules/settings/settings.dart
+++ b/lib/modules/settings/settings.dart
@@ -1,0 +1,3 @@
+export 'logic/settings_store.dart';
+export 'service/lang_service.dart';
+export 'view/lang_page.dart';

--- a/lib/modules/settings/view/lang_page.dart
+++ b/lib/modules/settings/view/lang_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:provider/provider.dart';
+
+import 'package:encointer_wallet/modules/modules.dart';
+import 'package:encointer_wallet/utils/translations/index.dart';
+
+class LangPage extends StatefulWidget {
+  const LangPage({Key? key}) : super(key: key);
+
+  static const route = '/lang-page';
+
+  @override
+  State<LangPage> createState() => _LangPageState();
+}
+
+class _LangPageState extends State<LangPage> {
+  @override
+  Widget build(BuildContext context) {
+    final dic = I18n.of(context)!.translationsForLocale().profile;
+    final settings = context.watch<SettingsStore2>();
+    return Scaffold(
+      appBar: AppBar(title: Text(dic.settingLang)),
+      body: Observer(builder: (_) {
+        return ListView.builder(
+          itemCount: settings.locales.length,
+          itemBuilder: (BuildContext context, int index) {
+            final lang = settings.getName(settings.locales[index].languageCode);
+            return RadioListTile(
+              title: Text(lang),
+              value: settings.locales[index],
+              groupValue: settings.locale,
+              onChanged: (v) async {
+                await context.read<SettingsStore2>().setLocale(index);
+              },
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/modules/settings/view/lang_page.dart
+++ b/lib/modules/settings/view/lang_page.dart
@@ -18,7 +18,7 @@ class _LangPageState extends State<LangPage> {
   @override
   Widget build(BuildContext context) {
     final dic = I18n.of(context)!.translationsForLocale().profile;
-    final settings = context.watch<SettingsStore2>();
+    final settings = context.watch<AppSettings>();
     return Scaffold(
       appBar: AppBar(title: Text(dic.settingLang)),
       body: Observer(builder: (_) {
@@ -31,7 +31,7 @@ class _LangPageState extends State<LangPage> {
               value: settings.locales[index],
               groupValue: settings.locale,
               onChanged: (v) async {
-                await context.read<SettingsStore2>().setLocale(index);
+                await context.read<AppSettings>().setLocale(index);
               },
             );
           },

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -192,6 +192,10 @@ class _ProfileState extends State<Profile> {
                 onTap: () => Navigator.pushNamed(context, Instruction.route),
               ),
               ListTile(
+                title: Text(dic.profile.settingLang, style: h3Grey),
+                onTap: () => Navigator.pushNamed(context, LangPage.route),
+              ),
+              ListTile(
                 title: Text(dic.profile.contactUs, style: h3Grey),
                 onTap: _sendEmail,
               ),

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -193,6 +193,11 @@ class AppRoute {
           builder: (_) => const Instruction(),
           settings: settings,
         );
+      case LangPage.route:
+        return CupertinoPageRoute(
+          builder: (_) => const LangPage(),
+          settings: settings,
+        );
       default:
         throw Exception(
           'no builder specified for route named: [${settings.name}]',

--- a/lib/utils/translations/index.dart
+++ b/lib/utils/translations/index.dart
@@ -42,5 +42,4 @@ class I18n {
     var translations = supportedLocales[locale];
     return translations ?? TranslationsEn();
   }
-  
 }

--- a/lib/utils/translations/index.dart
+++ b/lib/utils/translations/index.dart
@@ -10,7 +10,7 @@ class AppLocalizationsDelegate extends LocalizationsDelegate<I18n> {
   final Locale overriddenLocale;
 
   @override
-  bool isSupported(Locale locale) => ['en', 'de', 'fr'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => ['en', 'de', 'fr', 'ru'].contains(locale.languageCode);
 
   @override
   Future<I18n> load(Locale locale) {
@@ -42,4 +42,5 @@ class I18n {
     var translations = supportedLocales[locale];
     return translations ?? TranslationsEn();
   }
+  
 }

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:upgrader/upgrader.dart';
 
 import 'package:encointer_wallet/app.dart';
@@ -10,6 +11,7 @@ import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/mocks/storage/mock_local_storage.dart';
 import 'package:encointer_wallet/mocks/storage/mock_storage_setup.dart';
 import 'package:encointer_wallet/mocks/storage/prepare_mock_storage.dart';
+import 'package:encointer_wallet/modules/modules.dart';
 import 'package:encointer_wallet/store/app.dart';
 
 void main() async {
@@ -54,12 +56,21 @@ void main() async {
 
   // Clear settings to make upgrade dialog visible in subsequent test runs.
   await Upgrader.clearSavedSettings();
+  final localService = LangService(await SharedPreferences.getInstance());
 
   // Call the `main()` function of the app, or call `runApp` with
   // any widget you are interested in testing.
   runApp(
-    Provider(
-      create: (context) => _globalAppStore,
+    MultiProvider(
+      providers: [
+        Provider<SettingsStore2>(
+          create: (context) => SettingsStore2(localService)..init(),
+        ),
+        Provider<AppStore>(
+          // On test mode instead of LocalStorage() must be use MockLocalStorage()
+          create: (context) => _globalAppStore,
+        )
+      ],
       child: const WalletApp(),
     ),
   );

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -63,8 +63,8 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
-        Provider<SettingsStore2>(
-          create: (context) => SettingsStore2(localService)..init(),
+        Provider<AppSettings>(
+          create: (context) => AppSettings(localService)..init(),
         ),
         Provider<AppStore>(
           // On test mode instead of LocalStorage() must be use MockLocalStorage()

--- a/test_driver/app_test.dart
+++ b/test_driver/app_test.dart
@@ -1,8 +1,9 @@
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
 import 'package:encointer_wallet/mocks/data/mock_account_data.dart';
 import 'package:encointer_wallet/mocks/storage/mock_storage_setup.dart';
 import 'package:encointer_wallet/utils/screenshot.dart';
-import 'package:flutter_driver/flutter_driver.dart';
-import 'package:test/test.dart';
 
 void main() {
   FlutterDriver? driver;


### PR DESCRIPTION
### Fix localization
Yes I created new `AppSettings` because our `SettingsStore` and `AppStore` are very captivated by each other and when did little change app gave me more error 😓😓😓. I think we need to slowly divide our stores. How do you think?

Completed:
- [x] If user download app and his device locale is (`en, de, ru`) used device locale if not used `en`
- [x] Create age for change language 
- [x] When user change language application cache language code and when user open app again used cached locale code 
