### PR TITLE
Upgrade melos v3.0.0

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -26,7 +26,6 @@ command:
 # For more complex scenarios, we can consider writing cross-platform dart scripts as mentioned in this issue:
 # https://github.com/invertase/melos/issues/122
 
-
 scripts:
   format:
     run: >-

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  cli_launcher:
+    dependency: transitive
+    description:
+      name: cli_launcher
+      sha256: "5e7e0282b79e8642edd6510ee468ae2976d847a0a29b3916e85f5fa1bfe24005"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   cli_util:
     dependency: transitive
     description:
@@ -53,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: conventional_commit
-      sha256: "23b6865cc9f71913f8d3dd08e6c5b8d450a7357a9a59194340bf8dda13c9273d"
+      sha256: "8eee25c315cf1946215d02d598402ca75cfee8a8ab482f3fac34cb0717323afa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0+1"
+    version: "0.6.0"
   file:
     dependency: transitive
     description:
@@ -125,10 +133,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "913b9fbafafb70b786d2564d09468feee71d4ce9ccbc17c584cf70a7605c755d"
+      sha256: cd8e7db0250ee822c5354a8214afc751b6c1c41aadfbbef927456d509d953244
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "3.0.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   flutter: "3.7.3"
 
 dev_dependencies:
-  melos: "2.9.0"
+  melos: "3.0.0"


### PR DESCRIPTION
I got error like this from `github tests` and i was very surprised. 
And i found out it has to do with `melos`.
[see more about migrations](https://melos.invertase.dev/guides/migrations)
```console
Run ./flutterw pub global run melos bootstrap
  ./flutterw pub global run melos bootstrap
  shell: /bin/bash -e {0}
  env:
    NODE_VERSION: 16.13.1
    JAVA_VERSION: 1[2](https://github.com/encointer/encointer-wallet-flutter/actions/runs/4383959347/jobs/7674846517#step:10:2).x
    TEMP_SCREENSHOTS: /tmp/screenshots
    JAVA_HOME: /Users/runner/hostedtoolcache/Java_Zulu_jdk/12.0.2-[3](https://github.com/encointer/encointer-wallet-flutter/actions/runs/4383959347/jobs/7674846517#step:10:3)/x6[4](https://github.com/encointer/encointer-wallet-flutter/actions/runs/4383959347/jobs/7674846517#step:10:4)
    JAVA_HOME_12_X64: /Users/runner/hostedtoolcache/Java_Zulu_jdk/12.0.2-3/x64
Unhandled exception:
ProcessException: No such file or directory
  Command: dart run melos:melos CLI_LAUNCHER_LAUNCH_CONTEXT {"d":"/Users/runner/work/encointer-wallet-flutter/encointer-wallet-flutter","g":{"v":"3.0.0","e":{"p":"melos","e":"melos"},"s":false,"fp":null,"p":"/Users/runner/.pub-cache/global_packages/melos"},"l":{"v":"2.9.0","e":{"p":"melos","e":"melos"},"s":false,"fp":false,"p":"/Users/runner/work/encointer-wallet-flutter/encointer-wallet-flutter"}} bootstrap
#0      _ProcessImpl._start (dart:io-patch/process_patch.dart:401:33)
#1      Process.start (dart:io-patch/process_patch.dart:38:20)
#2      launchExecutable (package:cli_launcher/cli_launcher.dart:400:3[5](https://github.com/encointer/encointer-wallet-flutter/actions/runs/4383959347/jobs/7674846517#step:10:5))
#3      main (file:///Users/runner/.pub-cache/hosted/pub.dev/melos-3.0.0/bin/melos.dart:4:52)
#4      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:33)
#5      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:192:2[6](https://github.com/encointer/encointer-wallet-flutter/actions/runs/4383959347/jobs/7674846517#step:10:6))
pub finished with exit code 255
Error: Process completed with exit code 255.
```