### PR TITLE
Remove old package `animated_check` and implement it ourselves

### DIFF
--- a/app/lib/common/components/animation/animated_check.dart
+++ b/app/lib/common/components/animation/animated_check.dart
@@ -1,0 +1,87 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'package:encointer_wallet/theme/theme.dart';
+
+class AnimatedCheck extends StatelessWidget {
+  const AnimatedCheck({
+    required this.progress,
+    required this.size,
+    this.color,
+    super.key,
+  });
+
+  final Animation<double> progress;
+  final double size;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      foregroundPainter: AnimatedPathPainter(progress, color ?? context.colorScheme.primary),
+      child: SizedBox(width: size, height: size),
+    );
+  }
+}
+
+class AnimatedPathPainter extends CustomPainter {
+  const AnimatedPathPainter(this.animation, this.color) : super(repaint: animation);
+
+  final Animation<double> animation;
+  final Color color;
+
+  Path _createAnyPath(Size size) {
+    return Path()
+      ..moveTo(0.27083 * size.width, 0.54167 * size.height)
+      ..lineTo(0.41667 * size.width, 0.68750 * size.height)
+      ..lineTo(0.75000 * size.width, 0.35417 * size.height);
+  }
+
+  Path createAnimatedPath(Path originalPath, double animationPercent) {
+    final totalLength =
+        // ignore: prefer_int_literals
+        originalPath.computeMetrics().fold(0.0, (double prev, PathMetric metric) => prev + metric.length);
+    final currentLength = totalLength * animationPercent;
+
+    return extractPathUntilLength(originalPath, currentLength);
+  }
+
+  Path extractPathUntilLength(Path originalPath, double length) {
+    var currentLength = 0.0;
+    final path = Path();
+    final metricsIterator = originalPath.computeMetrics().iterator;
+
+    while (metricsIterator.moveNext()) {
+      final metric = metricsIterator.current;
+      final nextLength = currentLength + metric.length;
+      final isLastSegment = nextLength > length;
+
+      if (isLastSegment) {
+        final remainingLength = length - currentLength;
+        final pathSegment = metric.extractPath(0, remainingLength);
+        path.addPath(pathSegment, Offset.zero);
+        break;
+      } else {
+        final pathSegment = metric.extractPath(0, metric.length);
+        path.addPath(pathSegment, Offset.zero);
+      }
+      currentLength = nextLength;
+    }
+    return path;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final animationPercent = animation.value;
+    final path = createAnimatedPath(_createAnyPath(size), animationPercent);
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = size.width * 0.06;
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
+}

--- a/app/lib/page/assets/transfer/payment_confirmation_page/index.dart
+++ b/app/lib/page/assets/transfer/payment_confirmation_page/index.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:animated_check/animated_check.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
@@ -11,6 +10,7 @@ import 'package:encointer_wallet/common/components/gradient_elements.dart';
 import 'package:encointer_wallet/theme/theme.dart';
 import 'package:encointer_wallet/config.dart';
 import 'package:encointer_wallet/utils/repository_provider.dart';
+import 'package:encointer_wallet/common/components/animation/animated_check.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/page/assets/transfer/payment_confirmation_page/components/payment_overview.dart';
 import 'package:encointer_wallet/page/assets/transfer/payment_confirmation_page/components/transfer_state.dart';
@@ -192,11 +192,7 @@ class _PaymentConfirmationPageState extends State<PaymentConfirmationPage> with 
 
           return DecoratedBox(
             decoration: const BoxDecoration(shape: BoxShape.circle, color: Colors.green),
-            child: AnimatedCheck(
-              progress: _animation!,
-              size: 100,
-              color: Colors.white,
-            ),
+            child: AnimatedCheck(progress: _animation!, size: 100, color: Colors.white),
           );
         }
       case TransferState.failed:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -33,14 +33,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0"
-  animated_check:
-    dependency: "direct main"
-    description:
-      name: animated_check
-      sha256: "1da103a44b6aeacbecec799343b7170e627f4af465ca642b430c1d94922868aa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
   animated_stack_widget:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   package_info_plus: ^3.1.2
   quiver: ^3.2.1
   image_picker: ^0.8.8
-  animated_check: ^1.0.5 # Todo: #1269: replace with alternative package
   share_plus: ^6.3.4
   flutter_timezone: ^1.0.6
 


### PR DESCRIPTION
Very old package code integrated to dart 3
- [x] Fixed linter errors & warnings
- [x] Used `StatelessWidget` instead `StatefullWidget`
- [x] Removed unused params
- [x] Added `const` keyword where possible

See package https://pub.dev/packages/animated_check (last update 21 months ago)
* Closes #1269