### PR TITLE
az/[Announcements] Add dev and release modes

### DIFF
--- a/app/lib/config.dart
+++ b/app/lib/config.dart
@@ -1,7 +1,19 @@
 import 'package:upgrader/upgrader.dart';
 
+/// [AppEnvironment] is needed to set development environemt
+/// for now, we have [AppEnvironment.DEV] or [AppEnvironment.PROD] modes
+/// For ex: We start working on Announcements,
+/// we keep seeing and testing it in `DEV` mode,
+/// but it doesn't go onto production unless
+/// it's tested and approved.
+/// This is usually practiced for working in a team
+/// when a team member adds new features and
+/// let's tester to test them
+enum AppEnvironment { DEV, PROD }
+
 class AppConfig {
   const AppConfig({
+    required this.appEnvironment,
     this.mockSubstrateApi = false,
     this.isTestMode = false,
     this.appCast,
@@ -19,4 +31,7 @@ class AppConfig {
   /// If [AppcastConfiguration] variable is not null, the app is running real integration test.
   /// If [isIntegrationTest] value is `true`, test will close upgrader alert and won't ask notifications permission.
   bool get isIntegrationTest => appCast != null;
+
+  /// For now, it breaks nothing and has no effect, but we'll be using it a lot in the future
+  final AppEnvironment appEnvironment;
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -15,7 +15,7 @@ import 'package:encointer_wallet/service/subscan.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/local_storage.dart' as util;
 
-Future<void> main({AppcastConfiguration? appCast}) async {
+Future<void> main({AppcastConfiguration? appCast, AppEnvironment? appEnvironment}) async {
   WidgetsFlutterBinding.ensureInitialized();
   await NotificationPlugin.setup();
   // var notificationAppLaunchDetails =
@@ -37,7 +37,13 @@ Future<void> main({AppcastConfiguration? appCast}) async {
         ),
         Provider<AppStore>(
           // On test mode instead of LocalStorage() must be use MockLocalStorage()
-          create: (context) => AppStore(util.LocalStorage(), config: AppConfig(appCast: appCast)),
+          create: (context) => AppStore(
+            util.LocalStorage(),
+            config: AppConfig(
+              appCast: appCast,
+              appEnvironment: appEnvironment ?? AppEnvironment.DEV,
+            ),
+          ),
         )
       ],
       child: const WalletApp(),

--- a/app/test/store/account_test.dart
+++ b/app/test/store/account_test.dart
@@ -11,7 +11,11 @@ void main() {
   group('AccountStore test', () {
     final root = AppStore(
       MockLocalStorage(),
-      config: const AppConfig(mockSubstrateApi: true, isTestMode: true),
+      config: const AppConfig(
+        mockSubstrateApi: true,
+        isTestMode: true,
+        appEnvironment: AppEnvironment.DEV,
+      ),
     );
 
     test('account store test', () async {

--- a/app/test/store/app_test.dart
+++ b/app/test/store/app_test.dart
@@ -9,7 +9,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final store = AppStore(
     MockLocalStorage(),
-    config: const AppConfig(mockSubstrateApi: true, isTestMode: true),
+    config: const AppConfig(
+      mockSubstrateApi: true,
+      isTestMode: true,
+      appEnvironment: AppEnvironment.DEV,
+    ),
   );
   accList = [testAcc];
   currentAccountPubKey = accList[0]['pubKey'] as String;

--- a/app/test/store/encointer/encointer_test.dart
+++ b/app/test/store/encointer/encointer_test.dart
@@ -19,7 +19,11 @@ import 'package:encointer_wallet/store/encointer/sub_stores/community_store/comm
 Future<AppStore> setupAppStore(String networkInfo) async {
   final store = AppStore(
     MockLocalStorage(),
-    config: const AppConfig(mockSubstrateApi: true, isTestMode: true),
+    config: const AppConfig(
+      mockSubstrateApi: true,
+      isTestMode: true,
+      appEnvironment: AppEnvironment.DEV,
+    ),
   );
   await store.init('_en');
 

--- a/app/test/store/encointer/sub_stores/community_store/community_store_test.dart
+++ b/app/test/store/encointer/sub_stores/community_store/community_store_test.dart
@@ -19,7 +19,7 @@ void main() {
 
       // Only to not get null errors in tests
       webApi = getMockApi(
-        AppStore(MockLocalStorage(), config: const AppConfig()),
+        AppStore(MockLocalStorage(), config: const AppConfig(appEnvironment: AppEnvironment.DEV)),
         withUI: false,
       );
       await webApi.init();

--- a/app/test/store/settings_test.dart
+++ b/app/test/store/settings_test.dart
@@ -12,7 +12,11 @@ void main() {
   group('SettingsStore test', () {
     final root = AppStore(
       MockLocalStorage(),
-      config: const AppConfig(mockSubstrateApi: true, isTestMode: true),
+      config: const AppConfig(
+        mockSubstrateApi: true,
+        isTestMode: true,
+        appEnvironment: AppEnvironment.DEV,
+      ),
     );
     final store = SettingsStore(root);
 

--- a/app/test_driver/app.dart
+++ b/app/test_driver/app.dart
@@ -20,7 +20,12 @@ void main() async {
   final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
   final globalAppStore = AppStore(
     MockLocalStorage(),
-    config: AppConfig(mockSubstrateApi: true, isTestMode: true, appCast: cfg),
+    config: AppConfig(
+      mockSubstrateApi: true,
+      isTestMode: true,
+      appCast: cfg,
+      appEnvironment: AppEnvironment.DEV,
+    ),
   );
 
   // the tests are run in a separate isolate from the app. The test isolate can only interact with

--- a/app/test_driver/real_app.dart
+++ b/app/test_driver/real_app.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:encointer_wallet/config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:upgrader/upgrader.dart';
@@ -29,5 +30,5 @@ void main() async {
   const appcastURL = 'https://encointer.github.io/feed/app_cast/testappcast.xml';
   final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
   WidgetsApp.debugAllowBannerOverride = false;
-  await app.main(appCast: cfg);
+  await app.main(appCast: cfg, appEnvironment: AppEnvironment.PROD);
 }


### PR DESCRIPTION
[AppEnvironment] is needed to set development environemt, for now, we have [AppEnvironment.DEV] or [AppEnvironment.PROD] modes.

For ex: We start working on Announcements, we keep seeing and testing it in `DEV` mode, but it doesn't go onto production unless it's tested and approved.

This is usually practiced for working in a team when a team member adds new features and let's tester to test them.