### PR TITLE
Integration test

### DIFF
--- a/lib/common/components/address_input_field.dart
+++ b/lib/common/components/address_input_field.dart
@@ -123,27 +123,24 @@ class _AddressInputFieldState extends State<AddressInputField> {
       builder: (_) {
         final Map? accInfo = widget.store.account.addressIndexMap[item.pubKey];
         final String address = Fmt.addressOfAccount(item, widget.store);
-        return InkWell(
-          key: Key(item.name),
-          child: Container(
-            margin: const EdgeInsets.symmetric(horizontal: 8),
-            decoration: !isSelected
-                ? null
-                : BoxDecoration(
-                    border: Border.all(color: Theme.of(context).primaryColor),
-                    borderRadius: BorderRadius.circular(5),
-                    color: Colors.white,
-                  ),
-            child: ListTile(
-              selected: isSelected,
-              dense: true,
-              title: Text(Fmt.address(address)!),
-              subtitle: Text(
-                item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
-              ),
-              leading: CircleAvatar(
-                child: AddressIcon(item.address, item.pubKey),
-              ),
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: !isSelected
+              ? null
+              : BoxDecoration(
+                  border: Border.all(color: Theme.of(context).primaryColor),
+                  borderRadius: BorderRadius.circular(5),
+                  color: Colors.white,
+                ),
+          child: ListTile(
+            selected: isSelected,
+            dense: true,
+            title: Text(Fmt.address(address)!),
+            subtitle: Text(
+              item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
+            ),
+            leading: CircleAvatar(
+              child: AddressIcon(item.address, item.pubKey),
             ),
           ),
         );

--- a/lib/common/components/address_input_field.dart
+++ b/lib/common/components/address_input_field.dart
@@ -152,7 +152,6 @@ class _AddressInputFieldState extends State<AddressInputField> {
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context)!.translationsForLocale();
     return Container(
-      key: const Key('send-to-address'),
       decoration: BoxDecoration(
         color: ZurichLion.shade50,
         borderRadius: BorderRadius.circular(15),
@@ -163,7 +162,6 @@ class _AddressInputFieldState extends State<AddressInputField> {
           showSearchBox: true,
           showSelectedItems: true,
           itemBuilder: _listItemBuilder,
-          // modalBottomSheetProps: ModalBottomSheetProps()
         ),
         dropdownDecoratorProps: DropDownDecoratorProps(
           dropdownSearchDecoration: InputDecoration(

--- a/lib/common/components/address_input_field.dart
+++ b/lib/common/components/address_input_field.dart
@@ -1,4 +1,7 @@
 import 'package:dropdown_search/dropdown_search.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+
 import 'package:encointer_wallet/common/components/address_icon.dart';
 import 'package:encointer_wallet/common/theme.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
@@ -7,8 +10,6 @@ import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/translations/index.dart';
 import 'package:encointer_wallet/utils/translations/translations.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 
 class AddressInputField extends StatefulWidget {
   AddressInputField(this.store, {Key? key, this.label, this.initialValue, this.onChanged, this.hideIdenticon = false})
@@ -122,24 +123,27 @@ class _AddressInputFieldState extends State<AddressInputField> {
       builder: (_) {
         final Map? accInfo = widget.store.account.addressIndexMap[item.pubKey];
         final String address = Fmt.addressOfAccount(item, widget.store);
-        return Container(
-          margin: const EdgeInsets.symmetric(horizontal: 8),
-          decoration: !isSelected
-              ? null
-              : BoxDecoration(
-                  border: Border.all(color: Theme.of(context).primaryColor),
-                  borderRadius: BorderRadius.circular(5),
-                  color: Colors.white,
-                ),
-          child: ListTile(
-            selected: isSelected,
-            dense: true,
-            title: Text(Fmt.address(address)!),
-            subtitle: Text(
-              item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
-            ),
-            leading: CircleAvatar(
-              child: AddressIcon(item.address, item.pubKey),
+        return InkWell(
+          key: Key(item.name),
+          child: Container(
+            margin: const EdgeInsets.symmetric(horizontal: 8),
+            decoration: !isSelected
+                ? null
+                : BoxDecoration(
+                    border: Border.all(color: Theme.of(context).primaryColor),
+                    borderRadius: BorderRadius.circular(5),
+                    color: Colors.white,
+                  ),
+            child: ListTile(
+              selected: isSelected,
+              dense: true,
+              title: Text(Fmt.address(address)!),
+              subtitle: Text(
+                item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
+              ),
+              leading: CircleAvatar(
+                child: AddressIcon(item.address, item.pubKey),
+              ),
             ),
           ),
         );
@@ -151,6 +155,7 @@ class _AddressInputFieldState extends State<AddressInputField> {
   Widget build(BuildContext context) {
     final Translations dic = I18n.of(context)!.translationsForLocale();
     return Container(
+      key: const Key('send-to-address'),
       decoration: BoxDecoration(
         color: ZurichLion.shade50,
         borderRadius: BorderRadius.circular(15),
@@ -161,6 +166,7 @@ class _AddressInputFieldState extends State<AddressInputField> {
           showSearchBox: true,
           showSelectedItems: true,
           itemBuilder: _listItemBuilder,
+          // modalBottomSheetProps: ModalBottomSheetProps()
         ),
         dropdownDecoratorProps: DropDownDecoratorProps(
           dropdownSearchDecoration: InputDecoration(

--- a/lib/common/components/password_input_dialog.dart
+++ b/lib/common/components/password_input_dialog.dart
@@ -93,7 +93,7 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
       content: Padding(
         padding: const EdgeInsets.only(top: 16),
         child: CupertinoTextFormFieldRow(
-          key: const Key('input-passworf-dialod'),
+          key: const Key('input-password-dialog'),
           decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
           padding: EdgeInsets.zero,
           autofocus: true,

--- a/lib/common/components/password_input_dialog.dart
+++ b/lib/common/components/password_input_dialog.dart
@@ -94,6 +94,7 @@ class _PasswordInputDialogState extends State<PasswordInputDialog> {
       content: Padding(
         padding: const EdgeInsets.only(top: 16),
         child: CupertinoTextFormFieldRow(
+          key: const Key('input-passworf-dialod'),
           decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
           padding: EdgeInsets.zero,
           autofocus: true,

--- a/lib/page/assets/transfer/payment_confirmation_page/index.dart
+++ b/lib/page/assets/transfer/payment_confirmation_page/index.dart
@@ -112,7 +112,7 @@ class _PaymentConfirmationPageState extends State<PaymentConfirmationPage> with 
                 ),
                 !_transferState.isFinishedOrFailed()
                     ? PrimaryButton(
-                        key: const Key('make-transfer'),
+                        key: const Key('make-transfer-send'),
                         child: SizedBox(
                           height: 24,
                           child: !_transferState.isSubmitting()

--- a/lib/page/assets/transfer/transfer_page.dart
+++ b/lib/page/assets/transfer/transfer_page.dart
@@ -149,6 +149,7 @@ class _TransferPageState extends State<TransferPage> {
                 children: [
                   Expanded(
                     child: ListView(
+                      key: const Key('transfer-listview'),
                       children: [
                         CombinedCommunityAndAccountAvatar(_store, showCommunityNameAndAccountName: false),
                         const SizedBox(height: 12),

--- a/lib/page/profile/account/account_manage_page.dart
+++ b/lib/page/profile/account/account_manage_page.dart
@@ -63,6 +63,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
               onPressed: () => Navigator.of(context).pop(),
             ),
             CupertinoButton(
+              key: const Key('delete-account'),
               child: Text(I18n.of(context)!.translationsForLocale().home.ok),
               onPressed: () => {
                 _appStore.account.removeAccount(accountToBeEdited).then(
@@ -170,6 +171,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
         appBar: AppBar(
           title: _isEditingText
               ? TextFormField(
+                  key: const Key('account-name-field'),
                   controller: _nameCtrl,
                   validator: (v) =>
                       InputValidation.validateAccountName(context, v!, _appStore.account.optionalAccounts),
@@ -178,9 +180,8 @@ class _AccountManagePageState extends State<AccountManagePage> {
           actions: <Widget>[
             !_isEditingText
                 ? IconButton(
-                    icon: const Icon(
-                      Iconsax.edit,
-                    ),
+                    key: const Key('account-name-edit'),
+                    icon: const Icon(Iconsax.edit),
                     onPressed: () {
                       setState(() {
                         _isEditingText = true;
@@ -188,9 +189,8 @@ class _AccountManagePageState extends State<AccountManagePage> {
                     },
                   )
                 : IconButton(
-                    icon: const Icon(
-                      Icons.check,
-                    ),
+                    key: const Key('account-name-edit-check'),
+                    icon: const Icon(Icons.check),
                     onPressed: () {
                       _appStore.account.updateAccountName(accountToBeEdited, _nameCtrl!.text.trim());
                       setState(() {
@@ -267,6 +267,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
                   child: Row(
                     children: [
                       ElevatedButton(
+                        key: const Key('go-to-account-share'),
                         style: ElevatedButton.styleFrom(
                           padding: const EdgeInsets.all(16), // make splash animation as high as the container
                           backgroundColor: Colors.transparent,
@@ -288,7 +289,11 @@ class _AccountManagePageState extends State<AccountManagePage> {
                       Container(
                         child: PopupMenuButton<AccountAction>(
                             offset: const Offset(-10, -150),
-                            icon: const Icon(Iconsax.more, color: Colors.white),
+                            icon: const Icon(
+                              Iconsax.more,
+                              key: const Key('popup-menu-account-trash-export'),
+                              color: Colors.white,
+                            ),
                             color: ZurichLion.shade50,
                             padding: const EdgeInsets.all(20),
                             shape: RoundedRectangleBorder(
@@ -309,6 +314,7 @@ class _AccountManagePageState extends State<AccountManagePage> {
                                   AccountActionItemData(dic.profile.exportAccount, AccountAction.export),
                                 ]
                                     .map((AccountActionItemData data) => PopupMenuItem<AccountAction>(
+                                          key: Key(data.accountAction.name),
                                           value: data.accountAction,
                                           // https://github.com/flutter/flutter/issues/31247 as soon as we use a newer flutter version we might be able to add this to our theme.dart
                                           child: ListTileTheme(

--- a/lib/page/profile/account/export_result_page.dart
+++ b/lib/page/profile/account/export_result_page.dart
@@ -74,6 +74,7 @@ class ExportResultPage extends StatelessWidget {
                     padding: const EdgeInsets.all(16),
                     child: Text(
                       args['key'] as String,
+                      key: const Key('account-mnemonic-key'),
                       style: Theme.of(context).textTheme.headline4,
                     ),
                   ),

--- a/lib/page/profile/contacts/contact_detail_page.dart
+++ b/lib/page/profile/contacts/contact_detail_page.dart
@@ -115,6 +115,7 @@ class ContactDetailPage extends StatelessWidget {
               }),
               const SizedBox(height: 16),
               SecondaryButtonWide(
+                key: const Key('send-money-to-account'),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -169,6 +170,7 @@ class EndorseButton extends StatelessWidget {
     var dic = I18n.of(context)!.translationsForLocale();
 
     return SubmitButtonSecondary(
+      key: const Key('tap-endorse-button'),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/lib/page/profile/contacts/contacts_page.dart
+++ b/lib/page/profile/contacts/contacts_page.dart
@@ -50,6 +50,7 @@ class ContactsPage extends StatelessWidget {
                     trailing: SizedBox(
                       width: 36,
                       child: IconButton(
+                        key: Key(i.name),
                         icon: const Icon(Icons.arrow_forward_ios, size: 18),
                         onPressed: () => Navigator.of(context).pushNamed(ContactDetailPage.route, arguments: i),
                       ),

--- a/lib/page/profile/index.dart
+++ b/lib/page/profile/index.dart
@@ -42,6 +42,7 @@ class _ProfileState extends State<Profile> {
 
     allAccountsAsWidgets.addAll(accounts.map((account) {
       return InkWell(
+        key: Key(account.name),
         child: Column(
           children: [
             Stack(
@@ -176,6 +177,7 @@ class _ProfileState extends State<Profile> {
                 onTap: () => Navigator.pushNamed(context, ChangePasswordPage.route),
               ),
               ListTile(
+                key: const Key('remove-all-accounts'),
                 title: Text(dic.profile.accountsDeleteAll, style: h3Grey),
                 onTap: () => showRemoveAccountsDialog(context, _store),
               ),
@@ -283,6 +285,7 @@ Future<void> showRemoveAccountsDialog(BuildContext context, AppStore _store) {
             onPressed: () => Navigator.of(context).pop(),
           ),
           CupertinoButton(
+            key: const Key('remove-all-accounts-check'),
             child: Text(dic.home.ok),
             onPressed: () async {
               final accounts = _store.account.accountListAll;

--- a/test_driver/helpers/other_test.dart
+++ b/test_driver/helpers/other_test.dart
@@ -23,28 +23,32 @@ Future<void> createNewbieAccountAndSendMoney(FlutterDriver driver, String accoun
   await closePanel(driver);
 
   // await driver.tap(find.byValueKey('transfer'));
-  // await driver.tap(find.byValueKey('transfer-amount-input'));
-  // await driver.enterText('0.2');
+}
 
-  // await driver.runUnsynchronized(() async {
-  //   await scrollToSendAddress(driver);
-  //   await driver.tap(find.byValueKey('send-to-address'));
-  //   await driver.waitFor(find.byValueKey(account));
-  //   // await driver.(find.byValueKey(account));
+Future<void> sendMonayToAccount(FlutterDriver driver) async {
+  await driver.waitFor(find.byValueKey('transfer-amount-input'));
+  await driver.tap(find.byValueKey('transfer-amount-input'));
+  await driver.enterText('0.2');
 
-  //   await driver.waitFor(find.byValueKey('make-transfer'));
-  //   await driver.tap(find.byValueKey('make-transfer'));
+  await driver.runUnsynchronized(() async {
+    // await scrollToSendAddress(driver);
+    // await driver.tap(find.byValueKey('send-to-address'));
+    // await driver.waitFor(find.byValueKey(account));
+    // await driver.(find.byValueKey(account));
 
-  //   await driver.waitFor(find.byValueKey('make-transfer-send'));
-  //   await driver.tap(find.byValueKey('make-transfer-send'));
-  //   await driver.waitFor(find.byValueKey('transfer-done'));
-  //   await driver.tap(find.byValueKey('transfer-done'));
-  //   await addDelay(1000);
-  //   await driver.tap(find.byValueKey('panel-controller'));
-  //   await driver.tap(find.byValueKey(account));
-  //   await closePanel(driver);
-  //   await addDelay(1000);
-  // });
+    await driver.waitFor(find.byValueKey('make-transfer'));
+    await driver.tap(find.byValueKey('make-transfer'));
+
+    await driver.waitFor(find.byValueKey('make-transfer-send'));
+    await driver.tap(find.byValueKey('make-transfer-send'));
+    await driver.waitFor(find.byValueKey('transfer-done'));
+    await driver.tap(find.byValueKey('transfer-done'));
+    // await addDelay(1000);
+    // await driver.tap(find.byValueKey('panel-controller'));
+    // await driver.tap(find.byValueKey(account));
+    // await closePanel(driver);
+    await addDelay(1000);
+  });
 }
 
 Future<void> shareAccountAndCahngeNameTest(FlutterDriver driver, String account, String changedName) async {

--- a/test_driver/helpers/other_test.dart
+++ b/test_driver/helpers/other_test.dart
@@ -19,10 +19,7 @@ Future<void> createNewbieAccountAndSendMoney(FlutterDriver driver, String accoun
   await driver.enterText(account);
   await driver.tap(find.byValueKey('create-account-confirm'));
 
-  // await driver.tap(find.byValueKey('Alice'));
   await closePanel(driver);
-
-  // await driver.tap(find.byValueKey('transfer'));
 }
 
 Future<void> sendMonayToAccount(FlutterDriver driver) async {
@@ -31,11 +28,6 @@ Future<void> sendMonayToAccount(FlutterDriver driver) async {
   await driver.enterText('0.2');
 
   await driver.runUnsynchronized(() async {
-    // await scrollToSendAddress(driver);
-    // await driver.tap(find.byValueKey('send-to-address'));
-    // await driver.waitFor(find.byValueKey(account));
-    // await driver.(find.byValueKey(account));
-
     await driver.waitFor(find.byValueKey('make-transfer'));
     await driver.tap(find.byValueKey('make-transfer'));
 
@@ -43,10 +35,6 @@ Future<void> sendMonayToAccount(FlutterDriver driver) async {
     await driver.tap(find.byValueKey('make-transfer-send'));
     await driver.waitFor(find.byValueKey('transfer-done'));
     await driver.tap(find.byValueKey('transfer-done'));
-    // await addDelay(1000);
-    // await driver.tap(find.byValueKey('panel-controller'));
-    // await driver.tap(find.byValueKey(account));
-    // await closePanel(driver);
     await addDelay(1000);
   });
 }

--- a/test_driver/helpers/other_test.dart
+++ b/test_driver/helpers/other_test.dart
@@ -19,30 +19,76 @@ Future<void> createNewbieAccountAndSendMoney(FlutterDriver driver, String accoun
   await driver.enterText(account);
   await driver.tap(find.byValueKey('create-account-confirm'));
 
-  await driver.tap(find.byValueKey('Alice'));
+  // await driver.tap(find.byValueKey('Alice'));
   await closePanel(driver);
 
-  await driver.tap(find.byValueKey('transfer'));
-  await driver.tap(find.byValueKey('transfer-amount-input'));
-  await driver.enterText('0.2');
+  // await driver.tap(find.byValueKey('transfer'));
+  // await driver.tap(find.byValueKey('transfer-amount-input'));
+  // await driver.enterText('0.2');
 
-  await driver.runUnsynchronized(() async {
-    await scrollToSendAddress(driver);
-    await driver.tap(find.byValueKey('send-to-address'));
-    await driver.waitFor(find.byValueKey(account));
-    // await driver.(find.byValueKey(account));
+  // await driver.runUnsynchronized(() async {
+  //   await scrollToSendAddress(driver);
+  //   await driver.tap(find.byValueKey('send-to-address'));
+  //   await driver.waitFor(find.byValueKey(account));
+  //   // await driver.(find.byValueKey(account));
 
-    await driver.waitFor(find.byValueKey('make-transfer'));
-    await driver.tap(find.byValueKey('make-transfer'));
+  //   await driver.waitFor(find.byValueKey('make-transfer'));
+  //   await driver.tap(find.byValueKey('make-transfer'));
 
-    await driver.waitFor(find.byValueKey('make-transfer-send'));
-    await driver.tap(find.byValueKey('make-transfer-send'));
-    await driver.waitFor(find.byValueKey('transfer-done'));
-    await driver.tap(find.byValueKey('transfer-done'));
-    await addDelay(1000);
-    await driver.tap(find.byValueKey('panel-controller'));
-    await driver.tap(find.byValueKey(account));
-    await closePanel(driver);
-    await addDelay(1000);
-  });
+  //   await driver.waitFor(find.byValueKey('make-transfer-send'));
+  //   await driver.tap(find.byValueKey('make-transfer-send'));
+  //   await driver.waitFor(find.byValueKey('transfer-done'));
+  //   await driver.tap(find.byValueKey('transfer-done'));
+  //   await addDelay(1000);
+  //   await driver.tap(find.byValueKey('panel-controller'));
+  //   await driver.tap(find.byValueKey(account));
+  //   await closePanel(driver);
+  //   await addDelay(1000);
+  // });
+}
+
+Future<void> shareAccountAndCahngeNameTest(FlutterDriver driver, String account, String changedName) async {
+  await driver.tap(find.byValueKey('Profile'));
+
+  await driver.waitFor(find.byValueKey(account));
+  await driver.tap(find.byValueKey(account));
+
+  await driver.waitFor(find.byValueKey('go-to-account-share'));
+  await driver.tap(find.byValueKey('go-to-account-share'));
+
+  await addDelay(800);
+  await driver.waitFor(find.byValueKey('close-share-page'));
+  await driver.tap(find.byValueKey('close-share-page'));
+
+  await driver.waitFor(find.byValueKey('account-name-edit'));
+  await driver.tap(find.byValueKey('account-name-edit'));
+
+  await driver.waitFor(find.byValueKey('account-name-field'));
+  await driver.tap(find.byValueKey('account-name-field'));
+  await driver.enterText(changedName);
+  await driver.tap(find.byValueKey('account-name-edit-check'));
+  await driver.waitFor(find.text(changedName));
+  await addDelay(1000);
+
+  await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
+  await driver.tap(find.byValueKey('export'));
+  await driver.tap(find.byValueKey('input-passworf-dialod'));
+  await driver.enterText('0001');
+  await driver.tap(find.byValueKey('password-ok'));
+
+  await driver.waitFor(find.byValueKey('account-mnemonic-key'));
+  await addDelay(1000);
+  await driver.tap(find.pageBack());
+
+  await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
+  await driver.tap(find.byValueKey('delete'));
+  await driver.waitFor(find.byValueKey('delete-account'));
+  await driver.tap(find.byValueKey('delete-account'));
+}
+
+Future<void> rmAllAccounsFromProfilePage(FlutterDriver driver) async {
+  await driver.tap(find.byValueKey('remove-all-accounts'));
+  await driver.waitFor(find.byValueKey('remove-all-accounts-check'));
+  await driver.tap(find.byValueKey('remove-all-accounts-check'));
+  await driver.waitFor(find.byValueKey('import-account'));
 }

--- a/test_driver/helpers/other_test.dart
+++ b/test_driver/helpers/other_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_driver/flutter_driver.dart';
+
+import 'add_delay.dart';
+import 'real_app_helper.dart';
+
+Future<void> scrollToSendAddress(FlutterDriver driver) async {
+  await driver.scrollUntilVisible(
+    find.byValueKey('transfer-listview'),
+    find.byValueKey('send-to-address'),
+    dyScroll: -300.0,
+  );
+}
+
+Future<void> createNewbieAccountAndSendMoney(FlutterDriver driver, String account) async {
+  await driver.tap(find.byValueKey('panel-controller'));
+  await driver.tap(find.byValueKey('add-account-panel'));
+
+  await driver.tap(find.byValueKey('create-account-name'));
+  await driver.enterText(account);
+  await driver.tap(find.byValueKey('create-account-confirm'));
+
+  await driver.tap(find.byValueKey('Alice'));
+  await closePanel(driver);
+
+  await driver.tap(find.byValueKey('transfer'));
+  await driver.tap(find.byValueKey('transfer-amount-input'));
+  await driver.enterText('0.2');
+
+  await driver.runUnsynchronized(() async {
+    await scrollToSendAddress(driver);
+    await driver.tap(find.byValueKey('send-to-address'));
+    await driver.waitFor(find.byValueKey(account));
+    // await driver.(find.byValueKey(account));
+
+    await driver.waitFor(find.byValueKey('make-transfer'));
+    await driver.tap(find.byValueKey('make-transfer'));
+
+    await driver.waitFor(find.byValueKey('make-transfer-send'));
+    await driver.tap(find.byValueKey('make-transfer-send'));
+    await driver.waitFor(find.byValueKey('transfer-done'));
+    await driver.tap(find.byValueKey('transfer-done'));
+    await addDelay(1000);
+    await driver.tap(find.byValueKey('panel-controller'));
+    await driver.tap(find.byValueKey(account));
+    await closePanel(driver);
+    await addDelay(1000);
+  });
+}

--- a/test_driver/helpers/other_test.dart
+++ b/test_driver/helpers/other_test.dart
@@ -22,7 +22,7 @@ Future<void> createNewbieAccountAndSendMoney(FlutterDriver driver, String accoun
   await closePanel(driver);
 }
 
-Future<void> sendMonayToAccount(FlutterDriver driver) async {
+Future<void> sendMoneyToAccount(FlutterDriver driver) async {
   await driver.waitFor(find.byValueKey('transfer-amount-input'));
   await driver.tap(find.byValueKey('transfer-amount-input'));
   await driver.enterText('0.2');
@@ -39,7 +39,7 @@ Future<void> sendMonayToAccount(FlutterDriver driver) async {
   });
 }
 
-Future<void> shareAccountAndCahngeNameTest(FlutterDriver driver, String account, String changedName) async {
+Future<void> shareAccountAndChangeNameTest(FlutterDriver driver, String account, String changedName) async {
   await driver.tap(find.byValueKey('Profile'));
 
   await driver.waitFor(find.byValueKey(account));
@@ -64,7 +64,7 @@ Future<void> shareAccountAndCahngeNameTest(FlutterDriver driver, String account,
 
   await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
   await driver.tap(find.byValueKey('export'));
-  await driver.tap(find.byValueKey('input-passworf-dialod'));
+  await driver.tap(find.byValueKey('input-password-dialog'));
   await driver.enterText('0001');
   await driver.tap(find.byValueKey('password-ok'));
 
@@ -78,7 +78,7 @@ Future<void> shareAccountAndCahngeNameTest(FlutterDriver driver, String account,
   await driver.tap(find.byValueKey('delete-account'));
 }
 
-Future<void> rmAllAccounsFromProfilePage(FlutterDriver driver) async {
+Future<void> rmAllAccountsFromProfilePage(FlutterDriver driver) async {
   await driver.tap(find.byValueKey('remove-all-accounts'));
   await driver.waitFor(find.byValueKey('remove-all-accounts-check'));
   await driver.tap(find.byValueKey('remove-all-accounts-check'));

--- a/test_driver/real_app_test.dart
+++ b/test_driver/real_app_test.dart
@@ -55,22 +55,6 @@ void main() async {
     await addDelay(1000);
   });
 
-  test('contact-page', () async {
-    await driver.tap(find.byValueKey('Contacts'));
-    await driver.tap(find.byValueKey('add-contact'));
-
-    await driver.tap(find.byValueKey('contact-address'));
-    await driver.enterText('5Gjvca5pwQXENZeLz3LPWsbBXRCKGeALNj1ho13EFmK1FMWW');
-    await driver.tap(find.byValueKey('contact-name'));
-    await driver.enterText('Eldiar');
-
-    await driver.tap(find.byValueKey('contact-save'));
-    await addDelay(1000);
-
-    await driver.tap(find.byValueKey('Wallet'));
-    await addDelay(1000);
-  });
-
   test('turn on dev-mode', () async {
     await driver.tap(find.byValueKey('Profile'));
 
@@ -171,6 +155,38 @@ void main() async {
     await driver.tap(find.byValueKey('Profile'));
     await driver.waitFor(find.text('2'));
     await addDelay(1000);
+    await scrollToNextPhaseButton(driver);
+    await tapAndWaitNextPhase(driver);
+    await driver.tap(find.byValueKey('Wallet'));
+  });
+
+  test('contact-page add account', () async {
+    await driver.tap(find.byValueKey('Contacts'));
+    await driver.tap(find.byValueKey('add-contact'));
+
+    await driver.tap(find.byValueKey('contact-address'));
+    await driver.enterText('5Gjvca5pwQXENZeLz3LPWsbBXRCKGeALNj1ho13EFmK1FMWW');
+    await driver.tap(find.byValueKey('contact-name'));
+    await driver.enterText('Sezar');
+
+    await driver.tap(find.byValueKey('contact-save'));
+    await addDelay(1000);
+  });
+
+  test('send endorse to account', () async {
+    await driver.waitFor(find.byValueKey('Sezar'));
+    await driver.tap(find.byValueKey('Sezar'));
+
+    await driver.waitFor(find.byValueKey('tap-endorse-button'));
+    await driver.tap(find.byValueKey('tap-endorse-button'));
+    await addDelay(1000);
+  });
+
+  test('send money to account', () async {
+    await driver.waitFor(find.byValueKey('send-money-to-account'));
+    await driver.tap(find.byValueKey('send-money-to-account'));
+
+    await sendMonayToAccount(driver);
     await driver.tap(find.byValueKey('Wallet'));
   });
 

--- a/test_driver/real_app_test.dart
+++ b/test_driver/real_app_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';
 
 import 'helpers/add_delay.dart';
+import 'helpers/other_test.dart';
 import 'helpers/real_app_helper.dart';
 
 void main() async {
@@ -51,16 +52,6 @@ void main() async {
     await driver.tap(find.byValueKey('qr-receive'));
     await addDelay(1000);
     await driver.tap(find.byValueKey('close-receive-page'));
-    await addDelay(1000);
-  });
-
-  test('transfer-page', () async {
-    await driver.tap(find.byValueKey('transfer'));
-    await driver.tap(find.byValueKey('transfer-amount-input'));
-
-    await driver.enterText('3.4');
-    await addDelay(1000);
-    await driver.tap(find.byValueKey('close-transfer-page'));
     await addDelay(1000);
   });
 
@@ -174,6 +165,10 @@ void main() async {
     await driver.waitFor(find.byValueKey('claim-pending-dev'));
     await driver.tap(find.byValueKey('claim-pending-dev'));
     await addDelay(20000);
+  }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('create newbie account', () async {
+    await createNewbieAccountAndSendMoney(driver, 'Eldi');
   }, timeout: const Timeout(Duration(seconds: 120)));
 
   tearDownAll(() async {

--- a/test_driver/real_app_test.dart
+++ b/test_driver/real_app_test.dart
@@ -186,7 +186,7 @@ void main() async {
     await driver.waitFor(find.byValueKey('send-money-to-account'));
     await driver.tap(find.byValueKey('send-money-to-account'));
 
-    await sendMonayToAccount(driver);
+    await sendMoneyToAccount(driver);
     await driver.tap(find.byValueKey('Wallet'));
   });
 
@@ -195,12 +195,12 @@ void main() async {
   }, timeout: const Timeout(Duration(seconds: 120)));
 
   test('account share and change name', () async {
-    await shareAccountAndCahngeNameTest(driver, 'Tom', 'Jerry');
+    await shareAccountAndChangeNameTest(driver, 'Tom', 'Jerry');
     await addDelay(2500);
   }, timeout: const Timeout(Duration(seconds: 120)));
 
   test('delete all account ad show create account page', () async {
-    await rmAllAccounsFromProfilePage(driver);
+    await rmAllAccountsFromProfilePage(driver);
     await addDelay(2000);
   });
 

--- a/test_driver/real_app_test.dart
+++ b/test_driver/real_app_test.dart
@@ -167,9 +167,26 @@ void main() async {
     await addDelay(20000);
   }, timeout: const Timeout(Duration(seconds: 120)));
 
+  test('Go to Profile Page and Check reputation count', () async {
+    await driver.tap(find.byValueKey('Profile'));
+    await driver.waitFor(find.text('2'));
+    await addDelay(1000);
+    await driver.tap(find.byValueKey('Wallet'));
+  });
+
   test('create newbie account', () async {
-    await createNewbieAccountAndSendMoney(driver, 'Eldi');
+    await createNewbieAccountAndSendMoney(driver, 'Tom');
   }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('account share and change name', () async {
+    await shareAccountAndCahngeNameTest(driver, 'Tom', 'Jerry');
+    await addDelay(2500);
+  }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('delete all account ad show create account page', () async {
+    await rmAllAccounsFromProfilePage(driver);
+    await addDelay(2000);
+  });
 
   tearDownAll(() async {
     await driver.close();


### PR DESCRIPTION
### Integration test
- [x] After the meetup, go to registering phase. Then choose a bootstrapper account, and endorse a newcomer in the 
contact book. This newcomer shall register afterwards, and we want to test that he is an endorsee.

 - [x] After the meetup, check on the profile page that the overall reputation is one.

- [x] at the very end of the test, delete all accounts, and verify that we are at the account entry page again.
- [x] On profile page:
    - [x] click on an account → share account to verify the share flow.
    - [x] click on an account and change the name, verify that the name has changed
    - [x] export an account (this can't be an account that has been imported with `//Alice` etc, they can't be exported.)
    - [x] Delete one account, and verify that it does no longer exist
 
 The transaction test is ready but it is tested not from `HomePage` but from `contact book page`. 
 Because there is no default address from home page to transfer page and driver can't tap to drop `dropdown_search item`
 This package was not tested integration (no key).
- [x] actually transfer money to another account and verify that the money arrived.