### PR TITLE
[GA] run an encointer-node in the CI for an actual integration test.

### DIFF
--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Run encointer-node
         run: |
+          ls -alt
           cd demo_package
           ls -alt
           chmod +x encointer-node-notee

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -34,9 +34,6 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/checkout@v2
-        with:
-          # 2 to compare the last two revisions to check if JS changed
-          fetch-depth: 2
 
       - uses: monorepo-actions/config-for-actions@main
         id: config

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -50,10 +50,10 @@ jobs:
           # set the `run_id` to force a download of an updated binary.
           run_id: 3553681091
           repo: encointer/encointer-node
+          path: demo_package
 
       - name: Run encointer-node
         run: |
-          ls -alt
           cd demo_package
           ls -alt
           chmod +x encointer-node-notee

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -40,6 +40,28 @@ jobs:
         with:
           config_files: ./.github/action-config.json
 
+      - name: Download encointer-node
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build-and-test.yml
+          name: demo_package
+          # in fact this action should download the latest artifact, but sometimes fails. Then we need to
+          # set the `run_id` to force a download of an updated binary.
+          run_id: 3553681091
+          repo: encointer/encointer-node
+
+      - name: Run encointer-node
+        run: |
+          cd demo_package
+          ls -alt
+          chmod +x encointer-node-notee
+          chmod +x encointer-client-notee
+          ./node/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
+          sleep 10
+          cd client
+          ./bootstrap_demo_community.py --client ../encointer-client-notee
+
 #      - uses: actions/setup-java@v1
 #        with:
 #          java-version: ${{ steps.config.outputs.java-version }}

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -62,6 +62,8 @@ jobs:
           ./encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
           sleep 10
           cd client
+          # taken from https://github.com/encointer/encointer-node/blob/master/scripts/install_python_deps.sh
+          pip install geojson pyproj RandomWords wonderwords requests flask substrate-interface click
           ./bootstrap_demo_community.py --client ../encointer-client-notee
 
 #      - uses: actions/setup-java@v1

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -40,74 +40,74 @@ jobs:
         with:
           config_files: ./.github/action-config.json
 
-      - uses: actions/setup-java@v1
-        with:
-          java-version: ${{ steps.config.outputs.java-version }}
-
-      - name: Install flutter wrapper
-        run: ./scripts/install_flutter.sh
-
-      - name: Setup Android SDK and accept licences
-        uses: android-actions/setup-android@v2
-
-      - name: List android images
-        run: sdkmanager --list | grep system-images
-
-      # JS Stuff
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.config.outputs.node-version }}
-
-      - name: "Build JS"
-        working-directory: ./scripts
-        run: source ./init_env.sh && ./build_js.sh
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
-
-      - name: AVD cache
-        uses: actions/cache@v2
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ matrix.device }}
-
-      - name: "Create AVD and generate a clean snapshot for caching"
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          profile: ${{ matrix.device }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: "Android Integration Tests"
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          ANDROID_DEBUG: "true"
-          RECORD: ${{ matrix.record_video }}
-          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
-        with:
-          api-level: ${{ matrix.api-level }}
-          profile: ${{ matrix.device }}
-          force-avd-creation: false
-          # as we use the cleanly cached emulator, we need to define `-no-snapshot-save` here.
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./scripts/android_integration_test.sh
-
-      - name: "Upload screenshots"
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.device }}
-          path: ${{ steps.config.outputs.temp-screenshots }}
+#      - uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ steps.config.outputs.java-version }}
+#
+#      - name: Install flutter wrapper
+#        run: ./scripts/install_flutter.sh
+#
+#      - name: Setup Android SDK and accept licences
+#        uses: android-actions/setup-android@v2
+#
+#      - name: List android images
+#        run: sdkmanager --list | grep system-images
+#
+#      # JS Stuff
+#      - uses: actions/setup-node@v2
+#        with:
+#          node-version: ${{ steps.config.outputs.node-version }}
+#
+#      - name: "Build JS"
+#        working-directory: ./scripts
+#        run: source ./init_env.sh && ./build_js.sh
+#
+#      - name: Gradle cache
+#        uses: actions/cache@v2
+#        with:
+#          path: |
+#            ~/.gradle/caches
+#            ~/.gradle/wrapper
+#          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+#
+#      - name: AVD cache
+#        uses: actions/cache@v2
+#        id: avd-cache
+#        with:
+#          path: |
+#            ~/.android/avd/*
+#            ~/.android/adb*
+#          key: avd-${{ matrix.api-level }}-${{ matrix.device }}
+#
+#      - name: "Create AVD and generate a clean snapshot for caching"
+#        if: steps.avd-cache.outputs.cache-hit != 'true'
+#        uses: reactivecircus/android-emulator-runner@v2
+#        with:
+#          api-level: ${{ matrix.api-level }}
+#          profile: ${{ matrix.device }}
+#          force-avd-creation: false
+#          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#          disable-animations: false
+#          script: echo "Generated AVD snapshot for caching."
+#
+#      - name: "Android Integration Tests"
+#        uses: reactivecircus/android-emulator-runner@v2
+#        env:
+#          ANDROID_DEBUG: "true"
+#          RECORD: ${{ matrix.record_video }}
+#          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
+#        with:
+#          api-level: ${{ matrix.api-level }}
+#          profile: ${{ matrix.device }}
+#          force-avd-creation: false
+#          # as we use the cleanly cached emulator, we need to define `-no-snapshot-save` here.
+#          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+#          disable-animations: true
+#          script: ./scripts/android_integration_test.sh
+#
+#      - name: "Upload screenshots"
+#        if: always()
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ matrix.device }}
+#          path: ${{ steps.config.outputs.temp-screenshots }}

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -58,7 +58,8 @@ jobs:
           ls -alt
           chmod +x encointer-node-notee
           chmod +x encointer-client-notee
-          ./node/encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
+          chmod +x ./client/bootstrap_demo_community.py
+          ./encointer-node-notee --tmp --dev --enable-offchain-indexing true --rpc-methods unsafe &
           sleep 10
           cd client
           ./bootstrap_demo_community.py --client ../encointer-client-notee

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -52,7 +52,10 @@ jobs:
           repo: encointer/encointer-node
           path: demo_package
 
-      - name: Run encointer-node
+      - name: Run encointer-node & bootstrap demo community
+        # This whole thing should be heavily simplified, but we should refactor the stuff in the encointer-node
+        # repository to achieve that. Here, we just live with it for now. See
+        # https://github.com/encointer/encointer-node/issues/271
         run: |
           cd demo_package
           ls -alt
@@ -63,7 +66,7 @@ jobs:
           sleep 10
           cd client
           # taken from https://github.com/encointer/encointer-node/blob/master/scripts/install_python_deps.sh
-          pip install geojson pyproj RandomWords wonderwords requests flask substrate-interface click
+          pip install geojson requests click
           ./bootstrap_demo_community.py --client ../encointer-client-notee
 
 #      - uses: actions/setup-java@v1

--- a/.github/workflows/ios_integration_test.yaml
+++ b/.github/workflows/ios_integration_test.yaml
@@ -33,9 +33,6 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/checkout@v2
-        with:
-          # 2 to compare the last two revisions to check if JS changed
-          fetch-depth: 2
 
       - uses: monorepo-actions/config-for-actions@main
         id: config

--- a/.github/workflows/ios_integration_test.yaml
+++ b/.github/workflows/ios_integration_test.yaml
@@ -34,55 +34,55 @@ jobs:
       # Setup Environment
       - uses: actions/checkout@v2
 
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
-
-      - name: "Prepare environment for ios"
-        working-directory: ./scripts
-        run: ./ios_init_env.sh
-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: ${{ steps.config.outputs.java-version }}
-
-      - name: Install flutter wrapper
-        run: ./scripts/install_flutter.sh
-
-      - name: "Create Simulator if iPad Pro 2nd gen"
-        if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
-
-      - name: "Create Simulator if iPad Pro 3rd gen"
-        if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
-
-      - name: "Start Simulator"
-        working-directory: ./scripts
-        env:
-          DEVICE_ID: ${{ matrix.device }}
-        run: source ./ios_emulator.sh
-
-        # JS Stuff
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.config.outputs.node-version }}
-
-      - name: "Build JS"
-        working-directory: ./scripts
-        run: source ./init_env.sh && ./build_js.sh
-
-        # Run Tests
-      - name: "Flutter driver test and record video"
-        run: ./scripts/ios_integration_test.sh
-        env:
-          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
-          RECORD: ${{ matrix.record_video }}
-
-      - name: "Upload screenshots and recording"
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.device }}
-          path: ${{ steps.config.outputs.temp-screenshots }}
+#      - uses: monorepo-actions/config-for-actions@main
+#        id: config
+#        with:
+#          config_files: ./.github/action-config.json
+#
+#      - name: "Prepare environment for ios"
+#        working-directory: ./scripts
+#        run: ./ios_init_env.sh
+#
+#      - uses: actions/setup-java@v1
+#        with:
+#          java-version: ${{ steps.config.outputs.java-version }}
+#
+#      - name: Install flutter wrapper
+#        run: ./scripts/install_flutter.sh
+#
+#      - name: "Create Simulator if iPad Pro 2nd gen"
+#        if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
+#        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
+#
+#      - name: "Create Simulator if iPad Pro 3rd gen"
+#        if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
+#        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
+#
+#      - name: "Start Simulator"
+#        working-directory: ./scripts
+#        env:
+#          DEVICE_ID: ${{ matrix.device }}
+#        run: source ./ios_emulator.sh
+#
+#        # JS Stuff
+#      - uses: actions/setup-node@v2
+#        with:
+#          node-version: ${{ steps.config.outputs.node-version }}
+#
+#      - name: "Build JS"
+#        working-directory: ./scripts
+#        run: source ./init_env.sh && ./build_js.sh
+#
+#        # Run Tests
+#      - name: "Flutter driver test and record video"
+#        run: ./scripts/ios_integration_test.sh
+#        env:
+#          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
+#          RECORD: ${{ matrix.record_video }}
+#
+#      - name: "Upload screenshots and recording"
+#        if: always()
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ matrix.device }}
+#          path: ${{ steps.config.outputs.temp-screenshots }}


### PR DESCRIPTION
This is currently blocked because the integration tests have to run on MacOs ..., see https://github.com/encointer/encointer-node/issues/278