### PR TITLE
Remove ss58-prefix override and use the network-specific prefix for address display

### DIFF
--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -92,32 +92,14 @@ async function recover (keyType, cryptoType, key, password) {
 }
 
 /**
- * Add user's accounts to keyring incedence,
- * so user can use them to sign txs with password.
- * We use a list of ss58Formats to encode the accounts
- * into different address formats for different networks.
+ * Import accounts in to the `keyring` that can be used to
+ * sign extrinsics from then on.
  *
  * @param {List<Keystore>} accounts
- * @param {List<int>} ss58Formats
- * @returns {Map<String, String>} pubKeyAddressMap
  */
-async function initKeys (accounts, ss58Formats) {
+async function initKeys (accounts) {
   await cryptoWaitReady();
-  const res = {};
-  ss58Formats.forEach((ss58) => {
-    res[ss58] = {};
-  });
-
-  accounts.forEach((i) => {
-    // import account to keyring
-    const keyPair = keyring.addFromJson(i);
-    // then encode address into different ss58 formats
-    ss58Formats.forEach((ss58) => {
-      const pubKey = u8aToHex(keyPair.publicKey);
-      res[ss58][pubKey] = keyring.encodeAddress(keyPair.publicKey, ss58);
-    });
-  });
-  return res;
+  accounts.forEach((i) => keyring.addFromJson(i));
 }
 
 /**

--- a/app/js_service_encointer/src/service/settings.js
+++ b/app/js_service_encointer/src/service/settings.js
@@ -155,19 +155,6 @@ async function createApi(wsProvider, configOverride) {
     Object.assign(pallets, configOverride.pallets);
   }
   window.send('log', `overwritten pallet config: ${JSON.stringify(pallets)}`);
-
-  const chainProperties = api.registry.getChainProperties();
-  window.send('log', `chain properties: ${chainProperties}`);
-
-  // Hardcode SS58-prefix to 42, see https://github.com/encointer/encointer-wallet-flutter/issues/567
-  const properties = {
-    ss58Format: 42,
-    tokenDecimals: chainProperties.tokenDecimals,
-    tokenSymbol: chainProperties.tokenSymbol
-  };
-
-  window.send('log', `ss58 overwritten chain properties: ${JSON.stringify(properties)}`);
-  api.registry.setChainProperties(properties);
   return api;
 }
 

--- a/app/lib/config/consts.dart
+++ b/app/lib/config/consts.dart
@@ -28,7 +28,7 @@ EndpointData networkEndpointEncointerLietaer = EndpointData.fromJson({
 
 EndpointData networkEndpointEncointerMainnet = EndpointData.fromJson({
   'info': 'nctr-k',
-  'ss58': 42, // Fixme: #567
+  'ss58': 2,
   'text': 'Encointer Network on Kusama (Hosted by Encointer Association)',
   'value': 'wss://kusama.api.encointer.org',
   'overrideConfig': gesellConfig.toJson(),

--- a/app/lib/config/consts.dart
+++ b/app/lib/config/consts.dart
@@ -76,18 +76,6 @@ List<EndpointData> networkEndpoints = [
   // networkEndpointEncointerCantillonDev,
 ];
 
-const networkSs58Map = {
-  'encointer': 42,
-  'nctr-gsl': 42,
-  'nctr-r': 42,
-  'nctr-k': 42, // Fixme: #567
-  'ss58': 42, // Fixme: #567
-  'nctr-cln': 42,
-  'nctr-gsl-dev': 42,
-  'nctr-cln-dev': 42,
-  'substrate': 42,
-};
-
 const fallBackCommunityIcon = 'assets/nctr_logo_faces_only_thick.svg';
 const communityIconName = 'community_icon.svg';
 

--- a/app/lib/mocks/substrate_api/mock_encointer_api.dart
+++ b/app/lib/mocks/substrate_api/mock_encointer_api.dart
@@ -51,7 +51,7 @@ class MockEncointerApi extends EncointerApi {
   }
 
   @override
-  Future<AggregatedAccountData> getAggregatedAccountData(CommunityIdentifier cid, String address) {
+  Future<AggregatedAccountData> getAggregatedAccountData(CommunityIdentifier cid, String pubKey) {
     // ignore: null_argument_to_non_null_type
     return Future.value();
   }

--- a/app/lib/models/ceremonies/ceremonies.dart
+++ b/app/lib/models/ceremonies/ceremonies.dart
@@ -95,6 +95,7 @@ class Meetup {
   int locationIndex;
   // time is null in assigning phase
   int? time;
+
   /// Addresses belonging to the meetup encoded with prefix 42.
   List<String> registry;
 

--- a/app/lib/models/ceremonies/ceremonies.dart
+++ b/app/lib/models/ceremonies/ceremonies.dart
@@ -95,6 +95,7 @@ class Meetup {
   int locationIndex;
   // time is null in assigning phase
   int? time;
+  /// Addresses belonging to the meetup encoded with prefix 42.
   List<String> registry;
 
   @override

--- a/app/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/app/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/utils/format.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
@@ -139,9 +140,12 @@ class CeremonyStep2Scan extends StatelessWidget {
   }
 
   int getCurrentAccountIndex() {
-    final currentAddress = store.account.currentAddress;
-    final participiants = store.encointer.communityAccount!.meetup!.registry;
-    return participiants.indexOf(currentAddress);
+    final currentAccountPubKey = store.account.currentAccountPubKey!;
+    final participants = store.encointer.communityAccount!.meetup!.registry;
+    final address = Fmt.ss58Encode(currentAccountPubKey);
+
+    // the addresses of the meetup are unfortunately encoded with the default prefix: 42.
+    return participants.indexOf(address);
   }
 }
 

--- a/app/lib/page-encointer/meetup/ceremony_step2_scan2.dart
+++ b/app/lib/page-encointer/meetup/ceremony_step2_scan2.dart
@@ -41,7 +41,7 @@ class CeremonyStep2Scan extends StatelessWidget {
       appBar: AppBar(
         title: Text(dic.encointer.keySigningCycle),
         actions: [
-          UserMeetupAvatar(index: getCurrentAccountIndex()),
+          UserMeetupAvatar(index: meetupIndexOfAccount(store.account.currentAccountPubKey!)),
           const SizedBox(
             width: 20,
           )
@@ -139,12 +139,11 @@ class CeremonyStep2Scan extends StatelessWidget {
     );
   }
 
-  int getCurrentAccountIndex() {
-    final currentAccountPubKey = store.account.currentAccountPubKey!;
+  int meetupIndexOfAccount(String accountPubKey) {
     final participants = store.encointer.communityAccount!.meetup!.registry;
-    final address = Fmt.ss58Encode(currentAccountPubKey);
+    final address = Fmt.ss58Encode(accountPubKey);
 
-    // the addresses of the meetup are unfortunately encoded with the default prefix: 42.
+    // the addresses of the meetup are encoded with the default prefix: 42.
     return participants.indexOf(address);
   }
 }

--- a/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -23,40 +24,45 @@ class ScanClaimQrCode extends StatefulWidget {
 }
 
 class _ScanClaimQrCodeState extends State<ScanClaimQrCode> {
-  late final List<String> allParticipants;
-  late final String currentAddress;
+  late final List<String> allParticipantsPrefix42;
+  late final String currentAddressPrefix42;
 
   @override
   void initState() {
     final store = context.read<AppStore>();
-    currentAddress = store.account.currentAddress;
-    allParticipants = store.encointer.communityAccount?.meetup?.registry ?? [];
+    currentAddressPrefix42 = Fmt.ss58Encode(store.account.currentAccountPubKey!);
+    allParticipantsPrefix42 = store.encointer.communityAccount?.meetup?.registry ?? [];
     super.initState();
   }
 
-  void validateAndStoreParticipant(AppStore store, String attendee, Translations dic) {
-    if (attendee == currentAddress) {
+  /// Checks that the `attendeeAddress` is not equal to self and part of the meetup registry.
+  Future<void> validateAndStoreParticipant(AppStore store, String attendeeAddress, Translations dic) async {
+    // Todo: Replace this with a pure dart version #1105.
+    final attendeePubKey = await webApi.account.addressToPubKey(attendeeAddress);
+    final attendeeAddressPrefix42 = Fmt.ss58Encode(attendeePubKey);
+
+    if (attendeeAddressPrefix42 == currentAddressPrefix42) {
       RootSnackBar.showMsg(dic.encointer.meetupClaimantEqualToSelf);
-      Log.d('Claimant: $attendee is equal to self', 'ScanClaimQrCode');
+      Log.d('Claimant: $attendeeAddressPrefix42 is equal to self', 'ScanClaimQrCode');
     } else {
-      if (!allParticipants.contains(attendee)) {
+      if (!allParticipantsPrefix42.contains(attendeeAddressPrefix42)) {
         // this is important because the runtime checks if there are too many claims trying to be registered.
         RootSnackBar.showMsg(dic.encointer.meetupClaimantInvalid);
-        Log.d('Claimant: $attendee is not part of registry: $allParticipants', 'ScanClaimQrCode');
+        Log.d('Claimant: $attendeeAddressPrefix42 is not part of registry: $allParticipantsPrefix42', 'ScanClaimQrCode');
       } else {
-        final msg = store.encointer.communityAccount!.containsAttendee(attendee)
+        final msg = store.encointer.communityAccount!.containsAttendee(attendeeAddressPrefix42)
             ? dic.encointer.claimsScannedAlready
             : dic.encointer.claimsScannedNew;
 
-        store.encointer.communityAccount!.addAttendee(attendee);
+        store.encointer.communityAccount!.addAttendee(attendeeAddressPrefix42);
         RootSnackBar.showMsg(msg);
       }
     }
   }
 
-  void onScan(AppStore store, Translations dic, String address) {
+  Future<void> onScan(AppStore store, Translations dic, String address) async {
     if (Fmt.isAddress(address)) {
-      validateAndStoreParticipant(store, address, dic);
+      await validateAndStoreParticipant(store, address, dic);
     } else {
       Log.e('Claim is not an address: $address', 'ScanClaimQrCode');
       RootSnackBar.showMsg(dic.encointer.claimsScannedDecodeFailed, durationMillis: 3000);
@@ -88,11 +94,11 @@ class _ScanClaimQrCodeState extends State<ScanClaimQrCode> {
             }
             return Stack(
               children: [
-                MobileScanner(onDetect: (barcode, args) {
+                MobileScanner(onDetect: (barcode, args) async {
                   if (barcode.rawValue == null) {
                     Log.e('Failed to scan Barcode', 'ScanClaimQrCode');
                   } else {
-                    onScan(context.read<AppStore>(), dic, barcode.rawValue!);
+                    await onScan(context.read<AppStore>(), dic, barcode.rawValue!);
                   }
                 }),
                 //overlays a semi-transparent rounded square border that is 90% of screen width
@@ -129,12 +135,12 @@ class _ScanClaimQrCodeState extends State<ScanClaimQrCode> {
                           runSpacing: 5,
                           alignment: WrapAlignment.center,
                           children: List.generate(
-                            allParticipants.length,
+                            allParticipantsPrefix42.length,
                             (index) {
-                              if (allParticipants[index] == currentAddress) {
+                              if (allParticipantsPrefix42[index] == currentAddressPrefix42) {
                                 return const SizedBox.shrink();
                               } else if (store.encointer.communityAccount!.attendees!
-                                  .contains(allParticipants[index])) {
+                                  .contains(allParticipantsPrefix42[index])) {
                                 return ParticipantAvatar(index: index, isActive: true);
                               } else {
                                 return ParticipantAvatar(index: index);

--- a/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -48,7 +48,8 @@ class _ScanClaimQrCodeState extends State<ScanClaimQrCode> {
       if (!allParticipantsPrefix42.contains(attendeeAddressPrefix42)) {
         // this is important because the runtime checks if there are too many claims trying to be registered.
         RootSnackBar.showMsg(dic.encointer.meetupClaimantInvalid);
-        Log.d('Claimant: $attendeeAddressPrefix42 is not part of registry: $allParticipantsPrefix42', 'ScanClaimQrCode');
+        Log.d(
+            'Claimant: $attendeeAddressPrefix42 is not part of registry: $allParticipantsPrefix42', 'ScanClaimQrCode');
       } else {
         final msg = store.encointer.communityAccount!.containsAttendee(attendeeAddressPrefix42)
             ? dic.encointer.claimsScannedAlready

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -31,7 +31,8 @@ class AccountApi {
   /// Todo: Remove this #1105.
   Future<List<String>> addressesToPubKey(List<String> addresses) async {
     if (addresses.isEmpty) return [];
-    final pubKeyAddress = await jsApi.evalJavascript<Map<String, dynamic>?>('account.decodeAddress(${jsonEncode(addresses)})');
+    final pubKeyAddress =
+        await jsApi.evalJavascript<Map<String, dynamic>?>('account.decodeAddress(${jsonEncode(addresses)})');
 
     if (pubKeyAddress != null) {
       return pubKeyAddress.keys.toList();

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -19,9 +19,7 @@ class AccountApi {
   Future<void> initAccounts() async {
     if (store.account.accountList.isNotEmpty) {
       final accounts = jsonEncode(store.account.accountList.map(AccountData.toJson).toList());
-
-      final ss58 = jsonEncode(networkSs58Map.values.toSet().toList());
-      await jsApi.evalJavascript<Map<String, dynamic>>('account.initKeys($accounts, $ss58)');
+      await jsApi.evalJavascript<void>('account.initKeys($accounts)');
     }
   }
 

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/notification/lib/notification.dart';
 import 'package:encointer_wallet/service/substrate_api/core/js_api.dart';

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -26,18 +26,24 @@ class AccountApi {
     this.fetchAccountData = fetchAccountData;
   }
 
-  /// decode addresses to publicKeys
-  Future<Map> decodeAddresses(List<String> addresses) async {
-    if (addresses.isEmpty) return {};
-    final res = await jsApi.evalJavascript<Map<String, dynamic>?>('account.decodeAddress(${jsonEncode(addresses)})');
-    return res ?? {};
+  /// Returns the pubKeys of the corresponding addresses.
+  ///
+  /// Todo: Remove this #1105.
+  Future<List<String>> addressesToPubKey(List<String> addresses) async {
+    if (addresses.isEmpty) return [];
+    final pubKeyAddress = await jsApi.evalJavascript<Map<String, dynamic>?>('account.decodeAddress(${jsonEncode(addresses)})');
+
+    if (pubKeyAddress != null) {
+      return pubKeyAddress.keys.toList();
+    }
+
+    return [];
   }
 
   /// Decode one address to the corresponding pubKey.
   Future<String> addressToPubKey(String address) async {
-    final pubKeyAddress = await decodeAddresses([address]);
-    final pubKey = pubKeyAddress.keys.toList()[0] as String;
-    return pubKey;
+    final addressList = await addressesToPubKey([address]);
+    return addressList[0];
   }
 
   Future<String> addressFromUri(String uri) async {

--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -331,6 +331,10 @@ class EncointerApi {
   }
 
   Future<void> subscribeCurrentPhase() async {
+    // Get the next phase timestamp once before we subscribe otherwise
+    // it takes a long time until we get the first update.
+    await getNextPhaseTimestamp();
+
     await jsApi.subscribeMessage(
         'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel,
         (String data) async {

--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -331,22 +331,16 @@ class EncointerApi {
   }
 
   Future<void> subscribeCurrentPhase() async {
-    // Get the next phase timestamp once before we subscribe otherwise
-    // it takes a long time until we get the first update.
-    await getNextPhaseTimestamp();
-
     await jsApi.subscribeMessage(
         'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel,
         (String data) async {
-      if (store.account.currentAccountPubKey == null) return;
       final phase = ceremonyPhaseFromString(data.toUpperCase())!;
 
       final cid = store.encointer.chosenCid;
-      final address = store.account.currentAddress;
+      final pubKey = store.account.currentAccountPubKey;
 
-      final pubKey = store.account.currentAccountPubKey!;
-
-      if (cid != null) {
+      if (cid != null && pubKey != null) {
+        final address = store.account.currentAddress;
         final data = await pollAggregatedAccountDataUntilNextPhase(phase, cid, pubKey);
         store.encointer.setAggregatedAccountData(cid, address, data);
       }

--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -135,7 +135,11 @@ class EncointerApi {
 
   /// Queries the rpc 'encointer_getAggregatedAccountData' with the dart api.
   ///
-  Future<AggregatedAccountData> getAggregatedAccountData(CommunityIdentifier cid, String address) async {
+  /// Todo: Be able to handle pubKey and any address and transform it to the
+  /// address with prefix 42. Needs #1105.
+  Future<AggregatedAccountData> getAggregatedAccountData(CommunityIdentifier cid, String pubKey) async {
+    final address = Fmt.ss58Encode(pubKey);
+
     try {
       final accountData = await _dartApi.getAggregatedAccountData(cid, address);
       Log.d(
@@ -330,13 +334,16 @@ class EncointerApi {
     await jsApi.subscribeMessage(
         'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel,
         (String data) async {
+      if (store.account.currentAccountPubKey == null) return;
       final phase = ceremonyPhaseFromString(data.toUpperCase())!;
 
       final cid = store.encointer.chosenCid;
       final address = store.account.currentAddress;
 
+      final pubKey = store.account.currentAccountPubKey!;
+
       if (cid != null) {
-        final data = await pollAggregatedAccountDataUntilNextPhase(phase, cid, address);
+        final data = await pollAggregatedAccountDataUntilNextPhase(phase, cid, pubKey);
         store.encointer.setAggregatedAccountData(cid, address, data);
       }
 
@@ -352,10 +359,10 @@ class EncointerApi {
   Future<AggregatedAccountData> pollAggregatedAccountDataUntilNextPhase(
     CeremonyPhase nextPhase,
     CommunityIdentifier cid,
-    String address,
+    String pubKey,
   ) async {
     while (true) {
-      final data = await getAggregatedAccountData(cid, address);
+      final data = await getAggregatedAccountData(cid, pubKey);
       final phase = data.global.ceremonyPhase;
 
       if (nextPhase == phase) {

--- a/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -152,7 +152,7 @@ Future<void> submitRegisterParticipant(BuildContext context, AppStore store, Api
       store.encointer.account!.lastProofOfAttendance = proof;
       final data = await webApi.encointer.getAggregatedAccountData(
         store.encointer.chosenCid!,
-        store.account.currentAddress,
+        store.account.currentAccountPubKey!,
       );
       Log.d('$data', 'AggregatedAccountData from register participant');
       final registrationType = data.personal?.participantType;

--- a/app/lib/store/encointer/encointer.dart
+++ b/app/lib/store/encointer/encointer.dart
@@ -349,7 +349,8 @@ abstract class _EncointerStore with Store {
     try {
       if (chosenCid != null) {
         if (_rootStore.account.currentAccountPubKey == null) return;
-        final data = await webApi.encointer.getAggregatedAccountData(chosenCid!, _rootStore.account.currentAccountPubKey!);
+        final data =
+            await webApi.encointer.getAggregatedAccountData(chosenCid!, _rootStore.account.currentAccountPubKey!);
         setAggregatedAccountData(chosenCid!, _rootStore.account.currentAddress, data);
       } else {
         Log.d('chosenCid is null', 'Encointer updateAggregatedAccountData');

--- a/app/lib/store/encointer/encointer.dart
+++ b/app/lib/store/encointer/encointer.dart
@@ -348,7 +348,8 @@ abstract class _EncointerStore with Store {
   Future<void> updateAggregatedAccountData() async {
     try {
       if (chosenCid != null) {
-        final data = await webApi.encointer.getAggregatedAccountData(chosenCid!, _rootStore.account.currentAddress);
+        if (_rootStore.account.currentAccountPubKey == null) return;
+        final data = await webApi.encointer.getAggregatedAccountData(chosenCid!, _rootStore.account.currentAccountPubKey!);
         setAggregatedAccountData(chosenCid!, _rootStore.account.currentAddress, data);
       } else {
         Log.d('chosenCid is null', 'Encointer updateAggregatedAccountData');

--- a/app/lib/utils/format.dart
+++ b/app/lib/utils/format.dart
@@ -261,6 +261,8 @@ class Fmt {
 
   static const base58Codec = Base58Codec(Base58CheckCodec.BITCOIN_ALPHABET);
 
+  /// Convert a pubKey into an SS58-address.
+  ///
   /// Based on the rust version: https://github.com/paritytech/substrate/blob/48e7cb147cb9a27125fd2e82edbcf4d0ed5927c4/primitives/core/src/crypto.rs#L324
   ///
   /// Note: This only supports prefixes < 64, bigger prefixes require


### PR DESCRIPTION
After merging this PR, the addresses will start with a letter when we are connected to the Kusama network, e.g. `Alice: HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F`. When we are connected to all other networks Gesell, Gesell-dev, Rococo the addresses will still start with a 5, e.g. `Alice: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`.

* Closes #567: We now pass the pubKey into the dart RPC-API and always derive the address with prefix 42.
* Closes #1019 by implementing the last open subtask.

Tests:
- [x] test that we can scan addresses with both prefixes: 2, 42:
   - [x] Importing contact with both prefixes works.
   - [x] Scanning invoice with both prefixes works.
- [x] Meetup against a local node that was configured to have prefix 2, and also the network prefix in the app has been configured to 2: https://github.com/encointer/encointer-wallet-flutter/blob/28e936fd71618c93fa31a9be667b55761e42ef1b/app/lib/config/consts.dart#L40

Voucher should be unaffected as the QR-code is based on the secret seed.