### PR TITLE
[Bazaar] fix businesses padding

### DIFF
--- a/app/lib/page-encointer/new_bazaar/businesses/widgets/businesses_card.dart
+++ b/app/lib/page-encointer/new_bazaar/businesses/widgets/businesses_card.dart
@@ -49,7 +49,7 @@ class BusinessesCard extends StatelessWidget {
               ),
               Expanded(
                 child: ListTile(
-                  contentPadding: const EdgeInsets.fromLTRB(10, 10, 10, 5),
+                  contentPadding: const EdgeInsets.all(10),
                   title: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
@@ -64,7 +64,12 @@ class BusinessesCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const SizedBox(height: 28),
-                      Text(businesses.name, style: textTheme.labelLarge),
+                      Text(
+                        businesses.name,
+                        style: textTheme.labelLarge,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                      ),
                       const SizedBox(height: 8),
                       Text(
                         businesses.description,


### PR DESCRIPTION
* Constraint business titles to one line. Closes #1346 

<img src="https://github.com/encointer/encointer-wallet-flutter/assets/76556278/3b6ce8b8-c7d3-4186-be15-7e2f59225bc3"  width="40%" height="30%">

