### PR TITLE
Fix flaky integration test: share and change account name

### DIFF
--- a/app/lib/page/profile/account/account_manage_page.dart
+++ b/app/lib/page/profile/account/account_manage_page.dart
@@ -192,8 +192,8 @@ class _AccountManagePageState extends State<AccountManagePage> {
               IconButton(
                 key: const Key('account-name-edit-check'),
                 icon: const Icon(Icons.check),
-                onPressed: () {
-                  _appStore.account.updateAccountName(accountToBeEdited, _nameCtrl!.text.trim());
+                onPressed: () async {
+                  await _appStore.account.updateAccountName(accountToBeEdited, _nameCtrl!.text.trim());
                   setState(() {
                     _isEditingText = false;
                   });

--- a/app/test_driver/helpers/other_test.dart
+++ b/app/test_driver/helpers/other_test.dart
@@ -56,7 +56,7 @@ Future<void> sendMoneyToAccount(FlutterDriver driver) async {
   });
 }
 
-Future<void> shareAccountAndChangeNameTest(FlutterDriver driver, String account, String changedName) async {
+Future<void> shareAccount(FlutterDriver driver, String account) async {
   await driver.tap(find.byValueKey('profile'));
 
   await driver.waitFor(find.byValueKey(account));
@@ -68,17 +68,26 @@ Future<void> shareAccountAndChangeNameTest(FlutterDriver driver, String account,
   await addDelay(800);
   await driver.waitFor(find.byValueKey('close-share-page'));
   await driver.tap(find.byValueKey('close-share-page'));
+  await addDelay(500);
+}
 
+Future<void> accountChangeName(FlutterDriver driver, String changedName) async {
   await driver.waitFor(find.byValueKey('account-name-edit'));
   await driver.tap(find.byValueKey('account-name-edit'));
+  await addDelay(500);
 
   await driver.waitFor(find.byValueKey('account-name-field'));
   await driver.tap(find.byValueKey('account-name-field'));
   await driver.enterText(changedName);
+  await addDelay(1500);
+
   await driver.tap(find.byValueKey('account-name-edit-check'));
+  await addDelay(700);
   await driver.waitFor(find.text(changedName));
   await addDelay(1000);
+}
 
+Future<void> accountExport(FlutterDriver driver) async {
   await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
   await driver.tap(find.byValueKey('export'));
   await driver.tap(find.byValueKey('input-password-dialog'));
@@ -88,17 +97,15 @@ Future<void> shareAccountAndChangeNameTest(FlutterDriver driver, String account,
   await driver.waitFor(find.byValueKey('account-mnemonic-key'));
   await addDelay(1000);
   await driver.tap(find.pageBack());
-
-  await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
-  await driver.tap(find.byValueKey('delete'));
-  await driver.waitFor(find.byValueKey('delete-account'));
-  await driver.tap(find.byValueKey('delete-account'));
 }
 
 Future<void> deleteAccountFromAccountManagePage(FlutterDriver driver, String account) async {
   await driver.waitFor(find.byValueKey(account));
   await driver.tap(find.byValueKey(account));
+  await accountDeleteFromAccountManagePage(driver);
+}
 
+Future<void> accountDeleteFromAccountManagePage(FlutterDriver driver) async {
   await driver.tap(find.byValueKey('popup-menu-account-trash-export'));
   await driver.tap(find.byValueKey('delete'));
   await driver.waitFor(find.byValueKey('delete-account'));

--- a/app/test_driver/real_app_test.dart
+++ b/app/test_driver/real_app_test.dart
@@ -290,10 +290,25 @@ void main() async {
     await scrollToPanelController(driver);
   }, timeout: const Timeout(Duration(seconds: 120)));
 
-  test('account share and change name', () async {
+  test('account share', () async {
     await changeAccountFromPanel(driver, 'Tom');
-    await shareAccountAndChangeNameTest(driver, 'Tom', 'Jerry');
+    await shareAccount(driver, 'Tom');
     await addDelay(2500);
+  }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('account change name', () async {
+    await accountChangeName(driver, 'Jerry');
+    await addDelay(500);
+  }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('account export', () async {
+    await accountExport(driver);
+    await addDelay(500);
+  }, timeout: const Timeout(Duration(seconds: 120)));
+
+  test('account delete from account manage page', () async {
+    await accountDeleteFromAccountManagePage(driver);
+    await addDelay(500);
   }, timeout: const Timeout(Duration(seconds: 120)));
 
   test('delete all account ad show create account page', () async {


### PR DESCRIPTION
## Fix integration test share and change account name error
Some times real app integration test give error for axample:
```console
11:01 +31 -1: delete all account ad show create account page

VMServiceFlutterDriver: tap message is taking a long time to complete...

11:31 +31 -2: delete all account ad show create account page [E]

  TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts

  package:test_api/src/backend/invoker.dart 334:28  Invoker._handleError.<fn>
  dart:async/zone.dart 1390:47                      _rootRun
  dart:async/zone.dart 1300:19                      _CustomZone.run
  package:test_api/src/backend/invoker.dart 332:10  Invoker._handleError
  package:test_api/src/backend/invoker.dart 288:9   Invoker.heartbeat.<fn>.<fn>
  dart:async/zone.dart 1398:13                      _rootRun
  dart:async/zone.dart 1300:19                      _CustomZone.run
  package:test_api/src/backend/invoker.dart 287:38  Invoker.heartbeat.<fn>
  dart:async-patch/timer_patch.dart 18:15           Timer._createTimer.<fn>
  dart:isolate-patch/timer_impl.dart 398:19         _Timer._runTimers
  dart:isolate-patch/timer_impl.dart 429:5          _Timer._handleMessage
  dart:isolate-patch/isolate_patch.dart 192:26      _RawReceivePort._handleMessage


11:31 +31 -2: (tearDownAll)

11:31 +31 -2: account share and change name [E]

  DriverError: Failed to fulfill WaitFor due to remote error
  Original error: ext.flutter.driver: (-32000) Service connection disposed
  Original stack trace:
```