### PR TITLE
Fix display of buttons for non-newbies in dialog after registering

### DIFF
--- a/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -189,7 +189,6 @@ void _showEducationalDialog(ParticipantType registrationType, BuildContext conte
           textAlign: TextAlign.center,
         ),
         actions: <Widget>[
-          const SizedBox(),
           CupertinoButton(
             key: const Key('close-educate-dialog'),
             child: Text(dic.home.ok),
@@ -203,6 +202,7 @@ void _showEducationalDialog(ParticipantType registrationType, BuildContext conte
               ),
               onPressed: () => UI.launchURL(leuZurichCycleAssignmentFAQLink(languageCode)),
             ),
+          if (registrationType == ParticipantType.Newbie) const SizedBox(),
         ],
       );
     },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/37865735/209561997-dc785d9f-048f-4e59-a9d4-20bf2b2916b6.png)
After: 
![image](https://user-images.githubusercontent.com/37865735/209561871-183b3f5e-11e0-49d0-98b4-c819694a6792.png)
