### PR TITLE
Fix potential `NoReputation` error in faucet.

### DIFF
--- a/app/lib/models/ceremonies/ceremonies.dart
+++ b/app/lib/models/ceremonies/ceremonies.dart
@@ -145,6 +145,10 @@ extension ReputationExtension on Reputation {
   String toValue() {
     return toEnumValue(this);
   }
+
+  bool isVerified() {
+    return this == Reputation.VerifiedUnlinked || this == Reputation.VerifiedLinked;
+  }
 }
 
 extension ParticipantTypeExtension on ParticipantType {

--- a/app/lib/page/profile/account/faucet_list_tile.dart
+++ b/app/lib/page/profile/account/faucet_list_tile.dart
@@ -100,7 +100,7 @@ class _FaucetListTileState extends State<FaucetListTile> {
   /// Returns all reputation ids, which haven't been committed for this faucet's
   /// purpose id yet, i.e., can be used to drip the faucet currently.
   Future<Map<int, CommunityIdentifier>> _getUncommittedReputationIds(String address) async {
-    final reputations = widget.store.encointer.accountStores![address]!.reputations;
+    final reputations = widget.store.encointer.accountStores![address]!.verifiedReputations;
     final ids = Map<int, CommunityIdentifier>.of({});
 
     // Create a set of futures to await in parallel.

--- a/app/lib/page/profile/contacts/contact_detail_page.dart
+++ b/app/lib/page/profile/contacts/contact_detail_page.dart
@@ -225,7 +225,7 @@ class EndorseButton extends StatelessWidget {
               : const SizedBox();
         }),
         Observer(builder: (_) {
-          return store.encointer.account != null && store.encointer.account!.reputations.isNotEmpty
+          return store.encointer.account != null && store.encointer.account!.verifiedReputations.isNotEmpty
               ? FittedBox(
                   child: Row(children: [
                     Text(l10n.remainingNewbieTicketsAsReputable),
@@ -261,7 +261,7 @@ class EndorseButton extends StatelessWidget {
   }
 
   bool hasNewbieTickets() {
-    if (store.encointer.account!.reputations.isNotEmpty &&
+    if (store.encointer.account!.verifiedReputations.isNotEmpty &&
         store.encointer.account!.numberOfNewbieTicketsForReputable > 0) {
       return true;
     }

--- a/app/lib/page/profile/index.dart
+++ b/app/lib/page/profile/index.dart
@@ -164,7 +164,7 @@ class _ProfileState extends State<Profile> {
               ListTile(
                 title: Text(l10n.reputationOverall, style: h3Grey),
                 // Account can be null after switching networks.
-                trailing: Text('${store.encointer.account?.reputationCount.toString() ?? 0}'),
+                trailing: Text('${store.encointer.account?.verifiedReputationCount.toString() ?? 0}'),
               ),
               ListTile(
                 title: Text(l10n.about,

--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -599,7 +599,7 @@ class EncointerApi {
       return Future.value();
     }
 
-    final cid = store.encointer.account?.reputations[cIndex]?.communityIdentifier;
+    final cid = store.encointer.account?.verifiedReputations[cIndex]?.communityIdentifier;
     Log.d('getProofOfAttendance: cachedPin: $pin', 'EncointerApi');
     final proof = await jsApi
         .evalJavascript<Map<String, dynamic>>(
@@ -612,7 +612,7 @@ class EncointerApi {
 
   Future<int> getNumberOfNewbieTicketsForReputable({BlockHash? at}) async {
     final address = store.account.currentAddress;
-    final reputations = store.encointer.account?.reputations ?? {};
+    final reputations = store.encointer.account?.verifiedReputations ?? {};
     final cid = store.encointer.chosenCid;
     final cIndex = store.encointer.currentCeremonyIndex;
 

--- a/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
+++ b/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
@@ -59,6 +59,7 @@ abstract class _EncointerAccountStore with Store {
   @observable
   Map<int, CommunityReputation> reputations = {};
 
+  /// Returns all reputations associated with a meetup.
   @computed
   Map<int, CommunityReputation> get verifiedReputations {
     final entries = reputations.entries.where((e) => e.value.reputation.isVerified());
@@ -77,9 +78,9 @@ abstract class _EncointerAccountStore with Store {
 
   @computed
   int? get ceremonyIndexForNextProofOfAttendance {
-    if (reputations.isNotEmpty) {
+    if (verifiedReputations.isNotEmpty) {
       try {
-        return reputations.entries.firstWhere((e) => e.value.reputation == Reputation.VerifiedUnlinked).key;
+        return verifiedReputations.entries.firstWhere((e) => e.value.reputation == Reputation.VerifiedUnlinked).key;
       } catch (e, s) {
         Log.e('$address has reputation, but none that has not been linked yet', 'EncointerAccountStore', s);
         return 0;

--- a/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
+++ b/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
@@ -52,17 +52,22 @@ abstract class _EncointerAccountStore with Store {
 
   /// `CommunityReputations` across all communities keyed by the respective ceremony index.
   ///
+  /// Normally, we are more interested in the computed [verifiedReputations], as this map may
+  /// contain all potential reputation values: UnverifiedReputable, VerifiedUnlinked and VerifiedLinked.
+  ///
   /// Map: ceremony index -> CommunityReputation
   @observable
   Map<int, CommunityReputation> reputations = {};
 
+  @computed
+  Map<int, CommunityReputation> get verifiedReputations {
+    final entries = reputations.entries.where((e) => e.value.reputation.isVerified());
+    return Map.fromEntries(entries);
+  }
+
   /// Number of successfully attended meetups in the range of reputation lifetime.
   @computed
-  int get reputationCount {
-    return reputations.values
-        .where((r) => r.reputation == Reputation.VerifiedLinked || r.reputation == Reputation.VerifiedUnlinked)
-        .length;
-  }
+  int get verifiedReputationCount => verifiedReputations.length;
 
   @observable
   ObservableList<TransferData> txsTransfer = ObservableList<TransferData>();

--- a/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.g.dart
+++ b/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.g.dart
@@ -40,11 +40,18 @@ Map<String, dynamic> _$EncointerAccountStoreToJson(EncointerAccountStore instanc
 // ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic, no_leading_underscores_for_local_identifiers
 
 mixin _$EncointerAccountStore on _EncointerAccountStore, Store {
-  Computed<int>? _$reputationCountComputed;
+  Computed<Map<int, CommunityReputation>>? _$verifiedReputationsComputed;
 
   @override
-  int get reputationCount => (_$reputationCountComputed ??=
-          Computed<int>(() => super.reputationCount, name: '_EncointerAccountStore.reputationCount'))
+  Map<int, CommunityReputation> get verifiedReputations =>
+      (_$verifiedReputationsComputed ??= Computed<Map<int, CommunityReputation>>(() => super.verifiedReputations,
+              name: '_EncointerAccountStore.verifiedReputations'))
+          .value;
+  Computed<int>? _$verifiedReputationCountComputed;
+
+  @override
+  int get verifiedReputationCount => (_$verifiedReputationCountComputed ??=
+          Computed<int>(() => super.verifiedReputationCount, name: '_EncointerAccountStore.verifiedReputationCount'))
       .value;
   Computed<int?>? _$ceremonyIndexForNextProofOfAttendanceComputed;
 
@@ -198,7 +205,8 @@ reputations: ${reputations},
 txsTransfer: ${txsTransfer},
 numberOfNewbieTicketsForReputable: ${numberOfNewbieTicketsForReputable},
 lastProofOfAttendance: ${lastProofOfAttendance},
-reputationCount: ${reputationCount},
+verifiedReputations: ${verifiedReputations},
+verifiedReputationCount: ${verifiedReputationCount},
 ceremonyIndexForNextProofOfAttendance: ${ceremonyIndexForNextProofOfAttendance}
     ''';
   }


### PR DESCRIPTION
We tried to drip the faucet with a `UnverifiedReputable` reputation, as we couldn't find reputation commitments for it, and the app considered it to be good enough for dripping the faucet. This PR implements a change such that we only consider verified reputations for claiming the faucet, which is how it should be. Closes #1608.