### PR TITLE
only show endorse helper text if current account is not a bootstrapper

### DIFF
--- a/lib/page/profile/account/account_manage_page.dart
+++ b/lib/page/profile/account/account_manage_page.dart
@@ -64,16 +64,13 @@ class _AccountManagePageState extends State<AccountManagePage> {
             CupertinoButton(
               key: const Key('delete-account'),
               child: Text(I18n.of(context)!.translationsForLocale().home.ok),
-              onPressed: () => {
-                _appStore.account.removeAccount(accountToBeEdited).then(
-                  (_) async {
-                    // refresh balance
-                    await _appStore.loadAccountCache();
-                    webApi.fetchAccountData();
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pop();
-                  },
-                ),
+              onPressed: () {
+                Navigator.of(context).pop();
+                Navigator.of(context).pop();
+                _appStore.account
+                    .removeAccount(accountToBeEdited)
+                    .then((_) => _appStore.loadAccountCache())
+                    .then((_) => webApi.fetchAccountData());
               },
             ),
           ],

--- a/lib/page/profile/contacts/contact_detail_page.dart
+++ b/lib/page/profile/contacts/contact_detail_page.dart
@@ -240,7 +240,7 @@ class EndorseButton extends StatelessWidget {
     } else if (store.encointer.currentPhase != CeremonyPhase.Registering) {
       _popupDialog(context, dic.profile.canEndorseInRegisteringPhaseOnly);
     } else {
-      submitEndorseNewcomer(context, store, api, store.encointer.chosenCid, contact.address);
+      await submitEndorseNewcomer(context, store, api, store.encointer.chosenCid, contact.address);
     }
   }
 }

--- a/lib/page/profile/contacts/contact_detail_page.dart
+++ b/lib/page/profile/contacts/contact_detail_page.dart
@@ -182,21 +182,19 @@ class EndorseButton extends StatelessWidget {
               : const SizedBox();
         }),
         Observer(builder: (_) {
-          return FittedBox(
-            child: Row(
-              children: store.encointer.account != null && store.encointer.account!.reputations.isNotEmpty
-                  ? [
-                      Text(dic.encointer.remainingNewbieTicketsAsReputable),
-                      Text(
-                        ' ${store.encointer.account?.numberOfNewbieTicketsForReputable ?? 0}',
-                        style: TextStyle(color: zurichLion.shade800, fontSize: 15),
-                      ),
-                    ]
-                  : [
-                      Text(dic.encointer.onlyReputablesCanEndorseAttendGatheringToBecomeOne),
-                    ],
-            ),
-          );
+          return store.encointer.account != null && store.encointer.account!.reputations.isNotEmpty
+              ? FittedBox(
+                  child: Row(children: [
+                    Text(dic.encointer.remainingNewbieTicketsAsReputable),
+                    Text(
+                      ' ${store.encointer.account?.numberOfNewbieTicketsForReputable ?? 0}',
+                      style: TextStyle(color: zurichLion.shade800, fontSize: 15),
+                    ),
+                  ]),
+                )
+              : !store.encointer.community!.bootstrappers!.contains(store.account.currentAddress)
+                  ? Text(dic.encointer.onlyReputablesCanEndorseAttendGatheringToBecomeOne)
+                  : const SizedBox();
         }),
         const SizedBox(height: 5),
         Observer(builder: (_) {

--- a/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -189,6 +189,7 @@ void _showEducationalDialog(ParticipantType registrationType, BuildContext conte
           textAlign: TextAlign.center,
         ),
         actions: <Widget>[
+          if (registrationType == ParticipantType.Newbie) const SizedBox(),
           CupertinoButton(
             key: const Key('close-educate-dialog'),
             child: Text(dic.home.ok),
@@ -202,7 +203,6 @@ void _showEducationalDialog(ParticipantType registrationType, BuildContext conte
               ),
               onPressed: () => UI.launchURL(leuZurichCycleAssignmentFAQLink(languageCode)),
             ),
-          if (registrationType == ParticipantType.Newbie) const SizedBox(),
         ],
       );
     },


### PR DESCRIPTION
* [contact_details_page] Closes #939
* [contact_details_page] Fix: Show cupertino activity indicator after tapping the endorse newcomer button
* [tx] better placement of educational dialog spacers
* [profile] prevent short-term red screen when deleting the current account