### PR TITLE
Get basic encointer network params in initialization of webView

### DIFF
--- a/app/lib/service/substrate_api/api.dart
+++ b/app/lib/service/substrate_api/api.dart
@@ -97,7 +97,12 @@ class Api {
         await store.encointer.initializeUninitializedStores(store.account.currentAddress);
       }
 
-      return connectFunc();
+      await connectFunc();
+      await Future.wait([
+        webApi.encointer.getPhaseDurations(),
+        webApi.encointer.getCurrentPhase(),
+        webApi.encointer.getNextPhaseTimestamp(),
+      ]);
     }
 
     return js.launchWebView(_jsServiceEncointer, postInitCallback);


### PR DESCRIPTION
Sometimes the home page was in a weird state after changing the network: no info in the ceremony box, many activity indicators. I noticed that this is because basic network info is still null like `phaseDurations`, `nextPhaseTimestamp`, and for some reason the observer didn't pick up when they become non-null.

I couldn't find the reason why the observer didn't pick it up, so the quick-fix was to just wait until the values are set in the init function.