### PR TITLE
Move readme content from github folder into root readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,0 @@
-## GitHub Actions Hints
-
-### IOS
-Sometimes after a Github Actions Runner update, the Xcode version is updated, which changes the available IOS runtimes.
-This makes the IPad simulator creation fail because our runtime is no longer available. We can simply replace the 
-runtime with one of the available runtimes printed in the `Prepare environment for IOS` stage.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,14 @@ The flutter build-runner is used to generate repetitive boiler-plate code that i
 e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following 
 command must be run to update the `*.g` files.
 
-*  `./flutterw pub run build_runner build --delete-conflicting-outputs` 
+* `./flutterw pub run build_runner build --delete-conflicting-outputs`
+
+## GitHub Actions Hints
+
+### IOS
+Sometimes after a Github Actions Runner update, the Xcode version is updated, which changes the available IOS runtimes.
+This makes the IPad simulator creation fail because our runtime is no longer available. We can simply replace the
+runtime with one of the available runtimes printed in the `Prepare environment for IOS` stage.
 
 ### App Release
 


### PR DESCRIPTION
Somehow, github was unable to handle the readme in the `.github` folder. It has overwritten the one from the root of the repository.