### PR TITLE
[AnnouncementView] fetch new announcements when the cid changes

### DIFF
--- a/app/lib/page/assets/announcement/view/announcement_view.dart
+++ b/app/lib/page/assets/announcement/view/announcement_view.dart
@@ -38,6 +38,15 @@ class _AnnouncementViewState extends State<AnnouncementView> {
   }
 
   @override
+  void didUpdateWidget(AnnouncementView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _getAnnouncements();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Observer(builder: (_) {
       return switch (_announcementStore.fetchStatus) {

--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -287,7 +287,7 @@ class _AssetsViewState extends State<AssetsView> {
               CeremonyBox(widget.store, webApi, key: const Key(EWTestKeys.ceremonyBoxWallet)),
               const SizedBox(height: 24),
               if (widget.store.encointer.community != null)
-                AnnouncementView(cid: widget.store.encointer.community!.cid.toFmtString())
+                Observer(builder: (_) => AnnouncementView(cid: widget.store.encointer.community!.cid.toFmtString()))
             ],
           ),
         ),


### PR DESCRIPTION
As noted in https://github.com/encointer/encointer-wallet-flutter/pull/1501#issuecomment-1742720590, the announcements were not immediately fetched after the cid was changed.