### PR TITLE
Fix timezone uninitialized warning in integration test

### DIFF
--- a/app/test_driver/app.dart
+++ b/app/test_driver/app.dart
@@ -9,6 +9,7 @@ import 'package:upgrader/upgrader.dart';
 import 'package:encointer_wallet/app.dart';
 import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/mocks/storage/mock_local_storage.dart';
+import 'package:encointer_wallet/service/notification/lib/notification.dart';
 import 'package:encointer_wallet/mocks/storage/mock_storage_setup.dart';
 import 'package:encointer_wallet/mocks/storage/prepare_mock_storage.dart';
 import 'package:encointer_wallet/modules/modules.dart';
@@ -53,6 +54,8 @@ void main() async {
   enableFlutterDriverExtension(handler: dataHandler);
   WidgetsApp.debugAllowBannerOverride = false; // remove debug banner for screenshots
 
+  WidgetsFlutterBinding.ensureInitialized();
+  await NotificationPlugin.setup();
   // Clear settings to make upgrade dialog visible in subsequent test runs.
   await Upgrader.clearSavedSettings();
   final localService = LangService(await SharedPreferences.getInstance());


### PR DESCRIPTION
## Fix timezone uninitialized warning in integration test (app test)
```console
E/flutter ( 3321): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: LateInitializationError: Field '_local@447310200' has not been initialized.
E/flutter ( 3321): #0      _local (package:timezone/src/env.dart)
E/flutter ( 3321): #1      local (package:timezone/src/env.dart:28:23)
E/flutter ( 3321): #2      _EncointerHomePageState.initState.<anonymous closure> (package:encointer_wallet/page-encointer/home_page.dart:39:12)
E/flutter ( 3321): <asynchronous suspension>
```
I noticed this error give only when we test  `test_driver/app.dart`. Because in `test_driver/app.dart` file we didn’t call `await NotificationPlugin.setup();`
* Closes #1037