### PR TITLE
RefreshIndicator `TransferHistoryView`

### DIFF
--- a/app/lib/modules/transfer/view/transfer_history_view.dart
+++ b/app/lib/modules/transfer/view/transfer_history_view.dart
@@ -25,18 +25,23 @@ class TransferHistoryView extends StatelessWidget {
           style: context.textTheme.displayMedium,
         ),
       ),
-      body: Observer(builder: (_) {
-        return switch (transferHistoryStore.fetchStatus) {
-          FetchStatus.loading => const CenteredActivityIndicator(),
-          FetchStatus.success => TransactionsList(transactions: transferHistoryStore.transactions ?? []),
-          FetchStatus.error => ErrorView(
-              onRetryPressed: () {
-                final appStore = context.read<AppStore>();
-                context.read<TransferHistoryViewStore>().getTransfers(appStore);
-              },
-            ),
-        };
-      }),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          await context.read<TransferHistoryViewStore>().getTransfers(context.read<AppStore>());
+        },
+        child: Observer(builder: (_) {
+          return switch (transferHistoryStore.fetchStatus) {
+            FetchStatus.loading => const CenteredActivityIndicator(),
+            FetchStatus.success => TransactionsList(transactions: transferHistoryStore.transactions ?? []),
+            FetchStatus.error => ErrorView(
+                onRetryPressed: () {
+                  final appStore = context.read<AppStore>();
+                  context.read<TransferHistoryViewStore>().getTransfers(appStore);
+                },
+              ),
+          };
+        }),
+      ),
     );
   }
 }


### PR DESCRIPTION
We don't cache the transfer history, so the `TransferHistory` page already fetches the most up-to-date data every time it is opened. In this case, the only thing I think we can do is to add a `RefreshIndicator`. If you have any other suggestions for a solution, please let me know, and I'll do my best to implement it :).

* Closes #1284