### PR TITLE
bump flutter v3.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yarn run build
 
 ### Requirements
 - Dart sdk: ">=2.12.0 <3.0.0"
-- Flutter: "3.3.8"
+- Flutter: "3.3.10"
 - Android: minSdkVersion 17
 - iOS: --ios-language swift, Xcode version >= 14.0.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1475,4 +1475,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.3.8"
+  flutter: ">=3.3.10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: "3.3.8"
+  flutter: "3.3.10"
 
 dependencies:
   # intl - format numbers


### PR DESCRIPTION
 clean old flutter version run: `./flutterw clean` 
 download new version run: `./flutterw pub get`
 I think we can bump SDK version from `">=2.12.0 <3.0.0"` to `dart: ">=2.18.0 <3.0.0"` 
 this allows us to use the new features of dart language but after testing this i will do another PR