### PR TITLE
Bump flutter v3.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yarn run build
 
 ### Requirements
 - Dart sdk: ">=2.19.0 <3.0.0"
-- Flutter: "3.7.1"
+- Flutter: "3.7.3"
 - Android: minSdkVersion 17
 - iOS: --ios-language swift, Xcode version >= 14.0.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   async:
     dependency: transitive
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "7ff671ed0a6356fa8f2e1ae7d3558d3fb7b6a41e24455e4f8df75b811fb8e4ab"
+      sha256: "1d6e5a61674ba3a68fb048a7c7b4ff4bebfed8d7379dbe8f2b718231be9a7c95"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -571,10 +571,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: b1cbfec0f5aef427a18eb573f5445af8c9c568626bf3388553e40c263d3f7368
+      sha256: "385f12ee9c7288575572c7873a332016ec45ebd092e1c2f6bd421b4a9ad21f1d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5+5"
+    version: "0.8.5+6"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -819,10 +819,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f619162573096d428ccde2e33f92e05b5a179cd6f0e3120c1005f181bee8ed16
+      sha256: "8df5ab0a481d7dc20c0e63809e90a588e496d276ba53358afc4c4443d0a00697"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -883,10 +883,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
+      sha256: "2e32f1640f07caef0d3cb993680f181c79e54a3827b997d5ee221490d131fbd9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.8"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -1140,10 +1140,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: e387077716f80609bb979cd199331033326033ecd1c8f200a90c5f57b1c9f55e
+      sha256: "8c6892037b1824e2d7e8f59d54b3105932899008642e6372e5079c6939b4b625"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1639,4 +1639,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.19.0 <3.0.0"
-  flutter: ">=3.7.1"
+  flutter: ">=3.7.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,12 +40,12 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   base58check: ^2.0.0
-  package_info_plus: ^3.0.2
+  package_info_plus: ^3.0.3
   quiver: ^3.2.1
   dio: ^4.0.6
   image_picker: ^0.8.6+1
   animated_check: ^1.0.5
-  share_plus: ^6.3.0
+  share_plus: ^6.3.1
   flutter_timezone: ^1.0.4
 
   # Adjust screen brightness and keep awake for qrcodes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.19.0 <3.0.0"
-  flutter: "3.7.1"
+  flutter: "3.7.3"
 
 dependencies:
   # intl - format numbers


### PR DESCRIPTION
I migrated my other project to `impeller` with flutter version 3.7.1 but when i try in this project i have problem.
I noticed that the performance improves when I use `impeller`. that is  why I would like to try to use it in our `encointer_wallet` when the flutter skin version comes out. but this time there were some problems so I upgraded only flutter version without any other changes.