### PR TITLE
Fix android device tests; use macos 12 runners and switch to api level 33

### DIFF
--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
-        api-level: [29] # 30 is broken for now, 29 is way too flaky
+        api-level: [30]
         include:
           - os: macos-13
             # needs to be the `id` from the devices given by `avdmanager list device`

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    branches: [master, f-droid, cl/update-android-integration-tests]
+    branches: [master, f-droid]
   pull_request:
     branches: [master, f-droid]
 
@@ -20,7 +20,7 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-android:
+  android-device-tests:
     # use macos to have hardware acceleration https://github.com/ReactiveCircus/android-emulator-runner/issues/46
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -29,7 +29,7 @@ jobs:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
         api-level: [33]
         include:
-          - os: macos-12
+          - os: macos-12 # Macos 13 is broken currently.
             # needs to be the `id` from the devices given by `avdmanager list device`
             device: "pixel_3a"
             # disable for now. it takes ages to build and launch the app and the upper limit of

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./scripts/install_flutter_wrapper.sh
 
       - name: Setup Android SDK and accept licences
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v2
 
       - name: List android images
         run: sdkmanager --list | grep system-images

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
-        api-level: [30]
+        api-level: [33]
         include:
           - os: macos-13
             # needs to be the `id` from the devices given by `avdmanager list device`

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    branches: [master, f-droid]
+    branches: [master, f-droid, cl/update-android-integration-tests]
   pull_request:
     branches: [master, f-droid]
 

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -23,7 +23,7 @@ jobs:
   android-device-tests:
     # use macos to have hardware acceleration https://github.com/ReactiveCircus/android-emulator-runner/issues/46
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 70
     strategy:
       matrix:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./scripts/install_flutter_wrapper.sh
 
       - name: Setup Android SDK and accept licences
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v3
 
       - name: List android images
         run: sdkmanager --list | grep system-images

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -104,6 +104,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.device }}
           force-avd-creation: false
+          arch: x86_64
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -29,7 +29,7 @@ jobs:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
         api-level: [33]
         include:
-          - os: macos-13
+          - os: macos-12
             # needs to be the `id` from the devices given by `avdmanager list device`
             device: "pixel_3a"
             # disable for now. it takes ages to build and launch the app and the upper limit of
@@ -88,7 +88,6 @@ jobs:
       - name: Start colima a docker runtime for MacOs
         run: |
           brew install docker
-          brew install colima
           colima start
 
       - name: Run encointer-node

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -118,6 +118,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.device }}
           force-avd-creation: false
+          arch: x86_64
           # as we use the cleanly cached emulator, we need to define `-no-snapshot-save` here.
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true


### PR DESCRIPTION
They have been unstable for a long time, and completely broken since we started using macos 13, as the emulator couldn't start up. This PR reverts the change to macos-13, and uses now Android Api 33, which seems to be stable so far.