### PR TITLE
Fix potential encoding errors for EncointerBalances and catch ALL errors while sending extrinsics

### DIFF
--- a/app/js_service_encointer/package.json
+++ b/app/js_service_encointer/package.json
@@ -35,7 +35,7 @@
     "@polkadot/util": "^12.3.2",
     "@polkadot/util-crypto": "^12.3.2",
     "Buffer": "^0.0.0",
-    "bn.js": "^4.12.0",
+    "bn.js": "^5.2.1",
     "buffer": "^6.0.3",
     "core-js": "^3.20.2",
     "node-rsa": "^1.1.1",

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -232,7 +232,7 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
 
       if (txInfo.module === encointerBalances && txInfo.call === transfer) {
         balanceHuman = paramList[2];
-        paramList[2] = api.createType('BalanceType', stringNumberToEncointerBalanceU8(paramList[2]));
+        paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
       }
 
       console.log(`[js-account/sendTx]: txInfo ${JSON.stringify(txInfo)}`);
@@ -281,7 +281,7 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
         tip: new BN(txInfo.tip || 0, 10)
       };
 
-      console.log(`[js-account/sendTx]: Adding payment asset ${txInfo.txPaymentAsset}`);
+      console.log(`[js-account/sendTx]: Adding payment asset ${JSON.stringify(txInfo.txPaymentAsset)}`);
       if (txInfo.txPaymentAsset != null) {
         signerOptions.assetId = api.createType(
           'Option<CommunityIdentifier>', txInfo.txPaymentAsset

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -25,8 +25,8 @@ import {
 } from '../config/consts.js';
 import { unsubscribe } from '../utils/unsubscribe.js';
 import settings from './settings.js';
-import { stringToEncointerBalance } from '@encointer/types';
 import { extractEvents } from '@encointer/node-api';
+import { stringNumberToEncointerBalanceU8 } from '../utils/utils.js';
 
 export const keyring = new Keyring({ ss58Format: 0, type: 'sr25519' });
 
@@ -181,7 +181,7 @@ function getBlockTime (blocks) {
 export async function txFeeEstimate (txInfo, paramList) {
   if (txInfo.module === 'encointerBalances' && txInfo.call === 'transfer') {
     paramList[1] = communityIdentifierFromString(api.registry, paramList[1]);
-    paramList[2] = bnToU8a(stringToEncointerBalance(paramList[2]), 128, true);
+    paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
   }
 
   let dispatchInfo;
@@ -232,7 +232,7 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
 
     if (txInfo.module === encointerBalances && txInfo.call === transfer) {
       balanceHuman = paramList[2];
-      paramList[2] = bnToU8a(stringToEncointerBalance(paramList[2]), 128, true);
+      paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
     }
 
     const tx = api.tx[txInfo.module][txInfo.call](...paramList);
@@ -280,8 +280,9 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
         )
     }
 
-    console.log(`[js-account/sendTx]: ${JSON.stringify(txInfo)}`)
-    console.log(`[js-account/sendTx]: ${JSON.stringify(signerOptions)}`)
+    console.log(`[js-account/sendTx]: ${JSON.stringify(txInfo)}`);
+    console.log(`[js-account/sendTx]: ${JSON.stringify(signerOptions)}`);
+    console.log(`[js-account/sendTx]: ${JSON.stringify(paramList)}`);
 
     tx.signAndSend(keyPair, signerOptions, onStatusChange)
       .then((res) => {

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -7,11 +7,10 @@ import {
   u8aToBuffer,
   bufferToU8a,
   compactAddLength,
-  bnToU8a
 } from '@polkadot/util';
 import BN from 'bn.js';
 import { Keyring } from '@polkadot/keyring';
-import { createType } from '@polkadot/types';
+import { createType, } from '@polkadot/types';
 import { communityIdentifierFromString } from '@encointer/util';
 import { TrustedCallMap } from '../config/trustedCall.js';
 import { base58Decode } from '@polkadot/util-crypto/base58/bs58';
@@ -232,8 +231,10 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
 
     if (txInfo.module === encointerBalances && txInfo.call === transfer) {
       balanceHuman = paramList[2];
-      paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
+      paramList[2] = api.createType('BalanceType', stringNumberToEncointerBalanceU8(paramList[2]));
     }
+
+    console.log(`[js-account/sendTx]: Params ${JSON.stringify(paramList)}`);
 
     const tx = api.tx[txInfo.module][txInfo.call](...paramList);
     const onStatusChange = (result) => {
@@ -282,7 +283,6 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
 
     console.log(`[js-account/sendTx]: ${JSON.stringify(txInfo)}`);
     console.log(`[js-account/sendTx]: ${JSON.stringify(signerOptions)}`);
-    console.log(`[js-account/sendTx]: ${JSON.stringify(paramList)}`);
 
     tx.signAndSend(keyPair, signerOptions, onStatusChange)
       .then((res) => {

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -6,11 +6,11 @@ import {
   assert,
   u8aToBuffer,
   bufferToU8a,
-  compactAddLength,
+  compactAddLength
 } from '@polkadot/util';
 import BN from 'bn.js';
 import { Keyring } from '@polkadot/keyring';
-import { createType, } from '@polkadot/types';
+import { createType } from '@polkadot/types';
 import { communityIdentifierFromString } from '@encointer/util';
 import { TrustedCallMap } from '../config/trustedCall.js';
 import { base58Decode } from '@polkadot/util-crypto/base58/bs58';
@@ -25,7 +25,7 @@ import {
 import { unsubscribe } from '../utils/unsubscribe.js';
 import settings from './settings.js';
 import { extractEvents } from '@encointer/node-api';
-import { stringNumberToEncointerBalanceU8 } from '../utils/utils.js';
+import { stringNumberToEncointerBalanceU8a } from '../utils/utils.js';
 
 export const keyring = new Keyring({ ss58Format: 0, type: 'sr25519' });
 
@@ -180,7 +180,7 @@ function getBlockTime (blocks) {
 export async function txFeeEstimate (txInfo, paramList) {
   if (txInfo.module === 'encointerBalances' && txInfo.call === 'transfer') {
     paramList[1] = communityIdentifierFromString(api.registry, paramList[1]);
-    paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
+    paramList[2] = stringNumberToEncointerBalanceU8a(paramList[2]);
   }
 
   let dispatchInfo;
@@ -232,7 +232,7 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
 
       if (txInfo.module === encointerBalances && txInfo.call === transfer) {
         balanceHuman = paramList[2];
-        paramList[2] = stringNumberToEncointerBalanceU8(paramList[2]);
+        paramList[2] = stringNumberToEncointerBalanceU8a(paramList[2]);
       }
 
       console.log(`[js-account/sendTx]: txInfo ${JSON.stringify(txInfo)}`);

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -276,10 +276,12 @@ export function sendTxWithPair (keyPair, txInfo, paramList) {
         return;
       }
 
+      console.log(`[js-account/sendTx]: Adding tip: ${txInfo.tip}`);
       const signerOptions = {
-        tip: new BN(txInfo.tip, 10)
+        tip: new BN(txInfo.tip || 0, 10)
       };
 
+      console.log(`[js-account/sendTx]: Adding payment asset ${txInfo.txPaymentAsset}`);
       if (txInfo.txPaymentAsset != null) {
         signerOptions.assetId = api.createType(
           'Option<CommunityIdentifier>', txInfo.txPaymentAsset

--- a/app/js_service_encointer/src/service/encointer.js
+++ b/app/js_service_encointer/src/service/encointer.js
@@ -15,7 +15,7 @@ import {
   getDemurrage as _getDemurrage, submitAndWatchTx,
 } from '@encointer/node-api';
 import { getFinalizedHeader } from './chain.js';
-import { applyDemurrage } from '../utils/apply-demurrage.js';
+import { applyDemurrage } from '../utils/utils.js';
 import { Keyring } from '@polkadot/keyring';
 
 export async function getCurrentPhase () {

--- a/app/js_service_encointer/src/utils/utils.js
+++ b/app/js_service_encointer/src/utils/utils.js
@@ -1,12 +1,15 @@
 import { bnToU8a } from '@polkadot/util';
 import { stringToEncointerBalance } from '@encointer/types';
 
-export function applyDemurrage(balanceEntry, latestBlockNumber, demurrageRate) {
+export function applyDemurrage (balanceEntry, latestBlockNumber, demurrageRate) {
   const elapsed = latestBlockNumber - balanceEntry.lastUpdate;
-  const exponent = -demurrageRate * elapsed
+  const exponent = -demurrageRate * elapsed;
   return balanceEntry.principal * Math.pow(Math.E, exponent);
 }
 
-export function stringNumberToEncointerBalanceU8(balance) {
-  return bnToU8a(stringToEncointerBalance(balance), 128, true);
+export function stringNumberToEncointerBalanceU8 (balance) {
+  return bnToU8a(stringToEncointerBalance(balance), {
+    bitLength: 128,
+    isLe: true
+  });
 }

--- a/app/js_service_encointer/src/utils/utils.js
+++ b/app/js_service_encointer/src/utils/utils.js
@@ -7,7 +7,7 @@ export function applyDemurrage (balanceEntry, latestBlockNumber, demurrageRate) 
   return balanceEntry.principal * Math.pow(Math.E, exponent);
 }
 
-export function stringNumberToEncointerBalanceU8 (balance) {
+export function stringNumberToEncointerBalanceU8a (balance) {
   return bnToU8a(stringToEncointerBalance(balance), {
     bitLength: 128,
     isLe: true

--- a/app/js_service_encointer/src/utils/utils.js
+++ b/app/js_service_encointer/src/utils/utils.js
@@ -7,6 +7,10 @@ export function applyDemurrage (balanceEntry, latestBlockNumber, demurrageRate) 
   return balanceEntry.principal * Math.pow(Math.E, exponent);
 }
 
+/**
+ * Encodes a string representing a decimal number to a scale encoded U8a array that
+ * can be put as is into an extrinsic.
+ */
 export function stringNumberToEncointerBalanceU8a (balance) {
   return bnToU8a(stringToEncointerBalance(balance), {
     bitLength: 128,

--- a/app/js_service_encointer/src/utils/utils.js
+++ b/app/js_service_encointer/src/utils/utils.js
@@ -1,5 +1,12 @@
+import { bnToU8a } from '@polkadot/util';
+import { stringToEncointerBalance } from '@encointer/types';
+
 export function applyDemurrage(balanceEntry, latestBlockNumber, demurrageRate) {
   const elapsed = latestBlockNumber - balanceEntry.lastUpdate;
   const exponent = -demurrageRate * elapsed
   return balanceEntry.principal * Math.pow(Math.E, exponent);
+}
+
+export function stringNumberToEncointerBalanceU8(balance) {
+  return bnToU8a(stringToEncointerBalance(balance), 128, true);
 }

--- a/app/js_service_encointer/test/utils/utils.test.js
+++ b/app/js_service_encointer/test/utils/utils.test.js
@@ -3,11 +3,11 @@
  */
 
 import { describe, expect, it } from '@jest/globals';
-import { stringNumberToEncointerBalanceU8 } from '../../src/utils/utils.js';
+import { stringNumberToEncointerBalanceU8a } from '../../src/utils/utils.js';
 
 describe('utils', () => {
-  it('stringNumberToEncointerBalanceU8 works', () => {
-    const balanceArray = stringNumberToEncointerBalanceU8('128');
+  it('stringNumberToEncointerBalanceU8a works', () => {
+    const balanceArray = stringNumberToEncointerBalanceU8a('128');
     expect(balanceArray).toStrictEqual(new Uint8Array([
       0, 0, 0, 0, 0, 0,
       0, 0, 128, 0, 0, 0,

--- a/app/js_service_encointer/test/utils/utils.test.js
+++ b/app/js_service_encointer/test/utils/utils.test.js
@@ -6,7 +6,7 @@ import { describe, expect, it } from '@jest/globals';
 import { stringNumberToEncointerBalanceU8 } from '../../src/utils/utils.js';
 
 describe('utils', () => {
-  it('stringBalanceToU8 works', () => {
+  it('stringNumberToEncointerBalanceU8 works', () => {
     const balanceArray = stringNumberToEncointerBalanceU8('128');
     expect(balanceArray).toStrictEqual(new Uint8Array([
       0, 0, 0, 0, 0, 0,

--- a/app/js_service_encointer/test/utils/utils.test.js
+++ b/app/js_service_encointer/test/utils/utils.test.js
@@ -7,6 +7,17 @@ import { stringNumberToEncointerBalanceU8a } from '../../src/utils/utils.js';
 
 describe('utils', () => {
   it('stringNumberToEncointerBalanceU8a works', () => {
+    /*
+      Verified correctness with the following rust-test.
+
+     	#[test]
+     	fn decode_128() {
+     		let balance =
+     			BalanceType::from_le_bytes([0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0]);
+
+     		assert_eq!(balance, BalanceType::from_num(128));
+     	}
+    */
     const balanceArray = stringNumberToEncointerBalanceU8a('128');
     expect(balanceArray).toStrictEqual(new Uint8Array([
       0, 0, 0, 0, 0, 0,

--- a/app/js_service_encointer/test/utils/utils.test.js
+++ b/app/js_service_encointer/test/utils/utils.test.js
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { stringNumberToEncointerBalanceU8 } from '../../src/utils/utils.js';
+
+describe('utils', () => {
+  it('stringBalanceToU8 works', () => {
+    const balanceArray = stringNumberToEncointerBalanceU8('128');
+    expect(balanceArray).toStrictEqual(new Uint8Array([
+      0, 0, 0, 0, 0, 0,
+      0, 0, 128, 0, 0, 0,
+      0, 0, 0, 0
+    ]));
+  });
+});

--- a/app/js_service_encointer/yarn.lock
+++ b/app/js_service_encointer/yarn.lock
@@ -4311,7 +4311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9, bn.js@npm:^4.12.0":
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
   checksum: 39afb4f15f4ea537b55eaf1446c896af28ac948fdcf47171961475724d1bb65118cca49fa6e3d67706e4790955ec0e74de584e45c8f1ef89f46c812bee5b5a12
@@ -5669,7 +5669,7 @@ __metadata:
     "@webpack-cli/init": ^1.1.3
     Buffer: ^0.0.0
     babel-loader: ^9.1.2
-    bn.js: ^4.12.0
+    bn.js: ^5.2.1
     browserslist: ^4.19.1
     buffer: ^6.0.3
     constants-browserify: ^1.0.0

--- a/app/lib/service/tx/lib/src/submit_to_js.dart
+++ b/app/lib/service/tx/lib/src/submit_to_js.dart
@@ -31,7 +31,6 @@ Future<void> submitToJS(
   required Map<String, dynamic> txParams,
   void Function(dynamic res)? onError,
   required String password,
-  BigInt? tip,
 }) async {
   final l10n = context.l10n;
 
@@ -42,7 +41,6 @@ Future<void> submitToJS(
   txInfo['pubKey'] = store.account.currentAccount.pubKey;
   txInfo['address'] = store.account.currentAddress;
   txInfo['password'] = password;
-  txInfo['tip'] = tip.toString();
   Log.d('$txInfo', 'submitToJS');
   Log.d('${txParams['params']}', 'submitToJS');
 


### PR DESCRIPTION
An API change in BN.js v5 lead to potential encoding issues. The catchy thing here was that we depend on Bn.js v4, which encodes correctly, but for some (non-deterministic) reason, webpack sometimes resolves to v5, and then we got an encoding error as our bitlength setting was ignored.

Another notable change introduced is that we now try-catch the whole extrinsic sending process - I thought this would fix the endless activity indicators while sending an extrinsic, but it seems that they still occurr.

Failing IOS tests seem to occur on all branches now, and it seems unrelated to this PR: #1485