### PR TITLE
Forward mail to bugreports instead of trello directly

### DIFF
--- a/app/lib/common/components/launch/send_to_trello_list_tile.dart
+++ b/app/lib/common/components/launch/send_to_trello_list_tile.dart
@@ -14,7 +14,7 @@ class SendToTrelloListTile extends StatelessWidget {
     return ListTile(
       title: Text(dic.contactUs, style: h3Grey),
       onTap: () async => AppLaunch.sendEmail(
-        'malikelbay1+np8u5ozogws6ijqbldun@boards.trello.com',
+        'bugreports@mail.encointer.org',
         snackBarText: dic.checkEmailApp,
         context: context,
       ),


### PR DESCRIPTION
Sending bug report to `bugreports@mail.encointer.org` instead of troll board

* Closes #1192 