### PR TITLE
[CI] add automatic draft release generation

### DIFF
--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -1,0 +1,28 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'E0-silent'
+categories:
+  - title: ' ‼️ High Priority Release '
+    labels:
+      - 'B2-critical'
+  - title: '⚡ Breaking API Changes'
+    labels:
+      - 'C1-breaksapi'
+  - title: ' [Bug Fixes] '
+    collapse-after: 5
+    label:
+      - 'A1-bugfix'
+  - title: '[UX]'
+    collapse-after: 5
+    labels:
+      - 'A0-ux'
+  - title: ' [Technical] '
+    collapse-after: 5
+    label:
+      - 'A2-technical'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## What's Changed since $PREVIOUS_TAG
+  $CHANGES

--- a/.github/release_template.yml
+++ b/.github/release_template.yml
@@ -4,21 +4,19 @@ exclude-labels:
   - 'E0-silent'
 categories:
   - title: ' ‼️ High Priority Release '
+    collapse-after: 2
     labels:
       - 'B2-critical'
   - title: '⚡ Breaking API Changes'
     labels:
       - 'C1-breaksapi'
   - title: ' [Bug Fixes] '
-    collapse-after: 5
     label:
       - 'A1-bugfix'
   - title: '[UX]'
-    collapse-after: 5
     labels:
       - 'A0-ux'
   - title: ' [Technical] '
-    collapse-after: 5
     label:
       - 'A2-technical'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,0 +1,22 @@
+name: Release - Publish Draft
+
+on:
+  push:
+    tags:
+      # Catches v1.2.3 and v1.2.3-rc1
+      - v[0-9]+.[0-9]+.[0-9]+*
+jobs:
+  update_release_draft:
+    permissions:
+      # Write permission is required to create a github release
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release_template.yml
+          tag:  ${{ github.ref_name }}
+          name:  ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Generates a draft release upon a new tag with the name matching the format of `v[0-9]+.[0-9]+.[0-9]+*`. The release drafter will take all merges since the last published release and categorizes according to the PR labels.
Categories that do not have any commit do not get listed in the release.

Currently unused: `B1-medium` priority. Reasoning: if both, high and medium priorities PR are committed, both categories get listed. Ideally, only the highest priority would get printed, but that's not possible with the release drafter. If you'd like that, the more complex variant from the worker would be my next take. 

Important: Remember to publish the created draft releases. Otherwise, CI will simply overwrite the previous draft release when the next tag is pushed.

Uses the release drafter from https://github.com/release-drafter/release-drafter

Examples releases:
- Category `High Priority` collapses after 2 commits (https://github.com/haerdib/encointer-wallet-flutter/releases/tag/v0.12.0)
![grafik](https://user-images.githubusercontent.com/73821294/227892130-b76dc9da-8916-45e5-8c1c-e1a2c59e87a7.png)

- With labels `B2-critical` and `C1-breaksapi`:  https://github.com/haerdib/encointer-wallet-flutter/releases/tag/v0.10.0:
![grafik](https://user-images.githubusercontent.com/73821294/227890419-5f1f4860-d2ba-41b2-81ac-d58e043ef880.png)

- Without Critical priority and no breaking changes: https://github.com/haerdib/encointer-wallet-flutter/releases/tag/v0.11.0:
![grafik](https://user-images.githubusercontent.com/73821294/227892284-49e3a401-7265-4458-804d-5463fbc9162f.png)


