### PR TITLE
[GA] Remove deprecated monorepo-actions/config-for-actions

### DIFF
--- a/.github/action-config.json
+++ b/.github/action-config.json
@@ -1,8 +1,0 @@
-{
-  "flutter-channel": "stable",
-  "java-version": "12.x",
-  "node-version": "14.17.1",
-  "temp-screenshots": "/tmp/screenshots",
-  "js-service-encointer-path": "./lib/js_service_encointer",
-  "encointer-main-js-path": "./lib/js_service_encointer/dist/main.js"
-}

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, f-droid ]
 
+env:
+  NODE_VERSION: 16.13.1
+  JAVA_VERSION: 12.x
+
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
@@ -21,18 +25,10 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/checkout@v3
-        with:
-          # 2 to compare the last two revisions to check if JS changed
-          fetch-depth: 2
-
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
 
       - uses: actions/setup-java@v3
         with:
-          java-version: ${{ steps.config.outputs.java-version }}
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'zulu'
 
       - name: Install flutter wrapper
@@ -41,7 +37,7 @@ jobs:
       # JS Stuff
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.config.outputs.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: "Build JS"
         working-directory: ./scripts

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [master, f-droid]
 
+env:
+  NODE_VERSION: 16.13.1
+  JAVA_VERSION: 12.x
+  TEMP_SCREENSHOTS: /tmp/screenshots
+
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
@@ -34,18 +39,10 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/checkout@v3
-        with:
-          # 2 to compare the last two revisions to check if JS changed
-          fetch-depth: 2
-
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
 
       - uses: actions/setup-java@v3
         with:
-          java-version: ${{ steps.config.outputs.java-version }}
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'zulu'
 
       - name: Install flutter wrapper
@@ -60,7 +57,7 @@ jobs:
       # JS Stuff
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.config.outputs.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: "Build JS"
         working-directory: ./scripts
@@ -99,7 +96,7 @@ jobs:
         env:
           ANDROID_DEBUG: "true"
           RECORD: ${{ matrix.record_video }}
-          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
+          TEMP_DIR: ${{ env.TEMP_SCREENSHOTS }}
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.device }}
@@ -114,4 +111,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.device }}
-          path: ${{ steps.config.outputs.temp-screenshots }}
+          path: ${{ env.TEMP_SCREENSHOTS }}

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [master, f-droid]
 
+env:
+  NODE_VERSION: 16.13.1
+  JAVA_VERSION: 12.x
+  TEMP_SCREENSHOTS: /tmp/screenshots
+
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
@@ -33,14 +38,6 @@ jobs:
     steps:
       # Setup Environment
       - uses: actions/checkout@v3
-        with:
-          # 2 to compare the last two revisions to check if JS changed
-          fetch-depth: 2
-
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
 
       - name: "Prepare environment for ios"
         working-directory: ./scripts
@@ -48,7 +45,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: ${{ steps.config.outputs.java-version }}
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'zulu'
 
       - name: Install flutter wrapper
@@ -71,7 +68,7 @@ jobs:
         # JS Stuff
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.config.outputs.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: "Build JS"
         working-directory: ./scripts
@@ -81,7 +78,7 @@ jobs:
       - name: "Flutter driver test and record video"
         run: ./scripts/ios_integration_test.sh
         env:
-          TEMP_DIR: ${{ steps.config.outputs.temp-screenshots }}
+          TEMP_DIR: ${{ env.TEMP_SCREENSHOTS }}
           RECORD: ${{ matrix.record_video }}
 
       - name: "Upload screenshots and recording"
@@ -89,4 +86,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.device }}
-          path: ${{ steps.config.outputs.temp-screenshots }}
+          path: ${{ env.TEMP_SCREENSHOTS }}

--- a/.github/workflows/js_ci.yml
+++ b/.github/workflows/js_ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master, f-droid ]
 
+env:
+  NODE_VERSION: 16.13.1
+  JAVA_VERSION: 12.x
+  TEMP_SCREENSHOTS: /tmp/screenshots
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -14,15 +19,10 @@ jobs:
       # Setup Environment
       - uses: actions/checkout@v3
 
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
-
       # JS Stuff
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.config.outputs.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Download encointer-node
         uses: dawidd6/action-download-artifact@v2
@@ -59,15 +59,10 @@ jobs:
       # Setup Environment
       - uses: actions/checkout@v3
 
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
-
       # JS Stuff
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.config.outputs.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run e2e tests against  ${{ matrix.network }}
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master, f-droid ]
 
 env:
-  "JS_SERVICE_ENCOINTER_PATH": "lib/js_service_encointer",
-  "JS_SERVICE_ENCOINTER_MAIN": "lib/js_service_encointer/dist/main.js",
+  JS_SERVICE_ENCOINTER_PATH: lib/js_service_encointer
+  JS_SERVICE_ENCOINTER_MAIN: lib/js_service_encointer/dist/main.js
 
 jobs:
   flutter:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, f-droid ]
 
+env:
+  "JS_SERVICE_ENCOINTER_PATH": "lib/js_service_encointer",
+  "JS_SERVICE_ENCOINTER_MAIN": "lib/js_service_encointer/dist/main.js",
+
 jobs:
   flutter:
     runs-on: ubuntu-latest
@@ -14,19 +18,14 @@ jobs:
       # Setup Environment
       - uses: actions/checkout@v3
 
-      - uses: monorepo-actions/config-for-actions@main
-        id: config
-        with:
-          config_files: ./.github/action-config.json
-
       - name: Install flutter wrapper
         run: ./scripts/install_flutter_wrapper.sh
 
       # Analyzer throws an error if an asset is missing
       - name: "Make mock-main.js"
         run: |
-          mkdir -p ${{ steps.config.outputs.js-service-encointer-path }}/dist
-          touch ${{ steps.config.outputs.encointer-main-js-path }}
+          mkdir -p ${{ env.JS_SERVICE_ENCOINTER_PATH }}/dist
+          touch ${{ env.JS_SERVICE_ENCOINTER_MAIN }}
 
       # analyze and test
       - name: "Check fmt"

--- a/README.md
+++ b/README.md
@@ -105,12 +105,9 @@ and find the output in `build/app/outputs/bundle/release/app-release.aab`
 #### Dev hints
 
 ### Flutter version
-The following two files contain the supported flutter version:
+The following file contains the supported flutter version:
 
-* [GitHub Action Config](./.github/action-config.json)
 * [install_flutter_wrapper.sh](./scripts/install_flutter_wrapper.sh)
-
-These versions must always be aligned!
 
 ### Run tests
 


### PR DESCRIPTION
I decided to not overengineer stuff, and trade-off a bit of redundancy for simplicity. Closes #933.

No more deprecated warnings in the CI! Yaaay!