### PR TITLE
[GHA] use macos-13 runner image and update IOS Simulators

### DIFF
--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -29,7 +29,7 @@ jobs:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
         api-level: [29] # 30 is broken for now, 29 is way too flaky
         include:
-          - os: macos-latest
+          - os: macos-13
             # needs to be the `id` from the devices given by `avdmanager list device`
             device: "pixel_3a"
             # disable for now. it takes ages to build and launch the app and the upper limit of

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Start colima a docker runtime for MacOs
         run: |
           brew install docker
+          brew install colima
           colima start
 
       - name: Run encointer-node

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -60,11 +60,11 @@ jobs:
 
       - name: "Create Simulator if iPad Pro 2nd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
 
       - name: "Create Simulator if iPad Pro 3rd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
+        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
 
       # JS Stuff
       - uses: actions/setup-node@v3

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -30,14 +30,14 @@ jobs:
         # See up to date screenshots specifications for Appstores:
         # https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/
         include:
-          - device: "iPhone 11 Pro Max"
+          - device: "iPhone 14 Pro Max"
             record_video: true
             # With this flag we can run the CI against different node versions to check compatibility.
             docker_tag: "1.5.1"
           - device: "iPhone 8 Plus"
             record_video: false
             docker_tag: "1.5.1"
-          - device: "iPad Pro (12.9-inch) (3rd generation)"
+          - device: "iPad Pro (12.9-inch) (6th generation) Simulator (17.0)"
             record_video: false
             docker_tag: "1.5.1"
           - device: "iPad Pro (12.9-inch) (2nd generation)"
@@ -64,9 +64,9 @@ jobs:
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
         run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
 
-      - name: "Create Simulator if iPad Pro 3rd gen"
-        if: ${{ matrix.device == 'iPad Pro (12.9-inch) (3rd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (3rd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---3rd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
+      - name: "Create Simulator if iPad 8 Plus"
+        if: ${{ matrix.device == 'iPhone 8 Plus' }}
+        run: xcrun simctl create "iPhone 8 Plus" "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
 
       # JS Stuff
       - uses: actions/setup-node@v3

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -30,7 +30,7 @@ jobs:
         # See up to date screenshots specifications for Appstores:
         # https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/
         include:
-          - device: "iPhone 14 Pro Max"
+          - device: "iPhone 14 Pro Max Simulator (17.0)"
             record_video: true
             # With this flag we can run the CI against different node versions to check compatibility.
             docker_tag: "1.5.1"

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Start colima a docker runtime for MacOs
         run: |
           brew install docker
+          brew install colima
           colima start
 
       - name: Run encointer-node

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -62,11 +62,17 @@ jobs:
 
       - name: "Create Simulator if iPad Pro 2nd gen"
         if: ${{ matrix.device == 'iPad Pro (12.9-inch) (2nd generation)' }}
-        run: xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
+        # Unfortunately it is not deterministic if the 16.2 or the 16.4 runtime is available
+        run: |
+          xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-4" || \
+          xcrun simctl create "iPad Pro (12.9-inch) (2nd generation)" "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--12-9-inch---2nd-generation-" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
 
       - name: "Create Simulator if iPad 8 Plus"
         if: ${{ matrix.device == 'iPhone 8 Plus' }}
-        run: xcrun simctl create "iPhone 8 Plus" "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
+        # Unfortunately it is not deterministic if the 16.2 or the 16.4 runtime is available
+        run: |
+          xcrun simctl create "iPhone 8 Plus" "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus" "com.apple.CoreSimulator.SimRuntime.iOS-16-4" || \
+          xcrun simctl create "iPhone 8 Plus" "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus" "com.apple.CoreSimulator.SimRuntime.iOS-16-2"
 
       # JS Stuff
       - uses: actions/setup-node@v3

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
+        # See up to date screenshots specifications for Appstores:
+        # https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/
         include:
           - device: "iPhone 11 Pro Max"
             record_video: true

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -30,14 +30,14 @@ jobs:
         # See up to date screenshots specifications for Appstores:
         # https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/
         include:
-          - device: "iPhone 14 Pro Max Simulator (17.0)"
+          - device: "iPhone 14 Pro Max Simulator (16.4)"
             record_video: true
             # With this flag we can run the CI against different node versions to check compatibility.
             docker_tag: "1.5.1"
           - device: "iPhone 8 Plus"
             record_video: false
             docker_tag: "1.5.1"
-          - device: "iPad Pro (12.9-inch) (6th generation) Simulator (17.0)"
+          - device: "iPad Pro (12.9-inch) (6th generation) Simulator (16.4)"
             record_video: false
             docker_tag: "1.5.1"
           - device: "iPad Pro (12.9-inch) (2nd generation)"

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -30,14 +30,14 @@ jobs:
         # See up to date screenshots specifications for Appstores:
         # https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/
         include:
-          - device: "iPhone 14 Pro Max Simulator (16.4)"
+          - device: "iPhone 14 Pro Max"
             record_video: true
             # With this flag we can run the CI against different node versions to check compatibility.
             docker_tag: "1.5.1"
           - device: "iPhone 8 Plus"
             record_video: false
             docker_tag: "1.5.1"
-          - device: "iPad Pro (12.9-inch) (6th generation) Simulator (16.4)"
+          - device: "iPad Pro (12.9-inch) (6th generation)"
             record_video: false
             docker_tag: "1.5.1"
           - device: "iPad Pro (12.9-inch) (2nd generation)"

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -23,7 +23,7 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   ios_device_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
     strategy:
       matrix:

--- a/scripts/ios_emulator.sh
+++ b/scripts/ios_emulator.sh
@@ -6,7 +6,8 @@ echo "looking for emulator with device id: ${DEVICE_ID}"
 echo "Available devices are:"
 xcrun xctrace list devices 2>&1
 
-UUID=$(xcrun xctrace list devices 2>&1 | grep "$DEVICE_ID" | grep -oE "([A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12})")
+# Return the UUID of the first device that matches the device ID.
+UUID=$(xcrun xctrace list devices 2>&1 | grep "$DEVICE_ID" | head -1 | grep -oE "([A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12})")
 
 echo "Applesimutils help: "
 applesimutils --help


### PR DESCRIPTION
This PR is an attempt to fix the lately unstable IOS CI. The update changed the available predefined simulators; hence I took the time to revisit the latest specifications for the mandatory printscreens to publish the app on all IOS devices: https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/.

It seems that the CI is still unstable unfortunately, but the update was needed anyhow.