### PR TITLE
fix app startup: remove broken chain store cache

### DIFF
--- a/app/lib/service/substrate_api/chain_api.dart
+++ b/app/lib/service/substrate_api/chain_api.dart
@@ -36,7 +36,7 @@ class ChainApi {
 
     _latestHeaderSubscription = subscription.stream.map((res) {
       Log.p('Header: ${res.result}');
-      return Header.fromJson(res.result as Map<String, dynamic>);
+      return Header.fromRpc(res.result as Map<String, dynamic>);
     }).listen((header) {
       Log.p('[subscribeNewHeads] Got header: ${header.toJson()}');
       store.chain.setLatestHeader(header);

--- a/app/lib/store/chain/types/header.dart
+++ b/app/lib/store/chain/types/header.dart
@@ -2,8 +2,13 @@
 class Header {
   Header(this.hash, this.number);
 
-  factory Header.fromJson(Map<String, dynamic> json) {
+  /// Parse into header when retrieved from polkadart RPC.
+  factory Header.fromRpc(Map<String, dynamic> json) {
     return Header(json['hash'] as String?, BigInt.parse(json['number'] as String).toInt());
+  }
+
+  factory Header.fromJson(Map<String, dynamic> json) {
+    return Header(json['hash'] as String?, json['number'] as int?);
   }
 
   Map<String, dynamic> toJson() => <String, dynamic>{'hash': hash, 'number': number};


### PR DESCRIPTION
https://github.com/encointer/encointer-wallet-flutter/pull/1570 has introduced a change in the de-serialization of the `latestHeader`, which fails when the latest header is read from cache. As this is used upon app-startup, the app couldn't start anymore.

The bug was introduced by this change: https://github.com/encointer/encointer-wallet-flutter/pull/1570/files#r1410622103