### PR TITLE
[transfer_history] fix display names of contacts created pre-1.9.1

### DIFF
--- a/app/lib/models/transfer/transfer_history.dart
+++ b/app/lib/models/transfer/transfer_history.dart
@@ -4,6 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:encointer_wallet/utils/extensions/double/double_extension.dart';
 import 'package:encointer_wallet/store/account/types/account_data.dart';
 import 'package:encointer_wallet/l10n/l10.dart';
+import 'package:encointer_wallet/utils/format.dart';
 
 part 'transfer_history.g.dart';
 
@@ -44,7 +45,9 @@ class Transaction {
   /// Returns null if no matching contact is found.
   String? getNameFromContacts(List<AccountData> contacts) {
     for (final contact in contacts) {
-      if (contact.address == counterParty) return contact.name;
+      // Contact address might be with default prefix 42, or with Kusama prefix 2.
+      // So better to work with pubkey.
+      if (Fmt.ss58Decode(contact.address).pubKey == Fmt.ss58Decode(counterParty).pubKey) return contact.name;
     }
     return null;
   }

--- a/app/lib/models/transfer/transfer_history.dart
+++ b/app/lib/models/transfer/transfer_history.dart
@@ -46,7 +46,7 @@ class Transaction {
   String? getNameFromContacts(List<AccountData> contacts) {
     for (final contact in contacts) {
       // Contact address might be with default prefix 42, or with Kusama prefix 2.
-      // So better to work with pubkey.
+      // So better to work with the universal pubKey.
       if (Fmt.ss58Decode(contact.address).pubKey == Fmt.ss58Decode(counterParty).pubKey) return contact.name;
     }
     return null;

--- a/app/lib/modules/transfer/widgets/transaction_card.dart
+++ b/app/lib/modules/transfer/widgets/transaction_card.dart
@@ -28,7 +28,7 @@ class TransactionCard extends StatelessWidget {
       child: ListTile(
         contentPadding: const EdgeInsets.fromLTRB(10, 15, 15, 10),
         isThreeLine: true,
-        leading: AddressIcon(transaction.counterParty, transaction.counterParty, size: 55),
+        leading: AddressIcon(transaction.counterParty, Fmt.ss58Decode(transaction.counterParty).pubKey, size: 55),
         title: Padding(
           padding: const EdgeInsets.only(bottom: 12),
           child: Row(

--- a/app/lib/modules/transfer/widgets/transaction_card.dart
+++ b/app/lib/modules/transfer/widgets/transaction_card.dart
@@ -28,7 +28,7 @@ class TransactionCard extends StatelessWidget {
       child: ListTile(
         contentPadding: const EdgeInsets.fromLTRB(10, 15, 15, 10),
         isThreeLine: true,
-        leading: AddressIcon('', appStore.account.currentAccount.pubKey, size: 55, tapToCopy: false),
+        leading: AddressIcon(transaction.counterParty, transaction.counterParty, size: 55),
         title: Padding(
           padding: const EdgeInsets.only(bottom: 12),
           child: Row(


### PR DESCRIPTION
* Closes #1356

Other minor changes:
* Fix: use counterparty as source for the address icon instead of own account
* enable tap to copy address from counterparty to facilitate simple import into contacts.