### PR TITLE
adjust `scannedAttendeesCount` according to device settings

### DIFF
--- a/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
+++ b/app/lib/page-encointer/meetup/scan_claim_qr_code.dart
@@ -6,6 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import 'package:encointer_wallet/common/components/logo/participant_avatar.dart';
+import 'package:encointer_wallet/theme/custom/extension/theme_extension.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:encointer_wallet/utils/format.dart';
@@ -121,7 +122,10 @@ class _ScanClaimQrCodeState extends State<ScanClaimQrCode> {
 
                         return Text(
                           txt,
-                          style: const TextStyle(color: Colors.white, backgroundColor: Colors.black38, fontSize: 16),
+                          style: context.textTheme.displayMedium!.copyWith(
+                            color: Colors.white,
+                            backgroundColor: Colors.black38,
+                          ),
                         );
                       }),
                       const SizedBox(height: 10),


### PR DESCRIPTION
I don't know if it was because we manually set the text size before, but the text size didn't change according to the device settings. Now it changes according to device settings. 

If I understand the task correctly, the task is done.

* Closes #1355