### PR TITLE
Update IOS runtimes for IPad simulator creation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,6 @@
+## GitHub Actions Hints
+
+### IOS
+Sometimes after a Github Actions Runner update, the Xcode version is updated, which changes the available IOS runtimes.
+This makes the IPad simulator creation fail because our runtime is no longer available. We can simply replace the 
+runtime with one of the available runtimes printed in the `Prepare environment for IOS` stage.

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: "Create Simulator if iPad Pro 2nd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
 
       - name: "Create Simulator if iPad Pro 3rd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-0"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
 
       # JS Stuff
       - uses: actions/setup-node@v3


### PR DESCRIPTION
This is sometimes needed when the GitHub Action Runners are updated. I have added a small Readme in the `.github` folder, which explains the reason and the fix.