### PR TITLE
Bump polkadart and remove hack for wrongly generated storage key

### DIFF
--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:convert/convert.dart' show hex;
-
 import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/mocks/mock_bazaar_data.dart';
 import 'package:encointer_wallet/models/bazaar/account_business_tuple.dart';
@@ -33,7 +31,6 @@ import 'package:ew_substrate_fixed/substrate_fixed.dart';
 // disambiguate global imports of encointer types. We can remove this
 // once we got rid of our manual type definitions.
 import 'package:ew_polkadart/encointer_types.dart' as et;
-import 'package:flutter/foundation.dart';
 
 /// Api to interface with the `js_encointer_service.js`
 ///
@@ -508,17 +505,13 @@ class EncointerApi {
     if (cid == null) return 0;
 
     try {
-      final burned = await encointerKusama.query.encointerCeremonies.burnedBootstrapperNewbieTickets(
-        et.CommunityIdentifier(geohash: cid.geohash, digest: cid.digest),
-        AddressUtils.addressToPubKey(address).toList(),
-      );
-
-      // Nasty hack because of https://github.com/leonardocustodio/polkadart/issues/373
-      final ticketsPerBootstrapperKey =
-          Uint8List.fromList(hex.decode('a7d291a8132b2cc65c41da45f4de76795c03954ec993845da1c7ff36c91390da'));
-      final ticketsPerBootstrapperBytes = await encointerKusama.rpc.state.getStorage(ticketsPerBootstrapperKey);
-      final ticketsPerBootstrapper =
-          ticketsPerBootstrapperBytes != null ? U8Codec.codec.decode(ByteInput(ticketsPerBootstrapperBytes)) : 0;
+      final [burned, ticketsPerBootstrapper] = await Future.wait([
+        encointerKusama.query.encointerCeremonies.burnedBootstrapperNewbieTickets(
+          et.CommunityIdentifier(geohash: cid.geohash, digest: cid.digest),
+          AddressUtils.addressToPubKey(address).toList(),
+        ),
+        encointerKusama.query.encointerCeremonies.endorsementTicketsPerBootstrapper(),
+      ]);
 
       Log.p('NewbieTickets: ticketsPerBootstrapper: $ticketsPerBootstrapper, burned: $burned');
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -729,6 +729,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  hashlib_codecs:
+    dependency: transitive
+    description:
+      name: hashlib_codecs
+      sha256: "49e2a471f74b15f1854263e58c2ac11f2b631b5b12c836f9708a35397d36d626"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   html:
     dependency: transitive
     description:
@@ -1294,16 +1302,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.2.3"
+    version: "0.2.4"
   polkadart_keyring:
     dependency: transitive
     description:
       path: "packages/polkadart_keyring"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.2.1"
@@ -1312,7 +1320,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -1686,7 +1694,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -2046,10 +2054,10 @@ packages:
     dependency: transitive
     description:
       name: yaon
-      sha256: e4553813814a6cd5ed7d240d508d3fb1ba4942bc69ac39df4317f7524d41737c
+      sha256: fb0dd1654f203e52ef1631ba81a04c7762ddfd72d7bc58a178462d8b84258fd4
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2+6"
+    version: "1.1.4"
 sdks:
   dart: ">=3.1.0 <4.0.0"
   flutter: ">=3.13.8"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1309,16 +1309,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.2.4"
+    version: "0.2.5"
   polkadart_keyring:
     dependency: transitive
     description:
       path: "packages/polkadart_keyring"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.2.1"
@@ -1327,7 +1327,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -1701,7 +1701,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_keyring/pubspec.lock
+++ b/packages/ew_keyring/pubspec.lock
@@ -374,7 +374,7 @@ packages:
     description:
       path: "packages/polkadart_keyring"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.2.1"
@@ -383,7 +383,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_keyring/pubspec.lock
+++ b/packages/ew_keyring/pubspec.lock
@@ -374,7 +374,7 @@ packages:
     description:
       path: "packages/polkadart_keyring"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.2.1"
@@ -383,7 +383,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_polkadart/pubspec.lock
+++ b/packages/ew_polkadart/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: b2151ce26a06171005b379ecff6e08d34c470180ffe16b8e14b6d52be292b55f
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   collection:
     dependency: transitive
     description:
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  hashlib_codecs:
+    dependency: transitive
+    description:
+      name: hashlib_codecs
+      sha256: "49e2a471f74b15f1854263e58c2ac11f2b631b5b12c836f9708a35397d36d626"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   http:
     dependency: transitive
     description:
@@ -286,25 +294,25 @@ packages:
     description:
       path: "packages/polkadart"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.2.3"
+    version: "0.2.4"
   polkadart_cli:
     dependency: "direct dev"
     description:
       path: "packages/polkadart_cli"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.2.2"
+    version: "0.2.3"
   polkadart_scale_codec:
     dependency: "direct main"
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -441,7 +449,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: main
-      resolved-ref: "0295b130ae5f6542d58f3f8e1945f3042591139f"
+      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_polkadart/pubspec.lock
+++ b/packages/ew_polkadart/pubspec.lock
@@ -294,16 +294,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.2.4"
+    version: "0.2.5"
   polkadart_cli:
     dependency: "direct dev"
     description:
       path: "packages/polkadart_cli"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.2.3"
@@ -312,7 +312,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -449,7 +449,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: main
-      resolved-ref: "7dec311cd4ccd9933219790e32db187a1f1c6ac4"
+      resolved-ref: "6a0f9223e43d8f89c2a2c29618741492563b21bd"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"


### PR DESCRIPTION
They fixed the storage hash generation upstream: https://github.com/leonardocustodio/polkadart/pull/375