### PR TITLE
show default community icon instead of activity indicator when no community is selected

### DIFF
--- a/app/lib/common/components/logo/community_icon.dart
+++ b/app/lib/common/components/logo/community_icon.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/svg.dart';
@@ -28,8 +27,7 @@ class CommunityIconObserver extends StatelessWidget {
               return SvgPicture.asset(fallBackCommunityIcon);
             }
           } else {
-            ///TODO(Azamat): Add some image saying community not selected
-            return const CupertinoActivityIndicator();
+            return SvgPicture.asset(fallBackCommunityIcon);
           }
         },
       ),

--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -14,7 +14,6 @@ import 'package:upgrader/upgrader.dart';
 import 'package:collection/collection.dart';
 
 import 'package:encointer_wallet/l10n/l10.dart';
-import 'package:encointer_wallet/common/components/loading/centered_activity_indicator.dart';
 import 'package:encointer_wallet/page/assets/announcement/view/announcement_view.dart';
 import 'package:encointer_wallet/common/components/address_icon.dart';
 import 'package:encointer_wallet/gen/assets.gen.dart';
@@ -351,29 +350,11 @@ class _AssetsViewState extends State<AssetsView> {
 
   List<AccountOrCommunityData> _allCommunities() {
     final communityStores = context.read<AppStore>().encointer.communityStores?.values.toList();
-    if (communityStores != null && communityStores.isNotEmpty) {
-      return communityStores
-          .mapIndexed(
-            (i, e) => AccountOrCommunityData(
-              avatar: Container(
-                height: avatarSize,
-                width: avatarSize,
-                decoration: BoxDecoration(
-                  color: context.colorScheme.background,
-                  shape: BoxShape.circle,
-                ),
-                child: e.communityIcon != null
-                    ? SvgPicture.string(e.communityIcon!)
-                    : SvgPicture.asset(fallBackCommunityIcon),
-              ),
-              name: e.name,
-              isSelected: widget.store.encointer.community?.cid == e.cid,
-            ),
-          )
-          .toList();
-    } else {
-      return [
-        AccountOrCommunityData(
+
+    if (communityStores == null) return [];
+    return communityStores
+        .mapIndexed(
+          (i, e) => AccountOrCommunityData(
             avatar: Container(
               height: avatarSize,
               width: avatarSize,
@@ -381,11 +362,15 @@ class _AssetsViewState extends State<AssetsView> {
                 color: context.colorScheme.background,
                 shape: BoxShape.circle,
               ),
-              child: const CenteredActivityIndicator(),
+              child: e.communityIcon != null
+                  ? SvgPicture.string(e.communityIcon!)
+                  : SvgPicture.asset(fallBackCommunityIcon),
             ),
-            name: '...')
-      ];
-    }
+            name: e.name,
+            isSelected: widget.store.encointer.community?.cid == e.cid,
+          ),
+        )
+        .toList();
   }
 
   List<AccountOrCommunityData> initAllAccounts() {

--- a/app/test_driver/app/home/home_test.dart
+++ b/app/test_driver/app/home/home_test.dart
@@ -10,7 +10,6 @@ Future<void> homeInit(FlutterDriver driver) async {
 }
 
 Future<void> changeCommunity(FlutterDriver driver) async {
-  await driver.runUnsynchronized(() async {
     await driver.tap(find.byValueKey(EWTestKeys.panelController));
     await driver.tap(find.byValueKey(EWTestKeys.addCommunity));
 
@@ -21,7 +20,6 @@ Future<void> changeCommunity(FlutterDriver driver) async {
     await Future<void>.delayed(const Duration(milliseconds: 1000));
     await closePanel(driver);
     await refreshWalletPage(driver);
-  });
 }
 
 Future<void> registerAndWait(FlutterDriver driver, ParticipantTypeTestHelper registrationType) async {

--- a/app/test_driver/app/home/home_test.dart
+++ b/app/test_driver/app/home/home_test.dart
@@ -10,16 +10,16 @@ Future<void> homeInit(FlutterDriver driver) async {
 }
 
 Future<void> changeCommunity(FlutterDriver driver) async {
-    await driver.tap(find.byValueKey(EWTestKeys.panelController));
-    await driver.tap(find.byValueKey(EWTestKeys.addCommunity));
+  await driver.tap(find.byValueKey(EWTestKeys.panelController));
+  await driver.tap(find.byValueKey(EWTestKeys.addCommunity));
 
-    await driver.tap(find.byValueKey(EWTestKeys.cidMarkerIcon(0)));
-    await driver.tap(find.byValueKey(EWTestKeys.cidMarkerDescription(0)));
-    await driver.waitFor(find.byValueKey(EWTestKeys.addCommunity));
+  await driver.tap(find.byValueKey(EWTestKeys.cidMarkerIcon(0)));
+  await driver.tap(find.byValueKey(EWTestKeys.cidMarkerDescription(0)));
+  await driver.waitFor(find.byValueKey(EWTestKeys.addCommunity));
 
-    await Future<void>.delayed(const Duration(milliseconds: 1000));
-    await closePanel(driver);
-    await refreshWalletPage(driver);
+  await Future<void>.delayed(const Duration(milliseconds: 1000));
+  await closePanel(driver);
+  await refreshWalletPage(driver);
 }
 
 Future<void> registerAndWait(FlutterDriver driver, ParticipantTypeTestHelper registrationType) async {


### PR DESCRIPTION
I think this is more intuitive, and it also allows as to wait in tests until all frames have been rendered. I think, this was part of the flaky integration tests, as we didn't wait until the app was in a stable state in tests.