### PR TITLE
Improve handling of community icon

### DIFF
--- a/lib/common/components/logo/community_icon.dart
+++ b/lib/common/components/logo/community_icon.dart
@@ -22,7 +22,7 @@ class CommunityIconObserver extends StatelessWidget {
               return SvgPicture.string(store.encointer.community!.communityIcon!);
             } else {
               return FutureBuilder<String?>(
-                future: context.read<AppStore>().encointer.community!.getCommunityIcon(),
+                future: context.read<AppStore>().encointer.community!.getCommunityIcon(context),
                 builder: (_, AsyncSnapshot<String?> snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const CupertinoActivityIndicator();

--- a/lib/common/components/logo/community_icon.dart
+++ b/lib/common/components/logo/community_icon.dart
@@ -17,22 +17,11 @@ class CommunityIconObserver extends StatelessWidget {
       backgroundColor: Theme.of(context).backgroundColor,
       child: Observer(
         builder: (_) {
-          if (store.encointer.community != null && store.encointer.community!.name != null) {
+          if (store.encointer.community != null && store.encointer.community!.assetsCid != null) {
             if (store.encointer.community!.communityIcon != null) {
               return SvgPicture.string(store.encointer.community!.communityIcon!);
             } else {
-              return FutureBuilder<String?>(
-                future: context.read<AppStore>().encointer.community!.getCommunityIcon(context),
-                builder: (_, AsyncSnapshot<String?> snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return const CupertinoActivityIndicator();
-                  } else if (snapshot.hasData && snapshot.data != null && snapshot.data!.isNotEmpty) {
-                    return SvgPicture.string(snapshot.data!);
-                  } else {
-                    return SvgPicture.asset(fallBackCommunityIcon);
-                  }
-                },
-              );
+              return SvgPicture.asset(fallBackCommunityIcon);
             }
           } else {
             return const CupertinoActivityIndicator();

--- a/lib/page-encointer/common/community_chooser_on_map.dart
+++ b/lib/page-encointer/common/community_chooser_on_map.dart
@@ -59,7 +59,6 @@ class _CommunityDetailsPopupState extends State<CommunityDetailsPopup> {
       child: InkWell(
         key: Key('${widget.marker.key.toString().substring(3, widget.marker.key.toString().length - 3)}-description'),
         onTap: () async {
-          store.encointer.community?.clearCommunityIcon();
           setState(() {});
           await store.encointer.setChosenCid(widget.dataForThisMarker!.cid);
           Navigator.pop(context);

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -91,9 +91,6 @@ class _AssetsState extends State<Assets> {
   Translations? dic;
 
   Future<void> _refreshEncointerState() async {
-    if (context.read<AppStore>().encointer.community?.communityIcon == null) {
-      await context.read<AppStore>().encointer.community?.getCommunityIcon();
-    }
     // getCurrentPhase is the root of all state updates.
     await webApi.encointer.getCurrentPhase();
   }

--- a/lib/page/assets/index.dart
+++ b/lib/page/assets/index.dart
@@ -73,6 +73,11 @@ class _AssetsState extends State<Assets> {
     }
 
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+      if (context.read<AppStore>().encointer.community?.communityIcon == null) {
+        await context.read<AppStore>().encointer.community?.getCommunityIcon();
+      }
+    });
   }
 
   @override
@@ -86,6 +91,9 @@ class _AssetsState extends State<Assets> {
   Translations? dic;
 
   Future<void> _refreshEncointerState() async {
+    if (context.read<AppStore>().encointer.community?.communityIcon == null) {
+      await context.read<AppStore>().encointer.community?.getCommunityIcon();
+    }
     // getCurrentPhase is the root of all state updates.
     await webApi.encointer.getCurrentPhase();
   }

--- a/lib/store/encointer/sub_stores/community_store/community_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_store.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 
+import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/models/communities/community_metadata.dart';
 import 'package:encointer_wallet/models/encointer_balance_data/balance_entry.dart';
@@ -82,18 +84,15 @@ abstract class _CommunityStore with Store {
   double? Function(BalanceEntry)? get applyDemurrage => _applyDemurrage;
 
   @action
-  Future<String?> getCommunityIcon() async {
+  Future<String?> getCommunityIcon([BuildContext? context]) async {
     try {
       if (assetsCid == null) {
         return null;
       } else {
         final data = await webApi.ipfs.getCommunityIcon(assetsCid!);
-        if (data != null) {
-          communityIcon = data;
-          return communityIcon;
-        } else {
-          return null;
-        }
+        communityIcon =
+            data ?? (context != null ? await DefaultAssetBundle.of(context).loadString(fallBackCommunityIcon) : null);
+        return communityIcon;
       }
     } catch (e) {
       Log.e('getCommunityIcon $e', 'App Store getCommunityIcon');

--- a/lib/store/encointer/sub_stores/community_store/community_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_store.dart
@@ -85,7 +85,8 @@ abstract class _CommunityStore with Store {
   Future<String?> getCommunityIcon() async {
     try {
       if (assetsCid != null) {
-        communityIcon = await webApi.ipfs.getCommunityIcon(assetsCid!);
+        final maybeIcon = await webApi.ipfs.getCommunityIcon(assetsCid!);
+        if (maybeIcon != null) communityIcon = maybeIcon;
       }
     } catch (e) {
       Log.e('getCommunityIcon $e', 'App Store getCommunityIcon');

--- a/lib/store/encointer/sub_stores/community_store/community_store.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_store.dart
@@ -1,10 +1,8 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:mobx/mobx.dart';
 
-import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/models/communities/community_metadata.dart';
 import 'package:encointer_wallet/models/encointer_balance_data/balance_entry.dart';
@@ -84,24 +82,16 @@ abstract class _CommunityStore with Store {
   double? Function(BalanceEntry)? get applyDemurrage => _applyDemurrage;
 
   @action
-  Future<String?> getCommunityIcon([BuildContext? context]) async {
+  Future<String?> getCommunityIcon() async {
     try {
-      if (assetsCid == null) {
-        return null;
-      } else {
-        final data = await webApi.ipfs.getCommunityIcon(assetsCid!);
-        communityIcon =
-            data ?? (context != null ? await DefaultAssetBundle.of(context).loadString(fallBackCommunityIcon) : null);
-        return communityIcon;
+      if (assetsCid != null) {
+        communityIcon = await webApi.ipfs.getCommunityIcon(assetsCid!);
       }
     } catch (e) {
       Log.e('getCommunityIcon $e', 'App Store getCommunityIcon');
-      return null;
     }
+    return communityIcon;
   }
-
-  @action
-  void clearCommunityIcon() => communityIcon = null;
 
   @action
   Future<void> initCommunityAccountStore(String address) {
@@ -136,10 +126,11 @@ abstract class _CommunityStore with Store {
   }
 
   @action
-  void setCommunityMetadata(CommunityMetadata meta) {
+  Future<void> setCommunityMetadata(CommunityMetadata meta) async {
     Log.d('set metadata to $meta', 'CommunityStore');
 
     metadata = meta;
+    await getCommunityIcon();
     writeToCache();
   }
 

--- a/lib/store/encointer/sub_stores/community_store/community_store.g.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_store.g.dart
@@ -186,21 +186,18 @@ mixin _$CommunityStore on _CommunityStore, Store {
   late final _$getCommunityIconAsyncAction = AsyncAction('_CommunityStore.getCommunityIcon', context: context);
 
   @override
-  Future<String?> getCommunityIcon([BuildContext? context]) {
-    return _$getCommunityIconAsyncAction.run(() => super.getCommunityIcon(context));
+  Future<String?> getCommunityIcon() {
+    return _$getCommunityIconAsyncAction.run(() => super.getCommunityIcon());
+  }
+
+  late final _$setCommunityMetadataAsyncAction = AsyncAction('_CommunityStore.setCommunityMetadata', context: context);
+
+  @override
+  Future<void> setCommunityMetadata(CommunityMetadata meta) {
+    return _$setCommunityMetadataAsyncAction.run(() => super.setCommunityMetadata(meta));
   }
 
   late final _$_CommunityStoreActionController = ActionController(name: '_CommunityStore', context: context);
-
-  @override
-  void clearCommunityIcon() {
-    final _$actionInfo = _$_CommunityStoreActionController.startAction(name: '_CommunityStore.clearCommunityIcon');
-    try {
-      return super.clearCommunityIcon();
-    } finally {
-      _$_CommunityStoreActionController.endAction(_$actionInfo);
-    }
-  }
 
   @override
   Future<void> initCommunityAccountStore(String address) {
@@ -228,16 +225,6 @@ mixin _$CommunityStore on _CommunityStore, Store {
     final _$actionInfo = _$_CommunityStoreActionController.startAction(name: '_CommunityStore.setBootstrappers');
     try {
       return super.setBootstrappers(bs);
-    } finally {
-      _$_CommunityStoreActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
-  void setCommunityMetadata(CommunityMetadata meta) {
-    final _$actionInfo = _$_CommunityStoreActionController.startAction(name: '_CommunityStore.setCommunityMetadata');
-    try {
-      return super.setCommunityMetadata(meta);
     } finally {
       _$_CommunityStoreActionController.endAction(_$actionInfo);
     }

--- a/lib/store/encointer/sub_stores/community_store/community_store.g.dart
+++ b/lib/store/encointer/sub_stores/community_store/community_store.g.dart
@@ -186,8 +186,8 @@ mixin _$CommunityStore on _CommunityStore, Store {
   late final _$getCommunityIconAsyncAction = AsyncAction('_CommunityStore.getCommunityIcon', context: context);
 
   @override
-  Future<String?> getCommunityIcon() {
-    return _$getCommunityIconAsyncAction.run(() => super.getCommunityIcon());
+  Future<String?> getCommunityIcon([BuildContext? context]) {
+    return _$getCommunityIconAsyncAction.run(() => super.getCommunityIcon(context));
   }
 
   late final _$_CommunityStoreActionController = ActionController(name: '_CommunityStore', context: context);


### PR DESCRIPTION
community-icon-IPFS-error
if I understood correctly this issue https://github.com/encointer/encointer-wallet-flutter/issues/912
I think it is fixed
```dart
final data = await webApi.ipfs.getCommunityIcon(assetsCid!);
communityIcon = data ?? (context != null ? await DefaultAssetBundle.of(context).loadString(fallBackCommunityIcon) : null);
return communityIcon;
```
if `ipfs.getCommunityIcon` return null or has error our `communityIcon` get from `assets` and `communityIcon` be is not null