### PR TITLE
Fixed app crash on Android API < 26

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -30,6 +30,7 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -43,6 +44,7 @@ android {
     }
 
     defaultConfig {
+        multiDexEnabled true
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "org.encointer.wallet"
         // You can update the following values to match your application needs.
@@ -95,4 +97,8 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.jakewharton.threetenabp:threetenabp:1.4.6'
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -30,7 +30,11 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
+        // Flag to enable support for the new language API, see #1165.
         coreLibraryDesugaringEnabled true
+        // Older androids ( < API 26) use Java 7
+        // Sets Java compatibility to Java 8
+        // Needed to run JAVA 8 for backwards compatibility with Androids older than API 26, see #1165.
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -98,6 +102,8 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.jakewharton.threetenabp:threetenabp:1.4.6'
+    // Fixes bug for newer ( > API 26) android versions
+    // Bug: Failed to transform window-java-1.0.0-beta04.jar (androidx.window:window-java:1.0.0-beta04)
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
         android:icon="@mipmap/launcher_icon"
         android:allowBackup="false"
         android:usesCleartextTraffic="true">
+        <!-- android:name=".MainActivity": Android is run from MainActivity.kt file 
+        We need MainActivity.kt to initialize AndroidThreeTen for older versions of android
+        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:allowBackup="false"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"

--- a/app/android/app/src/main/kotlin/org/encointer/wallet/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/encointer/wallet/MainActivity.kt
@@ -1,0 +1,19 @@
+package org.encointer.wallet
+
+import androidx.annotation.NonNull
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugins.GeneratedPluginRegistrant
+import com.jakewharton.threetenabp.AndroidThreeTen
+
+class MainActivity: FlutterActivity() {
+  // You do not need to override onCreate() in order to invoke
+  // GeneratedPluginRegistrant. Flutter now does that on your behalf.
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        GeneratedPluginRegistrant.registerWith(flutterEngine);
+        AndroidThreeTen.init(this);
+    }
+}
+
+

--- a/app/android/app/src/main/kotlin/org/encointer/wallet/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/org/encointer/wallet/MainActivity.kt
@@ -9,11 +9,11 @@ import com.jakewharton.threetenabp.AndroidThreeTen
 class MainActivity: FlutterActivity() {
   // You do not need to override onCreate() in order to invoke
   // GeneratedPluginRegistrant. Flutter now does that on your behalf.
-
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine);
+        // Initialize AndroidThreeTen for older versions of android instead
+        // of java.time, in API 26 or newer versions java.time is used
+        // older versions will use AndroidThreeTen
         AndroidThreeTen.init(this);
     }
 }
-
-


### PR DESCRIPTION
* Closes #1050

It was crashing because the `java.time` package was added only in API 26 and above. Older phones still tried to call this API and thus it crashed. Adding `ThreeTenABP` resolves the issue.

This PR introduces the change to use `ThreeTenABP` for Android API < 26 and `java.time` in otherwise.