### PR TITLE
[launch.json] distinguished configuration for Android and iOS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,8 +22,7 @@
             "name": "encointer-wallet-flutter: iOS",
             "request": "launch",
             "type": "dart",
-            "program": "app/lib/main.dart",
-             
+            "program": "app/lib/main.dart",        
         },
         {
             "name": "encointer-wallet-flutter (profile mode)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "encointer-wallet-flutter",
+            "name": "encointer-wallet-flutter: Android",
             "request": "launch",
             "type": "dart",
             "program": "app/lib/main.dart",
@@ -17,6 +17,13 @@
                 "--target",
                 "lib/main.dart"
             ],
+        },
+        {
+            "name": "encointer-wallet-flutter: iOS",
+            "request": "launch",
+            "type": "dart",
+            "program": "app/lib/main.dart",
+             
         },
         {
             "name": "encointer-wallet-flutter (profile mode)",


### PR DESCRIPTION
Added configurations for Android and iOS in launch.json.

From now on, in order to run project on iOS, no need to comment `args`, just choose iOS and run it.


<img width="537" alt="Screenshot 2023-04-26 at 14 22 50" src="https://user-images.githubusercontent.com/13807762/234515351-6b5eaca0-27a4-43db-873b-7ffb0157197e.png">

