### PR TITLE
Add CI label check

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -1,0 +1,29 @@
+# File is copy-pasted and adapted from Integritee worker:
+# https://github.com/integritee-network/worker/blob/1a58d6a625fa76935902f16c798efa453bcef9a4/.github/workflows/label-checker.yml
+
+name: Check labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, ready_for_review]
+
+jobs:
+    check_for_matching_labels:
+      runs-on: ubuntu-latest
+      if: github.base_ref == 'master' && github.event.pull_request.draft == false
+      matrix:
+        include:
+          - test: A-change-type
+            enforced_labels: "A0-UX,A1-BugFix,A2-Technical"
+          - test: B-urgency
+            enforced_labels: "B0-Low,B1-Medium,B2-Critical"
+          - test: C-breaking-changes
+            enforced_labels: "C0-BreaksNothing,C1-BreaksApi"
+      steps:
+        - name: Label check
+          run: |
+            MATCH=$(jq -cn '${{ toJSON(github.event.pull_request.labels.*.name) }} as $USER_LABELS |
+            ${{ toJSON(matrix.enforced_labels)  }} | split(",") as $LABELS |
+            $USER_LABELS - ($USER_LABELS - $LABELS)')
+            if [[  "$MATCH" == '[]' ]]; then
+                exit 1
+            fi

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -7,19 +7,19 @@ on:
     types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 
 jobs:
-    check_for_matching_labels:
+    label-check:
       runs-on: ubuntu-latest
       if: github.base_ref == 'master' && github.event.pull_request.draft == false
       strategy:
         fail-fast: false
         matrix:
           include:
-            - test: A-change-type
-              enforced_labels: "A0-UX,A1-BugFix,A2-Technical"
-            - test: B-urgency
-              enforced_labels: "B0-Low,B1-Medium,B2-Critical"
-            - test: C-breaking-changes
-              enforced_labels: "C0-BreaksNothing,C1-BreaksApi"
+            - test: A Label (change type)
+              enforced_labels: "A0-ux,A1-bugfix,A2-technical"
+            - test: B Label (urgency)
+              enforced_labels: "B0-low,B1-medium,B2-critical"
+            - test: C Label (breaking changes)
+              enforced_labels: "C0-breaksnothing,C1-breaksapi"
       steps:
         - name: Label check
           run: |

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -10,14 +10,16 @@ jobs:
     check_for_matching_labels:
       runs-on: ubuntu-latest
       if: github.base_ref == 'master' && github.event.pull_request.draft == false
-      matrix:
-        include:
-          - test: A-change-type
-            enforced_labels: "A0-UX,A1-BugFix,A2-Technical"
-          - test: B-urgency
-            enforced_labels: "B0-Low,B1-Medium,B2-Critical"
-          - test: C-breaking-changes
-            enforced_labels: "C0-BreaksNothing,C1-BreaksApi"
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - test: A-change-type
+              enforced_labels: "A0-UX,A1-BugFix,A2-Technical"
+            - test: B-urgency
+              enforced_labels: "B0-Low,B1-Medium,B2-Critical"
+            - test: C-breaking-changes
+              enforced_labels: "C0-BreaksNothing,C1-BreaksApi"
       steps:
         - name: Label check
           run: |


### PR DESCRIPTION
CI now enforces on (non-draft) PRs at least one label of each category listed below:
- A label (change type):
    - `A0-ux`
    - `A1-bugfix`
    - `A2-technical`

- B label (urgency):
    - `B0-low`
    - `B1-medium`
    - `B2-critical`

- C label (breaking changes)
    - `C0-breaksnothing`
    - `C1-breaksapi`

part of https://github.com/encointer/encointer-wallet-flutter/issues/705

@clangenb  please check the newly introduced labels as well.

Tested:
- [x] PR does not fail if in draft mode: https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466657435/jobs/7845120019?pr=1
- [x] No label: failed https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466591490/jobs/7844970780?pr=1
- [x] Failed run with A label(s): https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466626088/jobs/7845050080?pr=1
- [x] Failed run with B labels(s):  https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466638253/jobs/7845076573?pr=1
- [x] Failed run with B & C labels(s):  https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466642479/jobs/7845085647?pr=1
- [x] Success with one label of each category: https://github.com/haerdib/encointer-wallet-flutter/actions/runs/4466647181/jobs/7845096436?pr=1