### PR TITLE
TxConfirmPage printscreen should have the tick visible

### DIFF
--- a/app/lib/config.dart
+++ b/app/lib/config.dart
@@ -10,5 +10,6 @@ class AppConfig {
   /// 1) The test will close the Upgrader alert.
   /// 2) The app won't ask for notification permissions.
   /// 3) The app will show the full `acoountPubKey` in the `AccountManage` page.
+  /// 4) The `_animationController!.reset()` method will not be called for the `PaymentConfirmationPage`.
   final bool isIntegrationTest;
 }

--- a/app/lib/page/assets/transfer/payment_confirmation_page/index.dart
+++ b/app/lib/page/assets/transfer/payment_confirmation_page/index.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:animated_check/animated_check.dart';
+import 'package:encointer_wallet/config.dart';
+import 'package:encointer_wallet/utils/repository_provider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
@@ -257,8 +259,10 @@ class _PaymentConfirmationPageState extends State<PaymentConfirmationPage> with 
   }
 
   void _animateTick() {
-    _animationController!.forward();
-    Future.delayed(const Duration(seconds: 1), () => _animationController!.reset());
+    if (!RepositoryProvider.of<AppConfig>(context).isIntegrationTest) {
+      _animationController!.forward();
+      Future.delayed(const Duration(seconds: 1), () => _animationController!.reset());
+    }
   }
 
   void _initializeAnimation() {


### PR DESCRIPTION
I think this will be useful for us. If the application is running for an integration test, it won't repeatedly execute the animate check. If it's in normal mode, it will continue to work as before.

`PaymentConfirmationPage` and animate seemed very complex to me. But since this PR is not about refactoring, I didn't do anything. It was just a small PR that completed the task. But if you want, I can do the refactoring.

* Closes #1114 