### PR TITLE
fix: reconnecting websocket checks connection state on each request

### DIFF
--- a/app/lib/service/substrate_api/api.dart
+++ b/app/lib/service/substrate_api/api.dart
@@ -242,8 +242,13 @@ class Api {
 }
 
 class ReconnectingWsProvider extends Provider {
-  ReconnectingWsProvider(Uri url, {bool autoConnect = true}) : provider = WsProvider(url, autoConnect: autoConnect);
+  ReconnectingWsProvider(this.url, {bool autoConnect = true})
+      : provider = WsProvider(
+          url,
+          autoConnect: autoConnect,
+        );
 
+  final Uri url;
   WsProvider provider;
 
   Future<void> connectToNewEndpoint(Uri url) async {
@@ -256,13 +261,19 @@ class ReconnectingWsProvider extends Provider {
     if (isConnected()) {
       return Future.value();
     } else {
+      // We want to use a new channel even if the channel exists but it was closed.
+      provider.channel = null;
+      provider = WsProvider(url, autoConnect: false);
       return provider.connect();
     }
   }
 
   @override
   Future disconnect() {
-    if (!isConnected()) {
+    // We only care if the channel is not equal to null.
+    // Because we still want the internal cleanup if
+    // the connection was closed from the other end.
+    if (provider.channel != null) {
       return Future.value();
     } else {
       return provider.disconnect();
@@ -271,7 +282,10 @@ class ReconnectingWsProvider extends Provider {
 
   @override
   bool isConnected() {
-    return provider.isConnected();
+    // the `provider.isConnected()` check is wrong upstream.
+    // Hence, we implement it ourselves.
+    final channel = provider.channel;
+    return channel != null && channel.closeCode == null;
   }
 
   @override

--- a/app/lib/service/substrate_api/api.dart
+++ b/app/lib/service/substrate_api/api.dart
@@ -256,7 +256,7 @@ class ReconnectingWsProvider extends Provider {
     if (isConnected()) {
       return Future.value();
     } else {
-      return connect();
+      return provider.connect();
     }
   }
 
@@ -265,7 +265,7 @@ class ReconnectingWsProvider extends Provider {
     if (!isConnected()) {
       return Future.value();
     } else {
-      return disconnect();
+      return provider.disconnect();
     }
   }
 
@@ -275,7 +275,9 @@ class ReconnectingWsProvider extends Provider {
   }
 
   @override
-  Future<RpcResponse> send(String method, List<dynamic> params) {
+  Future<RpcResponse> send(String method, List<dynamic> params) async {
+    // Connect if disconnected
+    await connect();
     return provider.send(method, params);
   }
 
@@ -284,7 +286,9 @@ class ReconnectingWsProvider extends Provider {
     String method,
     List<dynamic> params, {
     FutureOr<void> Function(String subscription)? onCancel,
-  }) {
+  }) async {
+    // Connect if disconnected
+    await connect();
     return provider.subscribe(method, params, onCancel: onCancel);
   }
 }

--- a/app/lib/service/substrate_api/api.dart
+++ b/app/lib/service/substrate_api/api.dart
@@ -273,7 +273,7 @@ class ReconnectingWsProvider extends Provider {
     // We only care if the channel is not equal to null.
     // Because we still want the internal cleanup if
     // the connection was closed from the other end.
-    if (provider.channel != null) {
+    if (provider.channel == null) {
       return Future.value();
     } else {
       return provider.disconnect();


### PR DESCRIPTION
In #1529, when we started sending txs with dart, I implemented all the fundamentals to try to reconnect upon each request if we are disconnected, but I forgot to actually call that check in the `send` and `subscription` methods. This should make our send process much more stable.

It is difficult to say, as I don't have the exact logs, but I think it closes #1546.