### PR TITLE
[assets] reset claim button after claiming

### DIFF
--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -265,7 +265,7 @@ class _AssetsViewState extends State<AssetsView> {
                                   widget.store,
                                   webApi,
                                   widget.store.encointer.chosenCid!,
-                                ),
+                                ).then((_) => webApi.encointer.hasPendingIssuance()),
                               );
                             } else {
                               return _appSettingsStore.developerMode


### PR DESCRIPTION
The claim button is not re-evaluated after we claimed the rewards, this fixes it.