### PR TITLE
UI Bug v1.10.0: Autofitting of Transfers Screen for small devices doesn't work

### DIFF
--- a/app/lib/modules/transfer/logic/transfer_history_view_store.dart
+++ b/app/lib/modules/transfer/logic/transfer_history_view_store.dart
@@ -3,7 +3,7 @@ import 'package:ew_http/ew_http.dart';
 import 'package:mobx/mobx.dart';
 
 import 'package:encointer_wallet/models/index.dart';
-// import 'package:encointer_wallet/utils/format.dart';
+import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/utils/fetch_status.dart';
@@ -25,17 +25,13 @@ abstract class _TransferHistoryViewStoreBase with Store {
   @action
   Future<void> getTransfers(AppStore appStore) async {
     fetchStatus = FetchStatus.loading;
-    // final address = Fmt.ss58Encode(
-    //   appStore.account.currentAccountPubKey ?? '',
-    //   prefix: appStore.settings.endpoint.ss58 ?? 42,
-    // );
+    final address = Fmt.ss58Encode(
+      appStore.account.currentAccountPubKey ?? '',
+      prefix: appStore.settings.endpoint.ss58 ?? 42,
+    );
 
-    // final response = await ewHttp.getTypeList<Transaction>(
-    //   getTransactionHistoryUrl(appStore.encointer.community?.cid.toFmtString() ?? '', address),
-    //   fromJson: Transaction.fromJson,
-    // );
     final response = await ewHttp.getTypeList<Transaction>(
-      getTransactionHistoryUrl('u0qj944rhWE', 'HxunEG4C3pzFGMKHYAVt3D6LgCSoLcodReJ4xziFPsNWCew'),
+      getTransactionHistoryUrl(appStore.encointer.community?.cid.toFmtString() ?? '', address),
       fromJson: Transaction.fromJson,
     );
 

--- a/app/lib/modules/transfer/logic/transfer_history_view_store.dart
+++ b/app/lib/modules/transfer/logic/transfer_history_view_store.dart
@@ -3,7 +3,7 @@ import 'package:ew_http/ew_http.dart';
 import 'package:mobx/mobx.dart';
 
 import 'package:encointer_wallet/models/index.dart';
-import 'package:encointer_wallet/utils/format.dart';
+// import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/utils/fetch_status.dart';
@@ -25,13 +25,17 @@ abstract class _TransferHistoryViewStoreBase with Store {
   @action
   Future<void> getTransfers(AppStore appStore) async {
     fetchStatus = FetchStatus.loading;
-    final address = Fmt.ss58Encode(
-      appStore.account.currentAccountPubKey ?? '',
-      prefix: appStore.settings.endpoint.ss58 ?? 42,
-    );
+    // final address = Fmt.ss58Encode(
+    //   appStore.account.currentAccountPubKey ?? '',
+    //   prefix: appStore.settings.endpoint.ss58 ?? 42,
+    // );
 
+    // final response = await ewHttp.getTypeList<Transaction>(
+    //   getTransactionHistoryUrl(appStore.encointer.community?.cid.toFmtString() ?? '', address),
+    //   fromJson: Transaction.fromJson,
+    // );
     final response = await ewHttp.getTypeList<Transaction>(
-      getTransactionHistoryUrl(appStore.encointer.community?.cid.toFmtString() ?? '', address),
+      getTransactionHistoryUrl('u0qj944rhWE', 'HxunEG4C3pzFGMKHYAVt3D6LgCSoLcodReJ4xziFPsNWCew'),
       fromJson: Transaction.fromJson,
     );
 

--- a/app/lib/modules/transfer/widgets/transaction_card.dart
+++ b/app/lib/modules/transfer/widgets/transaction_card.dart
@@ -44,19 +44,22 @@ class TransactionCard extends StatelessWidget {
         subtitle: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  transaction.getNameFromContacts(appStore.settings.contactList) ?? 'No Name',
-                  style: context.textTheme.titleMedium!.copyWith(fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 4),
-                Text(Fmt.address(transaction.counterParty) ?? ''),
-              ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(transaction.getNameFromContacts(appStore.settings.contactList) ?? 'No Name',
+                      style: context.textTheme.titleMedium!.copyWith(fontWeight: FontWeight.bold),
+                      overflow: TextOverflow.ellipsis),
+                  const SizedBox(height: 4),
+                  Text(
+                    Fmt.address(transaction.counterParty) ?? '',
+                    style: context.textTheme.bodySmall,
+                  ),
+                ],
+              ),
             ),
             Column(
-              mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Text.rich(
@@ -84,7 +87,7 @@ class TransactionCard extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 4),
-                Text(Fmt.dateTime(transaction.dateTime)),
+                Text(Fmt.dateTime(transaction.dateTime), style: context.textTheme.bodySmall),
               ],
             ),
           ],


### PR DESCRIPTION
Tried to fix fitting of TransfersPage on small devices. Bug was noticed on iphone8 which  has a 4.7-inch screen with a screen size (resolution): | 750px × 1334px |.
 if the `getNameFromContacts` cannot fit within the given space, it will be truncated with an ellipsis (...) at the end.

Tested on android emulator size Nexus 4 |  4,7" | 768x1280px | 

<img width="250" alt="Снимок экрана 2023-06-17 в 09 16 20" src="https://github.com/SourbaevaJanaraJ/lock_screen/assets/91150590/c4b761f6-12b8-4808-b944-484cc5d8a6b0"> 

on Iphone SE  | 750 x 1334px | 

<img width="250" alt="Снимок экрана 2023-06-17 в 09 12 43" src="https://github.com/SourbaevaJanaraJ/lock_screen/assets/91150590/7163231c-34a7-47f5-abd1-9eeac1cbd0a1">

Also I used [device_preview](https://pub.dev/packages/device_preview) package to test on even smaller device   | 360 x 640 px|

<img width="250" alt="Снимок экрана 2023-06-17 в 09 39 52" src="https://github.com/SourbaevaJanaraJ/lock_screen/assets/91150590/27e15637-2d4b-48b3-8588-f4d6284aaf5d">

Closes #1287 