### PR TITLE
Fix first app startup: Get `nextPhaseTimestamp` once before we subscribe to it.

### DIFF
--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -327,6 +327,10 @@ class EncointerApi {
   }
 
   Future<void> subscribeCurrentPhase() async {
+    // Get the next phase timestamp once before we subscribe otherwise
+    // it takes a long time until we get the first update.
+    await getNextPhaseTimestamp();
+
     await jsApi.subscribeMessage(
         'encointer.subscribeCurrentPhase("$_currentPhaseSubscribeChannel")', _currentPhaseSubscribeChannel,
         (String data) async {


### PR DESCRIPTION
* Closes #1152 

This fixes the integration tests for #1111. However, I don't understand why this is suddenly a problem. According to my understanding the integration tests should have been broken ever since.