### PR TITLE
[AddressInputField] simplify code and and add account filtering based on name

### DIFF
--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -31,6 +31,7 @@ class AddressInputField extends StatefulWidget {
 class _AddressInputFieldState extends State<AddressInputField> {
   /// Returns true if the [account]'s name or address starts with [nameOrAddress].
   bool filterByAddressOrName(AccountData account, String nameOrAddress) {
+    // we can't just use account.address unfortunately, see #1019.
     return account.name.startsWith(nameOrAddress.trim()) ||
         Fmt.addressOfAccount(account, widget.store).startsWith(nameOrAddress.trim());
   }

--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -53,23 +53,12 @@ class _AddressInputFieldState extends State<AddressInputField> {
     return filteredByName.followedBy(filteredByAddress);
   }
 
-  String _itemAsString(AccountData item) {
-    final address = Fmt.addressOfAccount(item, widget.store);
-    final accInfo = widget.store.account.addressIndexMap[item.address];
-    String? idx = '';
-    if (accInfo != null && accInfo['accountIndex'] != null) {
-      idx = accInfo['accountIndex'] as String?;
-    }
-    return '${item.name} $idx $address ${item.address}';
-  }
-
   Widget _selectedItemBuilder(BuildContext context, AccountData? item) {
     if (item == null) {
       return Container();
     }
     return Observer(
       builder: (_) {
-        final accInfo = widget.store.account.addressIndexMap[item.pubKey];
         final address = Fmt.addressOfAccount(item, widget.store);
         return Container(
           padding: const EdgeInsets.only(top: 8),
@@ -84,7 +73,7 @@ class _AddressInputFieldState extends State<AddressInputField> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
+                    item.name.isNotEmpty ? item.name : Fmt.address(address)!,
                   ),
                   Text(
                     Fmt.address(address)!,
@@ -105,7 +94,6 @@ class _AddressInputFieldState extends State<AddressInputField> {
   Widget _listItemBuilder(BuildContext context, AccountData item, bool isSelected) {
     return Observer(
       builder: (_) {
-        final accInfo = widget.store.account.addressIndexMap[item.pubKey];
         final address = Fmt.addressOfAccount(item, widget.store);
         return Container(
           margin: const EdgeInsets.symmetric(horizontal: 8),
@@ -122,7 +110,7 @@ class _AddressInputFieldState extends State<AddressInputField> {
             dense: true,
             title: Text(Fmt.address(address)!),
             subtitle: Text(
-              item.name.isNotEmpty ? item.name : Fmt.accountDisplayNameString(item.address, accInfo)!,
+              item.name.isNotEmpty ? item.name : Fmt.address(address)!,
             ),
             leading: CircleAvatar(
               child: AddressIcon(item.address, item.pubKey),
@@ -168,7 +156,6 @@ class _AddressInputFieldState extends State<AddressInputField> {
         compareFn: (AccountData i, s) => i.pubKey == s.pubKey,
         validator: (AccountData? u) => u == null ? dic.profile.errorUserNameIsRequired : null,
         asyncItems: _getAccountsFromInput,
-        itemAsString: _itemAsString,
         onChanged: (AccountData? data) {
           if (widget.onChanged != null && data != null) {
             widget.onChanged!(data);

--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -54,7 +54,7 @@ class _AddressInputFieldState extends State<AddressInputField> {
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(item.name.isNotEmpty ? item.name : Fmt.address(address)!),
+              Text(item.name),
               Text(
                 Fmt.address(address)!,
                 style: TextStyle(fontSize: 12, color: Theme.of(context).unselectedWidgetColor),
@@ -82,8 +82,8 @@ class _AddressInputFieldState extends State<AddressInputField> {
         key: Key(item.name),
         selected: isSelected,
         dense: true,
-        title: Text(Fmt.address(address)!),
-        subtitle: Text(item.name.isNotEmpty ? item.name : Fmt.address(address)!),
+        title: Text(item.name),
+        subtitle: Text(Fmt.address(address)!),
         leading: CircleAvatar(child: AddressIcon(item.address, item.pubKey)),
         onTap: () {
           widget.onChanged?.call(item);

--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -123,7 +123,6 @@ class _AddressInputFieldState extends State<AddressInputField> {
         selectedItem: widget.initialValue,
         compareFn: (AccountData i, s) => i.pubKey == s.pubKey,
         validator: (AccountData? u) => u == null ? dic.profile.errorUserNameIsRequired : null,
-        // For some reason there is no sync items?
         items: widget.store.account.accountListAll,
         filterFn: filterByAddressOrName,
         onChanged: (AccountData? data) {

--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -30,27 +30,10 @@ class AddressInputField extends StatefulWidget {
 }
 
 class _AddressInputFieldState extends State<AddressInputField> {
-  Future<List<AccountData>> _getAccountsFromInput(String input) async {
-    final listLocal = widget.store.account.accountList.toList()..addAll(widget.store.settings.contactList);
-
-    // return local account list if input empty
-    if (input.isEmpty || input.trim().length < 3) {
-      return listLocal;
-    }
-
-    return filterByAddressOrName(listLocal, input).toList();
-  }
-
-  /// Filters [accounts] by [nameOrAddress] and returns a filtered iterable.
-  ///
-  /// This returns duplicates if the `nameOrAddress` matches the name and the address of the same element.
-  Iterable<AccountData> filterByAddressOrName(Iterable<AccountData> accounts, String nameOrAddress) {
-    final filteredByName = accounts.where((account) => account.name.startsWith(nameOrAddress.trim()));
-    final filteredByAddress = accounts.where(
-      (account) => Fmt.addressOfAccount(account, widget.store).startsWith(nameOrAddress.trim()),
-    );
-
-    return filteredByName.followedBy(filteredByAddress);
+  /// Returns true if the [account]'s name or address starts with [nameOrAddress].
+  bool filterByAddressOrName(AccountData account, String nameOrAddress) {
+    return account.name.startsWith(nameOrAddress.trim()) ||
+        Fmt.addressOfAccount(account, widget.store).startsWith(nameOrAddress.trim());
   }
 
   Widget _selectedItemBuilder(BuildContext context, AccountData? item) {
@@ -155,7 +138,9 @@ class _AddressInputFieldState extends State<AddressInputField> {
         selectedItem: widget.initialValue,
         compareFn: (AccountData i, s) => i.pubKey == s.pubKey,
         validator: (AccountData? u) => u == null ? dic.profile.errorUserNameIsRequired : null,
-        asyncItems: _getAccountsFromInput,
+        // For some reason there is no sync items?
+        items: widget.store.account.accountListAll,
+        filterFn: filterByAddressOrName,
         onChanged: (AccountData? data) {
           if (widget.onChanged != null && data != null) {
             widget.onChanged!(data);

--- a/app/lib/common/components/address_input_field.dart
+++ b/app/lib/common/components/address_input_field.dart
@@ -1,6 +1,5 @@
 import 'package:dropdown_search/dropdown_search.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
 
 import 'package:encointer_wallet/common/components/address_icon.dart';
 import 'package:encointer_wallet/common/theme.dart';
@@ -40,71 +39,57 @@ class _AddressInputFieldState extends State<AddressInputField> {
     if (item == null) {
       return Container();
     }
-    return Observer(
-      builder: (_) {
-        final address = Fmt.addressOfAccount(item, widget.store);
-        return Container(
-          padding: const EdgeInsets.only(top: 8),
-          child: Row(
+
+    final address = Fmt.addressOfAccount(item, widget.store);
+
+    return Container(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          if (!widget.hideIdenticon)
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: AddressIcon(item.address, item.pubKey, tapToCopy: false, size: 36),
+            ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              if (!widget.hideIdenticon)
-                Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: AddressIcon(item.address, item.pubKey, tapToCopy: false, size: 36),
-                ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    item.name.isNotEmpty ? item.name : Fmt.address(address)!,
-                  ),
-                  Text(
-                    Fmt.address(address)!,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).unselectedWidgetColor,
-                    ),
-                  ),
-                ],
-              )
+              Text(item.name.isNotEmpty ? item.name : Fmt.address(address)!),
+              Text(
+                Fmt.address(address)!,
+                style: TextStyle(fontSize: 12, color: Theme.of(context).unselectedWidgetColor),
+              ),
             ],
-          ),
-        );
-      },
+          )
+        ],
+      ),
     );
   }
 
   Widget _listItemBuilder(BuildContext context, AccountData item, bool isSelected) {
-    return Observer(
-      builder: (_) {
-        final address = Fmt.addressOfAccount(item, widget.store);
-        return Container(
-          margin: const EdgeInsets.symmetric(horizontal: 8),
-          decoration: !isSelected
-              ? null
-              : BoxDecoration(
-                  border: Border.all(color: Theme.of(context).primaryColor),
-                  borderRadius: BorderRadius.circular(5),
-                  color: Colors.white,
-                ),
-          child: ListTile(
-            key: Key(item.name),
-            selected: isSelected,
-            dense: true,
-            title: Text(Fmt.address(address)!),
-            subtitle: Text(
-              item.name.isNotEmpty ? item.name : Fmt.address(address)!,
+    final address = Fmt.addressOfAccount(item, widget.store);
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: !isSelected
+          ? null
+          : BoxDecoration(
+              border: Border.all(color: Theme.of(context).primaryColor),
+              borderRadius: BorderRadius.circular(5),
+              color: Colors.white,
             ),
-            leading: CircleAvatar(
-              child: AddressIcon(item.address, item.pubKey),
-            ),
-            onTap: () {
-              widget.onChanged?.call(item);
-              Navigator.pop(context);
-            },
-          ),
-        );
-      },
+      child: ListTile(
+        key: Key(item.name),
+        selected: isSelected,
+        dense: true,
+        title: Text(Fmt.address(address)!),
+        subtitle: Text(item.name.isNotEmpty ? item.name : Fmt.address(address)!),
+        leading: CircleAvatar(child: AddressIcon(item.address, item.pubKey)),
+        onTap: () {
+          widget.onChanged?.call(item);
+          Navigator.pop(context);
+        },
+      ),
     );
   }
 

--- a/app/lib/js_service_encointer/src/service/account.js
+++ b/app/lib/js_service_encointer/src/service/account.js
@@ -168,12 +168,6 @@ async function addressFromUri(uri) {
   return keyring.encodeAddress(pubKey, ss58);
 }
 
-async function queryAddressWithAccountIndex (accIndex, ss58) {
-  const num = ss58Decode(accIndex, ss58).toJSON();
-  const res = await api.query.indices.accounts(num.data);
-  return res;
-}
-
 /**
  * get ERT balance of an address
  * @param {String} address
@@ -212,12 +206,6 @@ async function subscribeBalance (msgChannel, address) {
       lockedBreakdown
     });
   }).then((unsub) => unsubscribe(unsub, msgChannel));
-}
-
-function getAccountIndex (addresses) {
-  return api.derive.accounts.indexes().then((res) => {
-    return Promise.all(addresses.map((i) => api.derive.accounts.info(i)));
-  });
 }
 
 function getBlockTime (blocks) {
@@ -468,12 +456,10 @@ export default {
   addressFromUri,
   encodeAddress,
   decodeAddress,
-  queryAddressWithAccountIndex,
   gen,
   recover,
   getBalance,
   subscribeBalance,
-  getAccountIndex,
   getBlockTime,
   txFeeEstimate,
   sendTx,

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -74,14 +74,6 @@ class AccountApi {
     return address;
   }
 
-  /// query address with account index
-  Future<List<dynamic>?> queryAddressWithAccountIndex(String index) async {
-    final res = await jsApi.evalJavascript<List<dynamic>?>(
-      'account.queryAddressWithAccountIndex("$index", ${store.settings.endpoint.ss58})',
-    );
-    return res;
-  }
-
   Future<void> changeCurrentAccount({
     String? pubKey,
     bool fetchData = false,
@@ -148,17 +140,5 @@ class AccountApi {
     final pubKey = account.pubKey;
     Log.d('checkpass: $pubKey, $pass', 'AccountApi');
     return jsApi.evalJavascript('account.checkPassword("$pubKey", "$pass")');
-  }
-
-  Future<List<dynamic>> fetchAddressIndex(List addresses) async {
-    if (addresses.isEmpty) return [];
-
-    addresses.retainWhere((i) => !store.account.addressIndexMap.keys.contains(i));
-    if (addresses.isEmpty) return [];
-
-    final res = await jsApi.evalJavascript<List<dynamic>>('account.getAccountIndex(${jsonEncode(addresses)})');
-    store.account.setAddressIndex(res);
-
-    return res;
   }
 }

--- a/app/lib/store/account/account.dart
+++ b/app/lib/store/account/account.dart
@@ -58,9 +58,6 @@ abstract class _AccountStore with Store {
   ObservableList<AccountData> accountList = ObservableList<AccountData>();
 
   @observable
-  ObservableMap<String?, Map> addressIndexMap = ObservableMap<String?, Map>();
-
-  @observable
   Map<String?, Map> accountIndexMap = <String, Map>{};
 
   @observable
@@ -362,13 +359,6 @@ abstract class _AccountStore with Store {
       });
       // update state
       pubKeyAddressMap[int.parse(ss58)] = addresses;
-    }
-  }
-
-  @action
-  void setAddressIndex(List<dynamic> list) {
-    for (final i in list) {
-      addressIndexMap[(i as Map<String, dynamic>)['accountId'] as String] = i;
     }
   }
 }

--- a/app/lib/store/account/account.g.dart
+++ b/app/lib/store/account/account.g.dart
@@ -115,21 +115,6 @@ mixin _$AccountStore on _AccountStore, Store {
     });
   }
 
-  late final _$addressIndexMapAtom = Atom(name: '_AccountStore.addressIndexMap', context: context);
-
-  @override
-  ObservableMap<String?, Map<dynamic, dynamic>> get addressIndexMap {
-    _$addressIndexMapAtom.reportRead();
-    return super.addressIndexMap;
-  }
-
-  @override
-  set addressIndexMap(ObservableMap<String?, Map<dynamic, dynamic>> value) {
-    _$addressIndexMapAtom.reportWrite(value, super.addressIndexMap, () {
-      super.addressIndexMap = value;
-    });
-  }
-
   late final _$accountIndexMapAtom = Atom(name: '_AccountStore.accountIndexMap', context: context);
 
   @override
@@ -335,16 +320,6 @@ mixin _$AccountStore on _AccountStore, Store {
   }
 
   @override
-  void setAddressIndex(List<dynamic> list) {
-    final _$actionInfo = _$_AccountStoreActionController.startAction(name: '_AccountStore.setAddressIndex');
-    try {
-      return super.setAddressIndex(list);
-    } finally {
-      _$_AccountStoreActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
   String toString() {
     return '''
 loading: ${loading},
@@ -352,7 +327,6 @@ txStatus: ${txStatus},
 newAccount: ${newAccount},
 currentAccountPubKey: ${currentAccountPubKey},
 accountList: ${accountList},
-addressIndexMap: ${addressIndexMap},
 accountIndexMap: ${accountIndexMap},
 pubKeyAddressMap: ${pubKeyAddressMap},
 queuedTxs: ${queuedTxs},

--- a/app/lib/utils/format.dart
+++ b/app/lib/utils/format.dart
@@ -252,7 +252,12 @@ class Fmt {
     return tokenView;
   }
 
-  /// Returns the address of an account with the ss58-prefix encoded that matches the current network.
+  /// Returns the address of an account encoded with the ss58-prefix of the current network, if
+  /// available. Otherwise, it falls back the ss58 prefix of the connect network at account creation
+  /// time.
+  ///
+  /// This was inherited from upstream, and I have never observed that the fallback had to be
+  /// used.
   ///
   /// Todo: Improve handling of ss58-prefix: #1019
   static String addressOfAccount(AccountData acc, AppStore store) {

--- a/app/lib/utils/format.dart
+++ b/app/lib/utils/format.dart
@@ -252,6 +252,9 @@ class Fmt {
     return tokenView;
   }
 
+  /// Returns the address of an account with the ss58-prefix encoded that matches the current network.
+  ///
+  /// Todo: Improve handling of ss58-prefix: #1019
   static String addressOfAccount(AccountData acc, AppStore store) {
     return store.account.pubKeyAddressMap[store.settings.endpoint.ss58]![acc.pubKey] ?? acc.address;
   }


### PR DESCRIPTION
Before, the address input fields tried to look up onchain accounts. However, this feature is largely unnecessary IMO, as it needed a correct account id or account index to look up the account data on the blockchain. Further, the encointer blockchain does not even have the necessary pallet in the runtime.

So I removed all that code and simplified the address input field. Additionally, we can now filter by account name too.