### PR TITLE
Change contact name

### DIFF
--- a/app/lib/page/profile/contacts/contact_detail_page.dart
+++ b/app/lib/page/profile/contacts/contact_detail_page.dart
@@ -31,7 +31,7 @@ class ContactDetailPage extends StatefulWidget {
 
 class _ContactDetailPageState extends State<ContactDetailPage> {
   final TextEditingController _nameCtrl = TextEditingController();
-  late AccountData account;
+  late final AccountData account;
   bool isEditing = false;
 
   @override
@@ -45,19 +45,17 @@ class _ContactDetailPageState extends State<ContactDetailPage> {
   Widget build(BuildContext context) {
     final dic = I18n.of(context)!.translationsForLocale();
     final store = context.watch<AppStore>();
+    final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
       appBar: AppBar(
         title: !isEditing
-            ? Text(
-                _nameCtrl.text,
-                style: Theme.of(context).textTheme.displaySmall,
-              )
-            : TextFormField(controller: _nameCtrl),
+            ? Text(_nameCtrl.text, style: textTheme.displaySmall)
+            : TextFormField(key: const Key('contact-name-field'), controller: _nameCtrl),
         actions: [
           if (isEditing)
             IconButton(
-              key: const Key('account-name-edit-check'),
+              key: const Key('contact-name-edit-check'),
               icon: const Icon(Icons.check),
               onPressed: () async {
                 if (_nameCtrl.text != widget.accountData.name) {
@@ -77,7 +75,7 @@ class _ContactDetailPageState extends State<ContactDetailPage> {
             )
           else
             IconButton(
-              key: const Key('account-name-edit'),
+              key: const Key('contact-name-edit'),
               icon: const Icon(Iconsax.edit),
               onPressed: () {
                 setState(() {
@@ -131,8 +129,10 @@ class _ContactDetailPageState extends State<ContactDetailPage> {
                   children: [
                     const Icon(Iconsax.send_sqaure_2),
                     const SizedBox(width: 12),
-                    Text(dic.profile.tokenSend.replaceAll('SYMBOL', store.encointer.community?.symbol ?? 'null'),
-                        style: Theme.of(context).textTheme.displaySmall),
+                    Text(
+                      dic.profile.tokenSend.replaceAll('SYMBOL', store.encointer.community?.symbol ?? 'null'),
+                      style: textTheme.displaySmall,
+                    ),
                   ],
                 ),
                 onPressed: () {
@@ -155,7 +155,7 @@ class _ContactDetailPageState extends State<ContactDetailPage> {
                   children: [
                     const Icon(Iconsax.trash),
                     const SizedBox(width: 12),
-                    Text(dic.profile.contactDelete, style: Theme.of(context).textTheme.displaySmall)
+                    Text(dic.profile.contactDelete, style: textTheme.displaySmall)
                   ],
                 ),
               ),
@@ -207,6 +207,7 @@ class EndorseButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dic = I18n.of(context)!.translationsForLocale();
+    final textTheme = Theme.of(context).textTheme;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -250,7 +251,7 @@ class EndorseButton extends StatelessWidget {
                 children: [
                   const Icon(Iconsax.verify),
                   const SizedBox(width: 12),
-                  Text(dic.profile.contactEndorse, style: Theme.of(context).textTheme.displaySmall)
+                  Text(dic.profile.contactEndorse, style: textTheme.displaySmall)
                 ],
               ),
             ),

--- a/app/lib/page/profile/contacts/contact_detail_page.dart
+++ b/app/lib/page/profile/contacts/contact_detail_page.dart
@@ -49,9 +49,9 @@ class _ContactDetailPageState extends State<ContactDetailPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: !isEditing
-            ? Text(_nameCtrl.text, style: textTheme.displaySmall)
-            : TextFormField(key: const Key('contact-name-field'), controller: _nameCtrl),
+        title: isEditing
+            ? TextFormField(key: const Key('contact-name-field'), controller: _nameCtrl)
+            : Text(_nameCtrl.text, style: textTheme.displaySmall),
         actions: [
           if (isEditing)
             IconButton(

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/store/account/types/account_data.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 
@@ -152,10 +153,8 @@ class AppRoute {
           settings: settings,
         );
       case ContactDetailPage.route:
-        return CupertinoPageRoute(
-          builder: (_) => ContactDetailPage(webApi),
-          settings: settings,
-        );
+        final arg = settings.arguments!;
+        return CupertinoPageRoute(builder: (_) => ContactDetailPage(arg as AccountData));
       case SettingsPage.route:
         return CupertinoPageRoute(
           builder: (_) => const SettingsPage(),

--- a/app/test_driver/real_app_test.dart
+++ b/app/test_driver/real_app_test.dart
@@ -185,16 +185,31 @@ void main() async {
     await driver.tap(find.byValueKey('contact-address'));
     await driver.enterText('5Gjvca5pwQXENZeLz3LPWsbBXRCKGeALNj1ho13EFmK1FMWW');
     await driver.tap(find.byValueKey('contact-name'));
-    await driver.enterText('Sezar');
+    await driver.enterText('Obelix');
 
     await driver.tap(find.byValueKey('contact-save'));
     await addDelay(1000);
   });
 
-  test('send endorse to account', () async {
-    await driver.waitFor(find.byValueKey('Sezar'));
-    await driver.tap(find.byValueKey('Sezar'));
+  test('change contact name', () async {
+    await driver.waitFor(find.byValueKey('Obelix'));
+    await driver.tap(find.byValueKey('Obelix'));
 
+    await driver.waitFor(find.byValueKey('contact-name-edit'));
+    await driver.tap(find.byValueKey('contact-name-edit'));
+
+    await driver.waitFor(find.byValueKey('contact-name-field'));
+    await driver.tap(find.byValueKey('contact-name-field'));
+
+    await driver.enterText('Asterix');
+    await driver.tap(find.byValueKey('contact-name-edit-check'));
+
+    await driver.waitFor(find.text('Asterix'));
+
+    await addDelay(1000);
+  });
+
+  test('send endorse to account', () async {
     await driver.waitFor(find.byValueKey('tap-endorse-button'));
     await driver.tap(find.byValueKey('tap-endorse-button'));
     await addDelay(1000);


### PR DESCRIPTION
User can change contact name
I used `StatefulWidget` widget so that I could use `setState` method.
I didn't refactor so PR wouldn't grow.
If you want, I can create `ContactsStore` for Contact pages and refactor UI codes or I can do another PR for refactoring.

- [x] added `change contact name` test to real app integration test
- [x] Our *Sezar* changed to  *Obelix*. Integration test will change *Obelix* to *Asterix* 😂😂

* Closes #416 