### PR TITLE
Readme: Make code snippets copyable and add remark about outdated `.flutter` submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,24 +111,12 @@ The following file contains the supported flutter version:
 
 ### Run tests
 
-* run all tests from the command line:
-```
-./flutterw test
-```
-* exclude e2e-tests that need a running encointer node:
-```
-./flutterw test --exclude-tags encointer-node-e2e
-```
-* run e2e-tests that need a running encointer node:
-```
-./flutterw test --tags encointer-node-e2e
-```
+* run all tests from the command line:`./flutterw test`
+* exclude e2e-tests that need a running encointer node:`./flutterw test --exclude-tags encointer-node-e2e`
+* run e2e-tests that need a running encointer node:`./flutterw test --tags encointer-node-e2e`
 
 ### Integration tests
-* run all integration tests in `test_driver` directory: 
-```
-./flutterw drive --target=test_driver/app.dart --flavor dev
-```
+* run all integration tests in `test_driver` directory: `./flutterw drive --target=test_driver/app.dart --flavor dev`
 
 ### Automated screenshots
 * Github actions is used to create automated screenshots for the specified devices there. However, running the integration tests locally will create screenshots for the currently running device.
@@ -155,10 +143,7 @@ Setup to talk from emulators and/or cellphones with an encointer-node in the sam
     * Double check if the rule is activated.
 3. Find your local IP in the network and enter it in the encointer-wallet's [config](https://github.com/encointer/encointer-wallet-flutter/blob/1abb8a1f54ef551f19598fb809dfd6378cf1ac43/lib/config/consts.dart#L16-L23).
 4. Restart the computer to be sure that the new configs are active.
-5. Run the node with the flags: 
-```
-./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external
-```
+5. Run the node with the flags: `./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external`
 
 If the node is run in WSL2 (WSL1 should be fine), some extra steps are needed:
 
@@ -183,10 +168,7 @@ widgets. This causes many unwanted linebreaks that reduce the readability of flu
 
 * Settings > Dart > Line length 120.
 * Autoformat on save: Settings > Languages and Frameworks > then tick: `Format code on save`, `Organize imports on save`.
-* Format the whole codebase with: 
-```
-./flutterw format . --line-length 120
-```
+* Format the whole codebase with: `./flutterw format . --line-length 120`.
 
 #### Other fmt hints:
 
@@ -197,10 +179,9 @@ widgets. This causes many unwanted linebreaks that reduce the readability of flu
 ### Update generated files.
 The flutter build-runner is used to generate repetitive boiler-plate code that is generated based on code annotations,
 e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following 
-command must be run to update the `*.g` files:
-```
-./flutterw pub run build_runner build --delete-conflicting-outputs
-```
+command must be run to update the `*.g` files.
+
+* `./flutterw pub run build_runner build --delete-conflicting-outputs`
 
 ## GitHub Actions Hints
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ please refer to the [documentation](https://github.com/passsy/flutter_wrapper#id
 
 Further info can be found in the [Medium Article](https://passsy.medium.com/flutter-wrapper-bind-your-project-to-an-explicit-flutter-release-4062cfe6dcaf).
 
+**Note:** Git sometimes fails to update the flutter submodule, when it has changed on remote. This can be fixed with:
+```bash
+git submodule update --init
+```
+
 #### Linux and MacOs
 Linux and MacOs users can simply replace all `flutter` CLI commands with `./flutterw` and it will just work.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You'll need `Nodejs` and `yarn` installed to build the bundled `main.js` file:
 
 See the js_service_encointer [Readme](lib/js_service_encointer/README.md) for more documentation.
 
-```shell script
+```shell
 cd lib/js_service_encointer/
 # install nodejs dependencies
 yarn install
@@ -65,7 +65,7 @@ please refer to the [documentation](https://github.com/passsy/flutter_wrapper#id
 Further info can be found in the [Medium Article](https://passsy.medium.com/flutter-wrapper-bind-your-project-to-an-explicit-flutter-release-4062cfe6dcaf).
 
 **Note:** Git sometimes fails to update the flutter submodule, when it has changed on remote. This can be fixed with:
-```bash
+```shell
 git submodule update --init
 ```
 
@@ -75,7 +75,7 @@ Linux and MacOs users can simply replace all `flutter` CLI commands with `./flut
 #### Windows
 In windows, this does unfortunately not work, but you can still set up your IDE to use the flutter version in from the `.flutter` git submodule. And you can do the following workaround:
 
-```
+```shell
 // initialize .flutter git submodule (also works on windows)
 ./scripts/install_flutter_wrapper.sh
 
@@ -87,7 +87,7 @@ In windows, this does unfortunately not work, but you can still set up your IDE 
 
 If you have an AVD or real device attached, you can do
 
-```
+```shell
 ./flutterw run --flavor dev
 ```
 
@@ -96,13 +96,13 @@ If you have an AVD or real device attached, you can do
 You may build the App with Flutter's [Deployment Documentation](https://flutter.dev/docs).
 
 In order to build a fat APK, you can do
-```
+```shell
 ./flutterw build apk --flavor fdroid
 ```
 and find the output in `build/app/outputs/apk/fdroid/release/app-fdroid-release.apk`
 
 For the play store, an appbundle is preferred:
-```
+```shell
 ./flutterw build appbundle
 ```
 and find the output in `build/app/outputs/bundle/release/app-release.aab`
@@ -117,21 +117,21 @@ The following file contains the supported flutter version:
 ### Run tests
 
 * run all tests from the command line:
-```
+```shell
 ./flutterw test
 ```
 * exclude e2e-tests that need a running encointer node:
-```
+```shell
 ./flutterw test --exclude-tags encointer-node-e2e
 ```
 * run e2e-tests that need a running encointer node:
-```
+```shell
 ./flutterw test --tags encointer-node-e2e
 ```
 
 ### Integration tests
 * run all integration tests in `test_driver` directory:
-```
+```shell
 ./flutterw drive --target=test_driver/app.dart --flavor dev
 ```
 
@@ -161,7 +161,7 @@ OS fixes are needed to get this working. I don't know if all of these steps are 
 3. Find your local IP in the network and enter it in the encointer-wallet's [config](https://github.com/encointer/encointer-wallet-flutter/blob/1abb8a1f54ef551f19598fb809dfd6378cf1ac43/lib/config/consts.dart#L16-L23).
 4. Restart the computer to be sure that the new configs are active.
 5. Run the node with the flags:
-```
+```shell
 ./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external
 ```
 
@@ -189,7 +189,7 @@ length of the code to 120.
 * Settings > Dart > Line length 120.
 * Autoformat on save: Settings > Languages and Frameworks > then tick: `Format code on save`, `Organize imports on save`.
 * Format the whole codebase with:
-```
+```shell
 ./flutterw format . --line-length 120
 ```
 
@@ -203,7 +203,7 @@ length of the code to 120.
 The flutter build-runner is used to generate repetitive boiler-plate code that is generated based on code annotations,
 e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following
 command must be run to update the `*.g` files:
-```
+```shell
 ./flutterw pub run build_runner build --delete-conflicting-outputs
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Encointer wallet and client for mobile phones
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
-     alt="Get it on F-Droid"
-     height="55">](https://f-droid.org/packages/org.encointer.wallet/)
-     
+alt="Get it on F-Droid"
+height="55">](https://f-droid.org/packages/org.encointer.wallet/)
+
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
-     alt="Get it on Google Play"
-     height="55">](https://play.google.com/store/apps/details?id=org.encointer.wallet)
-     
+alt="Get it on Google Play"
+height="55">](https://play.google.com/store/apps/details?id=org.encointer.wallet)
+
 <a href="https://apps.apple.com/us/app/encointer-wallet/id1535471655?itsct=apps_box_badge&amp;itscg=30200" style="display: inline-block; overflow: hidden; border-radius: 13px; width: 150px; height: 83px;"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1619049600&h=f616bcfbdbf4c04f0ca6524a2a683d4b" alt="Download on the App Store" style="border-radius: 13px; width: 250px; height: 83px;"></a>
 
 [![Build](https://github.com/encointer/encointer-wallet-flutter/actions/workflows/android_build.yml/badge.svg)](https://github.com/encointer/encointer-wallet-flutter/actions/workflows/android_build.yml)
@@ -31,7 +31,7 @@ Encointer wallet and client for mobile phones
 
 Built with [Flutter](https://flutter.dev/), you need to have `Flutter` dev tools
 installed on your computer to compile the project. check [Flutter Documentation](https://flutter.dev/docs)
- to learn how to install `Flutter` and initialize a Flutter App.
+to learn how to install `Flutter` and initialize a Flutter App.
 
 ### Build js dependencies
 
@@ -59,7 +59,7 @@ This project uses [flutter_wrapper](https://github.com/passsy/flutter_wrapper). 
 having the same flutter version across multiple developers. It installs automatically the flutter version form the
 pubspec.yml into the `.flutter` submodule.
 
-Vscode automatically uses the `.flutter` as we have checked in the `.vscode` folder. For setting up the Android Studio, 
+Vscode automatically uses the `.flutter` as we have checked in the `.vscode` folder. For setting up the Android Studio,
 please refer to the [documentation](https://github.com/passsy/flutter_wrapper#ide-setup).
 
 Further info can be found in the [Medium Article](https://passsy.medium.com/flutter-wrapper-bind-your-project-to-an-explicit-flutter-release-4062cfe6dcaf).
@@ -90,7 +90,7 @@ If you have an AVD or real device attached, you can do
 
 You may build the App with Flutter's [Deployment Documentation](https://flutter.dev/docs).
 
-In order to build a fat APK, you can do 
+In order to build a fat APK, you can do
 ```
 ./flutterw build apk --flavor fdroid
 ```
@@ -111,12 +111,24 @@ The following file contains the supported flutter version:
 
 ### Run tests
 
-* run all tests from the command line:`./flutterw test`
-* exclude e2e-tests that need a running encointer node:`./flutterw test --exclude-tags encointer-node-e2e`
-* run e2e-tests that need a running encointer node:`./flutterw test --tags encointer-node-e2e`
+* run all tests from the command line:
+```
+./flutterw test
+```
+* exclude e2e-tests that need a running encointer node:
+```
+./flutterw test --exclude-tags encointer-node-e2e
+```
+* run e2e-tests that need a running encointer node:
+```
+./flutterw test --tags encointer-node-e2e
+```
 
 ### Integration tests
-* run all integration tests in `test_driver` directory: `./flutterw drive --target=test_driver/app.dart --flavor dev`
+* run all integration tests in `test_driver` directory:
+```
+./flutterw drive --target=test_driver/app.dart --flavor dev
+```
 
 ### Automated screenshots
 * Github actions is used to create automated screenshots for the specified devices there. However, running the integration tests locally will create screenshots for the currently running device.
@@ -133,7 +145,7 @@ To run the in Android Studio a build flavor must be specified. Go to Run/Debug c
 
 ### Windows Local Dev-setup
 Setup to talk from emulators and/or cellphones with an encointer-node in the same local network. In windows 10/11 some
- OS fixes are needed to get this working. I don't know if all of these steps are required.
+OS fixes are needed to get this working. I don't know if all of these steps are required.
 
 1. Make PC discoverable in local network.
 2. Enable inbound connections in windows firewall:
@@ -143,12 +155,15 @@ Setup to talk from emulators and/or cellphones with an encointer-node in the sam
     * Double check if the rule is activated.
 3. Find your local IP in the network and enter it in the encointer-wallet's [config](https://github.com/encointer/encointer-wallet-flutter/blob/1abb8a1f54ef551f19598fb809dfd6378cf1ac43/lib/config/consts.dart#L16-L23).
 4. Restart the computer to be sure that the new configs are active.
-5. Run the node with the flags: `./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external`
+5. Run the node with the flags:
+```
+./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external
+```
 
 If the node is run in WSL2 (WSL1 should be fine), some extra steps are needed:
 
-6. WSL2 does only expose ports on the local interface, which means they only listen to `127.0.0.1`, hence WSL2 can't be 
-accessed on `hostname/-ip` on other devices in the LAN. This can be fixed with a simple tool [WSLHostPatcher](https://github.com/CzBiX/WSLHostPatcher).
+6. WSL2 does only expose ports on the local interface, which means they only listen to `127.0.0.1`, hence WSL2 can't be
+   accessed on `hostname/-ip` on other devices in the LAN. This can be fixed with a simple tool [WSLHostPatcher](https://github.com/CzBiX/WSLHostPatcher).
     * Download the release.zip
     * Run `WSLHostPatcher.exe`
     * (Re-)start the service in WSL2. A firewall warning will pop-up the first time and access must be granted.
@@ -161,14 +176,17 @@ accessed on `hostname/-ip` on other devices in the LAN. This can be fixed with a
 * Add a shortcut to the `WSLHostPatcher.exe` in the windows startup folder.
 
 ### Fmt
-`dartfmt` lacks config file support, which implies that customizations need to be done by users individually. The default 
-limit of 80 characters line length conflicts with the deeply nested structure of flutter's declarative code for designing 
+`dartfmt` lacks config file support, which implies that customizations need to be done by users individually. The default
+limit of 80 characters line length conflicts with the deeply nested structure of flutter's declarative code for designing
 widgets. This causes many unwanted linebreaks that reduce the readability of flutter code. Hence, we increase the line
- length of the code to 120.
+length of the code to 120.
 
 * Settings > Dart > Line length 120.
 * Autoformat on save: Settings > Languages and Frameworks > then tick: `Format code on save`, `Organize imports on save`.
-* Format the whole codebase with: `./flutterw format . --line-length 120`.
+* Format the whole codebase with:
+```
+./flutterw format . --line-length 120
+```
 
 #### Other fmt hints:
 
@@ -178,10 +196,11 @@ widgets. This causes many unwanted linebreaks that reduce the readability of flu
 
 ### Update generated files.
 The flutter build-runner is used to generate repetitive boiler-plate code that is generated based on code annotations,
-e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following 
-command must be run to update the `*.g` files.
-
-* `./flutterw pub run build_runner build --delete-conflicting-outputs`
+e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following
+command must be run to update the `*.g` files:
+```
+./flutterw pub run build_runner build --delete-conflicting-outputs
+```
 
 ## GitHub Actions Hints
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ please refer to the [documentation](https://github.com/passsy/flutter_wrapper#id
 
 Further info can be found in the [Medium Article](https://passsy.medium.com/flutter-wrapper-bind-your-project-to-an-explicit-flutter-release-4062cfe6dcaf).
 
-**Note:** Git sometimes fails to update the flutter submodule, when it has changed on remote. This can be fixed with:
+**Note:** Git sometimes fails to update the flutter submodule when it has been changed on remote. This can be fixed with:
 ```shell
 git submodule update --init
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ please refer to the [documentation](https://github.com/passsy/flutter_wrapper#id
 
 Further info can be found in the [Medium Article](https://passsy.medium.com/flutter-wrapper-bind-your-project-to-an-explicit-flutter-release-4062cfe6dcaf).
 
-**Note:** Git sometimes fails to update the flutter submodule when it has been changed on remote. This can be fixed with:
+**Note:** On windows, Git fails to update the flutter submodule when it has been changed on remote. This can be fixed with:
 ```shell
 git submodule update --init
 ```

--- a/README.md
+++ b/README.md
@@ -111,12 +111,24 @@ The following file contains the supported flutter version:
 
 ### Run tests
 
-* run all tests from the command line:`./flutterw test`
-* exclude e2e-tests that need a running encointer node:`./flutterw test --exclude-tags encointer-node-e2e`
-* run e2e-tests that need a running encointer node:`./flutterw test --tags encointer-node-e2e`
+* run all tests from the command line:
+```
+./flutterw test
+```
+* exclude e2e-tests that need a running encointer node:
+```
+./flutterw test --exclude-tags encointer-node-e2e
+```
+* run e2e-tests that need a running encointer node:
+```
+./flutterw test --tags encointer-node-e2e
+```
 
 ### Integration tests
-* run all integration tests in `test_driver` directory: `./flutterw drive --target=test_driver/app.dart --flavor dev`
+* run all integration tests in `test_driver` directory: 
+```
+./flutterw drive --target=test_driver/app.dart --flavor dev
+```
 
 ### Automated screenshots
 * Github actions is used to create automated screenshots for the specified devices there. However, running the integration tests locally will create screenshots for the currently running device.
@@ -143,7 +155,10 @@ Setup to talk from emulators and/or cellphones with an encointer-node in the sam
     * Double check if the rule is activated.
 3. Find your local IP in the network and enter it in the encointer-wallet's [config](https://github.com/encointer/encointer-wallet-flutter/blob/1abb8a1f54ef551f19598fb809dfd6378cf1ac43/lib/config/consts.dart#L16-L23).
 4. Restart the computer to be sure that the new configs are active.
-5. Run the node with the flags: `./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external`
+5. Run the node with the flags: 
+```
+./target/release/encointer-node-notee --dev --enable-offchain-indexing true --rpc-methods unsafe -lencointer=debug --ws-external --rpc-external
+```
 
 If the node is run in WSL2 (WSL1 should be fine), some extra steps are needed:
 
@@ -168,7 +183,10 @@ widgets. This causes many unwanted linebreaks that reduce the readability of flu
 
 * Settings > Dart > Line length 120.
 * Autoformat on save: Settings > Languages and Frameworks > then tick: `Format code on save`, `Organize imports on save`.
-* Format the whole codebase with: `./flutterw format . --line-length 120`.
+* Format the whole codebase with: 
+```
+./flutterw format . --line-length 120
+```
 
 #### Other fmt hints:
 
@@ -179,9 +197,10 @@ widgets. This causes many unwanted linebreaks that reduce the readability of flu
 ### Update generated files.
 The flutter build-runner is used to generate repetitive boiler-plate code that is generated based on code annotations,
 e.g. `@JsonSerializable` or the mobx annotations. Whenever annotations are added, changed or removed, the following 
-command must be run to update the `*.g` files.
-
-* `./flutterw pub run build_runner build --delete-conflicting-outputs`
+command must be run to update the `*.g` files:
+```
+./flutterw pub run build_runner build --delete-conflicting-outputs
+```
 
 ## GitHub Actions Hints
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1638,5 +1638,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.6 <3.0.0"
+  dart: ">=2.18.6 <4.0.0"
   flutter: ">=3.7.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1638,5 +1638,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.6 <4.0.0"
+  dart: ">=2.18.6 <3.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
Changes:
* Make code snippets copyable by replacing '`' with '```'
* Add comment about `.flutter` submodule not being updated when it changed on remote
* Fix formatting and trailing whitespaces.