### PR TITLE
Fix: Initialize the locale with system language 

### DIFF
--- a/app/lib/modules/settings/logic/app_settings_store.dart
+++ b/app/lib/modules/settings/logic/app_settings_store.dart
@@ -39,7 +39,7 @@ abstract class _AppSettingsBase with Store {
   CustomTheme get theme => CustomTheme(colorScheme);
 
   @action
-  void init() => locale = _service.init();
+  void init() => locale = _service.getLocale;
 
   @computed
   BiometricAuthState? get getBiometricAuthState {

--- a/app/lib/modules/settings/service/app_service.dart
+++ b/app/lib/modules/settings/service/app_service.dart
@@ -12,11 +12,11 @@ class AppService {
   static const String localStorageLocaleKey = 'locale';
   static const String biometricAuthStateKey = 'biometric-auth-state';
 
-  Locale init() {
+  Locale get getLocale {
     final code = storage.getString(localStorageLocaleKey);
     if (code != null) return Locale(code);
     // ignore: deprecated_member_use
-    final deviceLocal = window.locale;
+    final deviceLocal = Locale(window.locale.languageCode);
     return AppLocalizations.delegate.isSupported(deviceLocal) ? deviceLocal : const Locale('en');
   }
 


### PR DESCRIPTION
With my previous corrections, a bug has emerged. If the user didn't select a language, the application was supposed to set its language based on the device's language.

| Before initial locale | After initial locale |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-24 at 11 15 27](https://github.com/encointer/encointer-wallet-flutter/assets/76556278/84d8ebb7-ca04-4283-a30d-9747000004a9) | ![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-24 at 11 20 41](https://github.com/encointer/encointer-wallet-flutter/assets/76556278/854b9e22-099d-49f8-b184-28f1d8dded3c)| 