### PR TITLE
Simplify network select page and remove `accountIndexMap` from account store

### DIFF
--- a/app/lib/page/network_select_page.dart
+++ b/app/lib/page/network_select_page.dart
@@ -83,34 +83,6 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
     Navigator.of(context).pop();
   }
 
-  Future<void> _onCreateAccount() async {
-    final isCurrentNetwork = _selectedNetwork.info == context.read<AppStore>().settings.endpoint.info;
-    if (!isCurrentNetwork) {
-      await _reloadNetwork();
-    }
-    Navigator.of(context).pushNamed(CreateAccountEntryPage.route);
-  }
-
-  Future<void> _showPasswordDialog(BuildContext context) async {
-    await showCupertinoDialog<void>(
-      context: context,
-      builder: (_) {
-        return Container(
-          child: showPasswordInputDialog(
-            context,
-            context.read<AppStore>().account.currentAccount,
-            Text(I18n.of(context)!.translationsForLocale().profile.unlock),
-            (String password) {
-              setState(() {
-                context.read<AppStore>().settings.setPin(password);
-              });
-            },
-          ),
-        );
-      },
-    );
-  }
-
   List<Widget> _buildAccountList() {
     // final primaryColor = Theme.of(context).primaryColor;
     final res = <Widget>[
@@ -121,19 +93,6 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
             _selectedNetwork.info!.toUpperCase(),
             style: Theme.of(context).textTheme.headlineMedium,
           ),
-          IconButton(
-              icon: Image.asset('assets/images/assets/plus_indigo.png'),
-              color: Theme.of(context).primaryColor,
-              onPressed: () async => {
-                    if (context.read<AppStore>().settings.cachedPin.isEmpty)
-                      {
-                        await _showPasswordDialog(context),
-                      }
-                    else
-                      {
-                        _onCreateAccount(),
-                      }
-                  })
         ],
       ),
     ];

--- a/app/lib/page/network_select_page.dart
+++ b/app/lib/page/network_select_page.dart
@@ -161,7 +161,7 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
         margin: const EdgeInsets.only(bottom: 16),
         padding: EdgeInsets.only(top: padding, bottom: padding),
         child: ListTile(
-          leading: AddressIcon(address!, i.pubKey),
+          leading: AddressIcon(address!, i.pubKey, size: 55),
           title: Text(Fmt.accountName(context, i)),
           subtitle: Text('$accIndex${Fmt.address(address)}', maxLines: 2),
           onTap: _networkChanging ? null : () => _onSelect(i, address),

--- a/app/lib/page/network_select_page.dart
+++ b/app/lib/page/network_select_page.dart
@@ -106,21 +106,16 @@ class _NetworkSelectPageState extends State<NetworkSelectPage> {
       if (context.read<AppStore>().account.pubKeyAddressMap[_selectedNetwork.ss58] != null) {
         address = context.read<AppStore>().account.pubKeyAddressMap[_selectedNetwork.ss58]![i.pubKey];
       }
-      final isCurrentNetwork = _selectedNetwork.info == context.read<AppStore>().settings.endpoint.info;
-      final accInfo = context.read<AppStore>().account.accountIndexMap[i.address];
-      final accIndex =
-          isCurrentNetwork && accInfo != null && accInfo['accountIndex'] != null ? '${accInfo['accountIndex']}\n' : '';
-      final padding = accIndex.isEmpty ? 0.0 : 7.0;
+
       return RoundedCard(
         border: address == context.read<AppStore>().account.currentAddress
             ? Border.all(color: Theme.of(context).primaryColorLight)
             : Border.all(color: Theme.of(context).cardColor),
         margin: const EdgeInsets.only(bottom: 16),
-        padding: EdgeInsets.only(top: padding, bottom: padding),
         child: ListTile(
           leading: AddressIcon(address!, i.pubKey, size: 55),
           title: Text(Fmt.accountName(context, i)),
-          subtitle: Text('$accIndex${Fmt.address(address)}', maxLines: 2),
+          subtitle: Text(Fmt.address(address)!, maxLines: 2),
           onTap: _networkChanging ? null : () => _onSelect(i, address),
         ),
       );

--- a/app/lib/page/network_select_page.dart
+++ b/app/lib/page/network_select_page.dart
@@ -4,10 +4,8 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:provider/provider.dart';
 
 import 'package:encointer_wallet/common/components/address_icon.dart';
-import 'package:encointer_wallet/common/components/password_input_dialog.dart';
 import 'package:encointer_wallet/common/components/rounded_card.dart';
 import 'package:encointer_wallet/config/consts.dart';
-import 'package:encointer_wallet/page/account/create_account_entry_page.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/account/types/account_data.dart';
 import 'package:encointer_wallet/store/app.dart';

--- a/app/lib/store/account/account.dart
+++ b/app/lib/store/account/account.dart
@@ -58,9 +58,6 @@ abstract class _AccountStore with Store {
   ObservableList<AccountData> accountList = ObservableList<AccountData>();
 
   @observable
-  Map<String?, Map> accountIndexMap = <String, Map>{};
-
-  @observable
   ObservableMap<int, Map<String, String>> pubKeyAddressMap = ObservableMap<int, Map<String, String>>();
 
   @observable

--- a/app/lib/store/account/account.g.dart
+++ b/app/lib/store/account/account.g.dart
@@ -115,21 +115,6 @@ mixin _$AccountStore on _AccountStore, Store {
     });
   }
 
-  late final _$accountIndexMapAtom = Atom(name: '_AccountStore.accountIndexMap', context: context);
-
-  @override
-  Map<String?, Map<dynamic, dynamic>> get accountIndexMap {
-    _$accountIndexMapAtom.reportRead();
-    return super.accountIndexMap;
-  }
-
-  @override
-  set accountIndexMap(Map<String?, Map<dynamic, dynamic>> value) {
-    _$accountIndexMapAtom.reportWrite(value, super.accountIndexMap, () {
-      super.accountIndexMap = value;
-    });
-  }
-
   late final _$pubKeyAddressMapAtom = Atom(name: '_AccountStore.pubKeyAddressMap', context: context);
 
   @override
@@ -327,7 +312,6 @@ txStatus: ${txStatus},
 newAccount: ${newAccount},
 currentAccountPubKey: ${currentAccountPubKey},
 accountList: ${accountList},
-accountIndexMap: ${accountIndexMap},
 pubKeyAddressMap: ${pubKeyAddressMap},
 queuedTxs: ${queuedTxs},
 currentAccount: ${currentAccount},


### PR DESCRIPTION
Changes:
* [NetworkSelectPage]: Remove the account creation button
* [NetworkSelectPage]: Finally fix the distorted icons display
* [NetworkSelectPage]: Remove handling of the account index, as it does not exist on encointer anyhow, for more info #1017.