### PR TITLE
More robust transfer history

### DIFF
--- a/app/lib/models/transfer/transfer_history.dart
+++ b/app/lib/models/transfer/transfer_history.dart
@@ -47,7 +47,7 @@ class Transaction {
     for (final contact in contacts) {
       // Contact address might be with default prefix 42, or with Kusama prefix 2.
       // So better to work with the universal pubKey.
-      if (Fmt.ss58Decode(contact.address).pubKey == Fmt.ss58Decode(counterParty).pubKey) return contact.name;
+      if (contact.pubKey == Fmt.ss58Decode(counterParty).pubKey) return contact.name;
     }
     return null;
   }

--- a/app/lib/models/transfer/transfer_history.dart
+++ b/app/lib/models/transfer/transfer_history.dart
@@ -9,6 +9,8 @@ import 'package:encointer_wallet/utils/format.dart';
 
 part 'transfer_history.g.dart';
 
+const _target = 'transfer_history';
+
 /// A class representing an Encointer transaction.
 @JsonSerializable()
 class Transaction {
@@ -53,7 +55,7 @@ class Transaction {
           return contact.name;
         }
       } catch (e) {
-        Log.e('Could not decode counterparty address: $counterParty. Error: $e');
+        Log.e('Could not decode counterparty address: $counterParty. Error: $e', _target);
       }
     }
     return null;

--- a/app/lib/models/transfer/transfer_history.dart
+++ b/app/lib/models/transfer/transfer_history.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -45,9 +46,15 @@ class Transaction {
   /// Returns null if no matching contact is found.
   String? getNameFromContacts(List<AccountData> contacts) {
     for (final contact in contacts) {
-      // Contact address might be with default prefix 42, or with Kusama prefix 2.
-      // So better to work with the universal pubKey.
-      if (contact.pubKey == Fmt.ss58Decode(counterParty).pubKey) return contact.name;
+      try {
+        // Contact address might be with default prefix 42, or with Kusama prefix 2.
+        // So better to work with the universal pubKey.
+        if (contact.pubKey == Fmt.ss58Decode(counterParty).pubKey) {
+          return contact.name;
+        }
+      } catch (e) {
+        Log.e('Could not decode counterparty address: $counterParty. Error: $e');
+      }
     }
     return null;
   }

--- a/app/lib/modules/transfer/logic/transfer_history_view_store.dart
+++ b/app/lib/modules/transfer/logic/transfer_history_view_store.dart
@@ -54,8 +54,8 @@ abstract class _TransferHistoryViewStoreBase with Store {
       );
 
       response.fold(
-            (l) => fetchStatus = FetchStatus.error,
-            (r) {
+        (l) => fetchStatus = FetchStatus.error,
+        (r) {
           fetchStatus = FetchStatus.success;
           transactions = r.reversed.toList();
         },

--- a/app/lib/modules/transfer/logic/transfer_history_view_store.dart
+++ b/app/lib/modules/transfer/logic/transfer_history_view_store.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: library_private_types_in_public_api
+import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:ew_http/ew_http.dart';
 import 'package:mobx/mobx.dart';
 
@@ -11,6 +12,8 @@ import 'package:encointer_wallet/utils/fetch_status.dart';
 part 'transfer_history_view_store.g.dart';
 
 class TransferHistoryViewStore = _TransferHistoryViewStoreBase with _$TransferHistoryViewStore;
+
+const _target = 'transfer_history_view_store';
 
 abstract class _TransferHistoryViewStoreBase with Store {
   _TransferHistoryViewStoreBase(this.ewHttp);
@@ -25,22 +28,41 @@ abstract class _TransferHistoryViewStoreBase with Store {
   @action
   Future<void> getTransfers(AppStore appStore) async {
     fetchStatus = FetchStatus.loading;
-    final address = Fmt.ss58Encode(
-      appStore.account.currentAccountPubKey ?? '',
-      prefix: appStore.settings.endpoint.ss58 ?? 42,
-    );
 
-    final response = await ewHttp.getTypeList<Transaction>(
-      getTransactionHistoryUrl(appStore.encointer.community?.cid.toFmtString() ?? '', address),
-      fromJson: Transaction.fromJson,
-    );
+    final pubKey = appStore.account.currentAccountPubKey;
+    final cid = appStore.encointer.community?.cid;
 
-    response.fold(
-      (l) => fetchStatus = FetchStatus.error,
-      (r) {
-        fetchStatus = FetchStatus.success;
-        transactions = r.reversed.toList();
-      },
-    );
+    if (pubKey == null || pubKey.isEmpty) {
+      Log.e('currentAccountPubKey is not set', _target);
+      return;
+    }
+
+    if (cid == null) {
+      Log.e('chosen community is not set', _target);
+      return;
+    }
+
+    try {
+      final address = Fmt.ss58Encode(
+        pubKey,
+        prefix: appStore.settings.endpoint.ss58 ?? 42,
+      );
+
+      final response = await ewHttp.getTypeList<Transaction>(
+        getTransactionHistoryUrl(cid.toFmtString(), address),
+        fromJson: Transaction.fromJson,
+      );
+
+      response.fold(
+            (l) => fetchStatus = FetchStatus.error,
+            (r) {
+          fetchStatus = FetchStatus.success;
+          transactions = r.reversed.toList();
+        },
+      );
+    } catch (e) {
+      Log.e('Error getting transfers: $e');
+      fetchStatus = FetchStatus.error;
+    }
   }
 }

--- a/app/lib/modules/transfer/widgets/transaction_card.dart
+++ b/app/lib/modules/transfer/widgets/transaction_card.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:provider/provider.dart';
@@ -28,7 +29,7 @@ class TransactionCard extends StatelessWidget {
       child: ListTile(
         contentPadding: const EdgeInsets.fromLTRB(10, 15, 15, 10),
         isThreeLine: true,
-        leading: AddressIcon(transaction.counterParty, Fmt.ss58Decode(transaction.counterParty).pubKey, size: 55),
+        leading: AddressIcon(transaction.counterParty, tryGetPubKey(transaction), size: 55),
         title: Padding(
           padding: const EdgeInsets.only(bottom: 12),
           child: Row(
@@ -103,4 +104,18 @@ class TransactionCard extends StatelessWidget {
       ),
     );
   }
+}
+
+String tryGetPubKey(Transaction transaction) {
+  String counterPartyPubKey;
+
+  try {
+    counterPartyPubKey = Fmt.ss58Decode(transaction.counterParty).pubKey;
+  } catch (e) {
+    Log.e('Could not decode address. Error: $e');
+
+    // this is only used in the identicon, so we don't need to localize it.
+    counterPartyPubKey = 'invalid address';
+  }
+  return counterPartyPubKey;
 }

--- a/app/lib/modules/transfer/widgets/transactions_list.dart
+++ b/app/lib/modules/transfer/widgets/transactions_list.dart
@@ -15,6 +15,7 @@ class TransactionsList extends StatelessWidget {
   Widget build(BuildContext context) {
     if (transactions.isEmpty) return const TransactionsEmpty(key: Key('transactions-empty'));
     final appStore = context.watch<AppStore>();
+    final knownAccounts = appStore.settings.knownAccounts();
     return ListView.builder(
       key: const Key('transactions-list'),
       padding: const EdgeInsets.fromLTRB(14, 20, 14, 35),
@@ -27,7 +28,7 @@ class TransactionsList extends StatelessWidget {
           );
         } else if (index <= transactions.length) {
           final transaction = transactions[index - 1];
-          return TransactionCard(transaction, appStore.settings.knownAccounts());
+          return TransactionCard(transaction, knownAccounts);
         } else {
           return Padding(
             padding: const EdgeInsets.only(top: 10),


### PR DESCRIPTION
Although I did not manage to reproduce #1392 successfully, the first occurrence was after https://github.com/encointer/encointer-wallet-flutter/pull/1376. So I am quite confident, that address decoding failed at some point. Hence, I made the transfer list more robust by handling errors during that process, hoping that it will resolve that issue.

* Closes #1392 