### PR TITLE
bump melos and always use the project's melos instead of the global one

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -38,14 +38,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Melos Install
-        run: ./scripts/install_melos.sh
+      - name: Get dependencies (i.e., melos)
+        run: .flutter/bin/dart pub get
 
       - name: Melos Bootstrap
-        run: ./flutterw pub global run melos bootstrap
+        run: .flutter/bin/dart run melos bootstrap
 
       - name: "Build JS"
-        run: ./flutterw pub global run melos yarn-build
+        run: .flutter/bin/dart run melos yarn-build
 
       - name: "Build apk"
-        run: ./flutterw pub global run melos build-apk-fdroid
+        run: .flutter/bin/dart run melos build-apk-fdroid

--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -59,14 +59,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Melos Install
-        run: ./scripts/install_melos.sh
+      - name: Get dependencies (i.e., melos)
+        run: .flutter/bin/dart pub get
 
       - name: Melos Bootstrap
-        run: ./flutterw pub global run melos bootstrap
+        run: .flutter/bin/dart run melos bootstrap
 
       - name: "Build JS"
-        run: ./flutterw pub global run melos yarn-build
+        run: .flutter/bin/dart run melos yarn-build
 
       - name: Gradle cache
         uses: actions/cache@v3

--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -79,14 +79,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Melos Install
-        run: ./scripts/install_melos.sh
+      - name: Get dependencies (i.e., melos)
+        run: .flutter/bin/dart pub get
 
       - name: Melos Bootstrap
-        run: ./flutterw pub global run melos bootstrap
+        run: .flutter/bin/dart run melos bootstrap
 
       - name: "Build JS"
-        run: ./flutterw pub global run melos yarn-build
+        run: .flutter/bin/dart run melos yarn-build
 
       - name: Start colima a docker runtime for MacOs
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,20 +17,20 @@ jobs:
       - name: Install flutter wrapper
         run: ./scripts/install_flutter_wrapper.sh
 
-      - name: Get dependencies
+      - name: Get dependencies (i.e., melos)
         run: .flutter/bin/dart pub get
 
       - name: Melos Bootstrap
         run: .flutter/bin/dart run melos bootstrap
 
       - name: "Build JS"
-        run: ./flutterw run melos yarn-build
+        run: .flutter/bin/dart run melos yarn-build
 
       - name: "Check fmt"
-        run: ./flutterw run melos format-check
+        run: .flutter/bin/dart run melos format-check
 
       - name: "Analyze Code"
-        run: ./flutterw run melos analyze-check
+        run: .flutter/bin/dart melos analyze-check
 
       - name: "Check translations"
         run: |
@@ -38,15 +38,15 @@ jobs:
           ./scripts/check_translations.sh ./app/.untranslated-messages.txt
 
       - name: "Run unit tests Encointer"
-        run: ./flutterw run melos unit-test-app-exclude-encointer-node-e2e
+        run: .flutter/bin/dart run melos unit-test-app-exclude-encointer-node-e2e
 
       - name: "Run unit tests Packages"
-        run: ./flutterw run melos unit-test-packages
+        run: .flutter/bin/dart run melos unit-test-packages
 
       - name: "Run the build_runner and return an error if files are changed"
         run: |
-          ./flutterw run melos run-build-runner
-          ./flutterw run melos format
+          .flutter/bin/dart run melos run-build-runner
+          .flutter/bin/dart run melos format
           git diff --exit-code
 
     #  test-js:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests & Code Quality
 
 on:
   push:
-    branches: [master, f-droid]
+    branches: [master, f-droid, cl/bump-melos-and-simplify-command]
   pull_request:
     branches: [master, f-droid]
 
@@ -21,16 +21,16 @@ jobs:
         run: ./scripts/install_melos.sh
 
       - name: Melos Bootstrap
-        run: ./flutterw pub global run melos bootstrap
+        run: ./flutterw run melos bootstrap
 
       - name: "Build JS"
-        run: ./flutterw pub global run melos yarn-build
+        run: ./flutterw run melos yarn-build
 
       - name: "Check fmt"
-        run: ./flutterw pub global run melos format-check
+        run: ./flutterw run melos format-check
 
       - name: "Analyze Code"
-        run: ./flutterw pub global run melos analyze-check
+        run: ./flutterw run melos analyze-check
 
       - name: "Check translations"
         run: |
@@ -38,15 +38,15 @@ jobs:
           ./scripts/check_translations.sh ./app/.untranslated-messages.txt
 
       - name: "Run unit tests Encointer"
-        run: ./flutterw pub global run melos unit-test-app-exclude-encointer-node-e2e
+        run: ./flutterw run melos unit-test-app-exclude-encointer-node-e2e
 
       - name: "Run unit tests Packages"
-        run: ./flutterw pub global run melos unit-test-packages
+        run: ./flutterw run melos unit-test-packages
 
       - name: "Run the build_runner and return an error if files are changed"
         run: |
-          ./flutterw pub global run melos run-build-runner
-          ./flutterw pub global run melos format
+          ./flutterw run melos run-build-runner
+          ./flutterw run melos format
           git diff --exit-code
 
     #  test-js:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests & Code Quality
 
 on:
   push:
-    branches: [master, f-droid, cl/bump-melos-and-simplify-command]
+    branches: [master, f-droid]
   pull_request:
     branches: [master, f-droid]
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Install flutter wrapper
         run: ./scripts/install_flutter_wrapper.sh
 
-      - name: Melos Install
-        run: ./scripts/install_melos.sh
+      - name: Get dependencies
+        run: .flutter/bin/dart pub get
 
       - name: Melos Bootstrap
-        run: ./flutterw run melos bootstrap
+        run: .flutter/bin/dart run melos bootstrap
 
       - name: "Build JS"
         run: ./flutterw run melos yarn-build

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: .flutter/bin/dart run melos format-check
 
       - name: "Analyze Code"
-        run: .flutter/bin/dart melos analyze-check
+        run: .flutter/bin/dart run melos analyze-check
 
       - name: "Check translations"
         run: |

--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ then:
 sudo apt install cmake ninja-build libgtk-3-dev npm build-essentials
 ./scripts/install_flutter_wrapper.sh
 # install project deps (i.e., melos)
-.flutter/bin/dart
-# add the following line to `~/.bashrc` as well
-export PATH="$PATH":"$HOME/.pub-cache/bin:$HOME/encointer/encointer-wallet-flutter/.flutter/bin"
-
+.flutter/bin/dart pub get
 .flutter/bin/dart melos bootstrap
 
 sudo npm install --global yarn

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ then:
 ```
 sudo apt install cmake ninja-build libgtk-3-dev npm build-essentials
 ./scripts/install_flutter_wrapper.sh
-./flutterw pub global activate melos
+# install project deps (i.e., melos)
+.flutter/bin/dart
 # add the following line to `~/.bashrc` as well
 export PATH="$PATH":"$HOME/.pub-cache/bin:$HOME/encointer/encointer-wallet-flutter/.flutter/bin"
 
-melos bootstrap
+.flutter/bin/dart melos bootstrap
 
 sudo npm install --global yarn
 # optional:

--- a/melos.yaml
+++ b/melos.yaml
@@ -27,7 +27,7 @@ command:
 
 scripts:
   format:
-    exec: dart format . --line-length 120
+    run: dart format . --line-length 120
     description: "Format all Dart code"
 
   format-check:
@@ -35,23 +35,23 @@ scripts:
     description: "Check format all Dart code"
 
   analyze:
-    exec: dart analyze
+    run: dart analyze
     description: "Analyze all Dart code"
 
   analyze-check:
-    exec: dart analyze --fatal-warnings
+    run: dart analyze --fatal-warnings
     description: "Analyze all Dart code and exit if there are any fatal warnings"
 
   flutter-clean:
-    exec: flutter clean
+    run: flutter clean
     description: "Clean pub dependencies"
 
   pub-get:
-    exec: flutter pub get
+    run: flutter pub get
     description: "Get pub dependencies"
 
   unit-test:
-    exec: flutter test
+    run: flutter test
     description: "Run unit tests (all packages)"
 
   doctor:

--- a/melos.yaml
+++ b/melos.yaml
@@ -28,15 +28,11 @@ command:
 
 scripts:
   format:
-    run: >-
-      flutter pub global run melos exec \
-      dart format . --line-length 120
+    exec: dart format . --line-length 120
     description: "Format all Dart code"
 
   format-check:
-    run: >-
-      flutter pub global run melos exec \
-      dart format . --line-length 120 --set-exit-if-changed
+    exec: dart format . --line-length 120 --set-exit-if-changed
     description: "Check format all Dart code"
 
   analyze:

--- a/melos.yaml
+++ b/melos.yaml
@@ -31,7 +31,7 @@ scripts:
     description: "Format all Dart code"
 
   format-check:
-    exec: dart format . --line-length 120 --set-exit-if-changed
+    run: dart format . --line-length 120 --set-exit-if-changed
     description: "Check format all Dart code"
 
   analyze:

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,7 +14,7 @@ command:
 # Notes:
 # 1.  On windows the multiline operator doesn't work in most cases, so we should try to have one liner scripts commands
 #     connected with '&&'.
-# 2.  make sure that you have installed the projects dependencies with ./flutter/bin/dart pub get. Otherwise, melos
+# 2.  make sure that you have installed the project dependencies with ./flutter/bin/dart pub get. Otherwise, melos
 #     will fallback to the globally installed version and errors might occur.
 #
 # Cross platform linebreaks:

--- a/melos.yaml
+++ b/melos.yaml
@@ -14,9 +14,8 @@ command:
 # Notes:
 # 1.  On windows the multiline operator doesn't work in most cases, so we should try to have one liner scripts commands
 #     connected with '&&'.
-# 2.  Using `flutter pub global run melos` will make the scripts find melos even if the `pub-cache` is not on the path.
-#     The `exec:` directive isn't found either if the `pub-cache` is not on the path, which is why we only use the `run:`
-#     directive here. (This is a hack, but devs need less set up then).
+# 2.  make sure that you have installed the projects dependencies with ./flutter/bin/dart pub get. Otherwise, melos
+#     will fallback to the globally installed version and errors might occur.
 #
 # Cross platform linebreaks:
 # * Can only be used with a `melos exec` command, which must be after directly before the command to be executed. So
@@ -36,33 +35,23 @@ scripts:
     description: "Check format all Dart code"
 
   analyze:
-    run: >-
-      flutter pub global run melos exec \
-      flutter analyze
+    exec: dart analyze
     description: "Analyze all Dart code"
 
   analyze-check:
-    run: >-
-      flutter pub global run melos exec \
-      flutter analyze --fatal-warnings
+    exec: dart analyze --fatal-warnings
     description: "Analyze all Dart code and exit if there are any fatal warnings"
 
   flutter-clean:
-    run: >-
-      flutter pub global run melos exec \
-      flutter clean
+    exec: flutter clean
     description: "Clean pub dependencies"
 
   pub-get:
-    run: >-
-      flutter pub global run melos exec \
-      flutter pub get
+    exec: flutter pub get
     description: "Get pub dependencies"
 
   unit-test:
-    run: >-
-      flutter pub global run melos exec \
-      flutter test
+    exec: flutter test
     description: "Run unit tests (all packages)"
 
   doctor:
@@ -71,7 +60,7 @@ scripts:
 
   run-build-runner:
     run: >-
-      flutter pub global run melos exec --depends-on="build_runner" -- \
+      dart run melos exec --depends-on="build_runner" -- \
       flutter pub run build_runner build --delete-conflicting-outputs
     description: "Generate code with build_runner"
 
@@ -89,19 +78,19 @@ scripts:
   # Unit test Encointer Wallet with tag
   unit-test-app-exclude-encointer-node-e2e:
     run: >-
-      flutter pub global run melos exec --scope="encointer_wallet" -- \
+      dart run melos exec --scope="encointer_wallet" -- \
       flutter test --exclude-tags encointer-node-e2e
     description: "Run unit tests excluding the `encointer-node-e2e` tag"
 
   unit-test-app-with-encointer-node-e2e:
     run: >-
-      flutter pub global run melos exec --scope="encointer_wallet" -- \
+      dart run melos exec --scope="encointer_wallet" -- \
       flutter test --tags encointer-node-e2e
     description: "Run unit tests with the `encointer-node-e2e` tag"
 
   unit-test-packages:
     run: >-
-      flutter pub global run melos exec --ignore="encointer_wallet" -- \
+      dart run melos exec --ignore="encointer_wallet" -- \
       flutter test
     description: "Run unit tests with the `encointer-node-e2e` tag"
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: ccbb6ecd8bb3f08ae8f9ce22920d816bff325a98940c845eda0257cd395503ac
+      sha256: a45e54b72cc2444b46be9d32a590119b9ba8c4e87117f2743a73ec049542f2d3
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   meta:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: pub_updater
-      sha256: "42890302ab2672adf567dc2b20e55b4ecc29d7e19c63b6b98143ab68dd717d3a"
+      sha256: "05ae70703e06f7fdeb05f7f02dd680b8aad810e87c756a618f33e1794635115c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.3.0"
   pubspec:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   flutter: "3.13.0"
 
 dev_dependencies:
-  melos: ^3.2.0
+  melos: 3.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   flutter: "3.13.0"
 
 dev_dependencies:
-  melos: 3.1.0
+  melos: ^3.2.0

--- a/scripts/android_integration_test.sh
+++ b/scripts/android_integration_test.sh
@@ -14,8 +14,8 @@ then
   echo "Recording process up with pid: ${RECORDING_PID}"
 fi
 
-./flutterw pub global run melos integration-scan-test-android
-./flutterw pub global run melos integration-app-test-android-screenshot
+.flutter/bin/dart run melos integration-scan-test-android
+.flutter/bin/dart run melos integration-app-test-android-screenshot
 
 mkdir -p "$TEMP_DIR"
 

--- a/scripts/install_melos.sh
+++ b/scripts/install_melos.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -euxo pipefail
-
-./flutterw pub global activate melos 3.1.0

--- a/scripts/ios_integration_test.sh
+++ b/scripts/ios_integration_test.sh
@@ -12,8 +12,8 @@ then
   echo "Recording process up with pid: ${RECORDING_PID}"
 fi
 
-./flutterw pub global run melos integration-scan-test-ios
-./flutterw pub global run melos integration-app-test-ios-screenshot
+.flutter/bin/dart run melos integration-scan-test-ios
+.flutter/bin/dart run melos integration-app-test-ios-screenshot
 
 mkdir -p "$TEMP_DIR"
 

--- a/scripts/multi_language_screenshot_ci_test.sh
+++ b/scripts/multi_language_screenshot_ci_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-./flutterw pub global run melos integration-scan-test-ios
-./flutterw pub global run melos integration-app-test-ios-screenshot-multi-language
+.flutter/bin/dart run melos integration-scan-test-ios
+.flutter/bin/dart run melos integration-app-test-ios-screenshot-multi-language


### PR DESCRIPTION
I had some issues on my machine with melos. When I debugged I noticed, that we can improve our setup by using the projects melos all the time instead of the globally installed one.

Benefits:
* Ensure that we have the same melos version on different machines
* Simplify commands and remove hacks

Note: Make sure to install the project dependencies once with pub get to ensure that you use the project's melos instead of the global one.