### PR TITLE
update bazaar business store unit test to match business logic

### DIFF
--- a/app/test/store/bazaar/businesses_store_test.dart
+++ b/app/test/store/bazaar/businesses_store_test.dart
@@ -34,8 +34,8 @@ void main() {
     test('`getBusinesses()` should filter businesses by category', () async {
       await businessesStore.getBusinesses();
 
-      expect(businessesStore.businesses, isNotNull);
-      expect(businessesStore.businesses.every((business) => business.category == Category.food), isTrue);
+      expect(businessesStore.sortedBusinesses, isNotNull);
+      expect(businessesStore.sortedBusinesses.every((business) => business.category == Category.food), isTrue);
     });
   });
 }


### PR DESCRIPTION
Nothing really was broken, since we use `sortedBusinesses` in UI, changed it for unit test as well.

- Closes: #1374 