### PR TITLE
Create accounts in dart instead of JS

### DIFF
--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -15,16 +15,6 @@ import { stringNumberToEncointerBalanceU8a } from '../utils/utils.js';
 
 export const keyring = new Keyring({ ss58Format: 0, type: 'sr25519' });
 
-async function gen () {
-  await cryptoWaitReady();
-  return new Promise((resolve) => {
-    const key = mnemonicGenerate();
-    resolve({
-      mnemonic: key
-    });
-  });
-}
-
 async function recover (keyType, cryptoType, key, password) {
   await cryptoWaitReady();
   return new Promise((resolve, reject) => {
@@ -222,7 +212,6 @@ export async function _getXt (keyPair, txInfo, paramList) {
 export default {
   initKeys,
   addressFromUri,
-  gen,
   recover,
   getBlockTime,
   txFeeEstimate,

--- a/app/lib/modules/account/logic/new_account_result.dart
+++ b/app/lib/modules/account/logic/new_account_result.dart
@@ -1,12 +1,14 @@
+import 'package:ew_keyring/ew_keyring.dart';
+
 class NewAccountResult {
-  const NewAccountResult(this.operationResult, {this.newAccountData});
+  const NewAccountResult(this.operationResult, {this.newAccount});
 
   final NewAccountResultType operationResult;
-  final Map<String, dynamic>? newAccountData;
+  final KeyringAccount? newAccount;
 
-  Map<String, dynamic> get duplicateAccountData {
-    assert(newAccountData != null, 'Error: You need to assign a value to `newAccountData` before accessing it.');
-    return newAccountData!;
+  KeyringAccount get duplicateAccountData {
+    assert(newAccount != null, 'Error: You need to assign a value to `newAccountData` before accessing it.');
+    return newAccount!;
   }
 }
 

--- a/app/lib/modules/account/logic/new_account_store.dart
+++ b/app/lib/modules/account/logic/new_account_store.dart
@@ -65,17 +65,16 @@ abstract class _NewAccountStoreBase with Store {
   Future<NewAccountResult> _generateAccount(BuildContext context, String pin) async {
     try {
       _loading = true;
-      final mnemonic = KeyringUtils.generateMnemonic();
-      final acc = await webApi.account.importAccount(key: mnemonic.sentence, password: pin);
-      if (acc['error'] != null) {
+      final keyringAccount = await KeyringAccount.generate(name!);
+      final result = await webApi.account.importAccount(key: keyringAccount.uri, password: pin);
+      if (result['error'] != null) {
         _loading = false;
         return const NewAccountResult(NewAccountResultType.error);
       }
 
       await context.read<LoginStore>().setPin(pin);
-      acc['address'] =
-          AddressUtils.pubKeyHexToAddress(acc['pubKey'] as String, prefix: appStore.settings.endpoint.ss58!);
-      return saveAccount(acc, pin);
+
+      return saveAccount(keyringAccount, pin);
     } catch (e, s) {
       _loading = false;
       Log.e('generate account', '$e', s);
@@ -88,24 +87,24 @@ abstract class _NewAccountStoreBase with Store {
     try {
       _loading = true;
       assert(accountKey != null && accountKey!.isNotEmpty, 'accountKey can not be null or empty');
-      final acc = await webApi.account.importAccount(
+      final keyringAccount = await KeyringAccount.fromUri(name!, accountKey!);
+      final result = await webApi.account.importAccount(
         key: accountKey!,
         password: pin,
         keyType: keyType.name,
       );
-      if (acc['error'] != null) {
+      if (result['error'] != null) {
         _loading = false;
         return const NewAccountResult(NewAccountResultType.error);
       } else {
         await context.read<LoginStore>().setPin(pin);
-        acc['address'] =
-            AddressUtils.pubKeyHexToAddress(acc['pubKey'] as String, prefix: appStore.settings.endpoint.ss58!);
-        final index = appStore.account.accountList.indexWhere((i) => i.pubKey == acc['pubKey']);
+
+        final index = appStore.account.accountList.indexWhere((i) => i.pubKey == keyringAccount.pubKeyHex);
         if (index > -1) {
           _loading = false;
-          return NewAccountResult(NewAccountResultType.duplicateAccount, newAccountData: acc);
+          return NewAccountResult(NewAccountResultType.duplicateAccount, newAccount: keyringAccount);
         }
-        return saveAccount(acc, pin);
+        return saveAccount(keyringAccount, pin);
       }
     } catch (e, s) {
       _loading = false;
@@ -115,12 +114,12 @@ abstract class _NewAccountStoreBase with Store {
   }
 
   @action
-  Future<NewAccountResult> saveAccount(Map<String, dynamic> acc, String pin) async {
-    await appStore.addAccount(acc, pin, acc['address'] as String, name!);
-    await appStore.setCurrentAccount(acc['pubKey'] as String?);
+  Future<NewAccountResult> saveAccount(KeyringAccount account, String pin) async {
+    await appStore.addAccount(account);
+    await appStore.setCurrentAccount(account.pubKeyHex);
     await appStore.loadAccountCache();
     webApi.fetchAccountData();
     _loading = false;
-    return NewAccountResult(NewAccountResultType.ok, newAccountData: acc);
+    return NewAccountResult(NewAccountResultType.ok, newAccount: account);
   }
 }

--- a/app/lib/modules/account/logic/new_account_store.dart
+++ b/app/lib/modules/account/logic/new_account_store.dart
@@ -65,8 +65,8 @@ abstract class _NewAccountStoreBase with Store {
   Future<NewAccountResult> _generateAccount(BuildContext context, String pin) async {
     try {
       _loading = true;
-      final key = await webApi.account.generateAccount();
-      final acc = await webApi.account.importAccount(key: key, password: pin);
+      final mnemonic = KeyringUtils.generateMnemonic();
+      final acc = await webApi.account.importAccount(key: mnemonic.sentence, password: pin);
       if (acc['error'] != null) {
         _loading = false;
         return const NewAccountResult(NewAccountResultType.error);

--- a/app/lib/modules/account/logic/new_account_store.g.dart
+++ b/app/lib/modules/account/logic/new_account_store.g.dart
@@ -117,8 +117,8 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
   late final _$saveAccountAsyncAction = AsyncAction('_NewAccountStoreBase.saveAccount', context: context);
 
   @override
-  Future<NewAccountResult> saveAccount(Map<String, dynamic> acc, String pin) {
-    return _$saveAccountAsyncAction.run(() => super.saveAccount(acc, pin));
+  Future<NewAccountResult> saveAccount(KeyringAccount account, String pin) {
+    return _$saveAccountAsyncAction.run(() => super.saveAccount(account, pin));
   }
 
   late final _$_NewAccountStoreBaseActionController = ActionController(name: '_NewAccountStoreBase', context: context);

--- a/app/lib/modules/account/view/import_account_view.dart
+++ b/app/lib/modules/account/view/import_account_view.dart
@@ -16,7 +16,7 @@ import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/input_validation.dart';
 import 'package:encointer_wallet/l10n/l10.dart';
 import 'package:encointer_wallet/modules/account/logic/key_type.dart';
-import 'package:ew_keyring/ew_keyring.dart' show ValidateKeys;
+import 'package:ew_keyring/ew_keyring.dart' show KeyringAccount, ValidateKeys;
 
 class ImportAccountView extends StatelessWidget {
   const ImportAccountView({super.key});
@@ -144,11 +144,13 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
     );
   }
 
-  Future<void> _onDuplicateAccount(BuildContext context, Map<String, dynamic> acc) async {
+  Future<void> _onDuplicateAccount(BuildContext context, KeyringAccount acc) async {
     final l10n = context.l10n;
+    final store = context.read<AppStore>();
+
     await AppAlert.showDialog<void>(
       context,
-      title: Text(Fmt.address(acc['address'] as String)!),
+      title: Text(Fmt.address(acc.address(prefix: store.settings.endpoint.ss58 ?? 42).encode())!),
       content: Text(l10n.importDuplicate),
       actions: [
         CupertinoButton(

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -88,11 +88,6 @@ class AccountApi {
     return jsApi.evalJavascript<Map<String, dynamic>>(call);
   }
 
-  Future<String> generateAccount() async {
-    final acc = await jsApi.evalJavascript<Map<String, dynamic>>('account.gen()');
-    return acc['mnemonic'] as String;
-  }
-
   Future<Map<String, dynamic>> importAccount({
     required String key,
     required String password,

--- a/app/lib/store/account/account.dart
+++ b/app/lib/store/account/account.dart
@@ -178,10 +178,8 @@ abstract class _AccountStore with Store {
 
   /// Adds a new account, will overwrite the account data if they same seed already exists.
   @action
-  Future<void> addAccount(Map<String, dynamic> acc, String password, {required String name}) async {
-    final uri = getUriFromMeta(acc);
-    final account = await KeyringAccount.fromUri(name, uri);
-    Log.d('[AddAccount]: added account ${account.toAccountData()}');
+  Future<void> addAccount(KeyringAccount account) async {
+    Log.d('[AddAccount]: adding account ${account.toAccountData()}');
 
     keyring.addAccount(account);
     await storeAccountData();

--- a/app/lib/store/account/account.g.dart
+++ b/app/lib/store/account/account.g.dart
@@ -147,8 +147,8 @@ mixin _$AccountStore on _AccountStore, Store {
   late final _$addAccountAsyncAction = AsyncAction('_AccountStore.addAccount', context: context);
 
   @override
-  Future<void> addAccount(Map<String, dynamic> acc, String password, {required String name}) {
-    return _$addAccountAsyncAction.run(() => super.addAccount(acc, password, name: name));
+  Future<void> addAccount(KeyringAccount account) {
+    return _$addAccountAsyncAction.run(() => super.addAccount(account));
   }
 
   late final _$removeAccountAsyncAction = AsyncAction('_AccountStore.removeAccount', context: context);

--- a/app/lib/store/app.dart
+++ b/app/lib/store/app.dart
@@ -207,8 +207,8 @@ abstract class _AppStore<S extends SecureStorageInterface, L extends LegacyStora
     }
   }
 
-  Future<void> addAccount(Map<String, dynamic> acc, String password, String? address, String name) {
-    return account.addAccount(acc, password, name: name);
+  Future<void> addAccount(KeyringAccount acc) {
+    return account.addAccount(acc);
   }
 
   Future<void> setCurrentAccount(String? pubKey) async {

--- a/app/test/store/account_test.dart
+++ b/app/test/store/account_test.dart
@@ -1,4 +1,5 @@
 import 'package:encointer_wallet/store/account/services/legacy_storage.dart';
+import 'package:ew_keyring/ew_keyring.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:encointer_wallet/store/app.dart';
@@ -17,8 +18,9 @@ void main() {
       final store = root.account;
 
       /// add account
-      const testPass = 'a111111';
-      await store.addAccount(testAccount1, testPass, name: testAccount1['name'] as String);
+      final keyringAccount1 =
+          await KeyringAccount.fromUri(testAccount1['name'] as String, testAccount1['mnemonic'] as String);
+      await store.addAccount(keyringAccount1);
       expect(store.accountList.length, 1);
       await store.setCurrentAccount(testAccount1['pubKey'] as String);
       expect(store.currentAccountPubKey, testAccount1['pubKey']);
@@ -26,7 +28,9 @@ void main() {
       expect(store.currentAccount.pubKey, testAccount1['pubKey']);
       expect(store.currentAccount.address, testAccount1['address']);
 
-      await store.addAccount(testAccount2, testPass, name: testAccount2['name'] as String);
+      final keyringAccount2 =
+          await KeyringAccount.fromUri(testAccount2['name'] as String, testAccount2['mnemonic'] as String);
+      await store.addAccount(keyringAccount2);
       expect(store.accountList.length, 2);
       await store.setCurrentAccount(testAccount2['pubKey'] as String);
       expect(store.currentAccountPubKey, testAccount2['pubKey']);

--- a/packages/ew_keyring/lib/src/keyring.dart
+++ b/packages/ew_keyring/lib/src/keyring.dart
@@ -1,6 +1,5 @@
 import 'package:convert/convert.dart';
-import 'package:ew_keyring/ew_keyring.dart' show KeyringUtils, KeyringAccount, KeyringAccountData;
-import 'package:ew_keyring/src/address_utils.dart';
+import 'package:ew_keyring/ew_keyring.dart' show AddressUtils, KeyringAccount, KeyringAccountData, KeyringUtils;
 import 'package:polkadart_keyring/polkadart_keyring.dart';
 
 /// The public key (as a list of integers).

--- a/packages/ew_keyring/lib/src/keyring_account.dart
+++ b/packages/ew_keyring/lib/src/keyring_account.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:convert/convert.dart';
-import 'package:ew_keyring/src/address_utils.dart';
+import 'package:ew_keyring/ew_keyring.dart';
 import 'package:ew_keyring/src/validate_keys.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:polkadart_keyring/polkadart_keyring.dart';
@@ -40,6 +40,10 @@ class KeyringAccount {
   static Future<KeyringAccount> fromUri(String name, String uri) async {
     final pair = await Sr25519KeyPair().fromUri(uri) as Sr25519KeyPair;
     return KeyringAccount._(name: name, uri: uri, pair: pair);
+  }
+
+  static Future<KeyringAccount> generate(String name) {
+    return KeyringAccount.fromUri(name, KeyringUtils.generateMnemonic().sentence);
   }
 
   String name;

--- a/packages/ew_keyring/lib/src/keyring_utils.dart
+++ b/packages/ew_keyring/lib/src/keyring_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:ew_keyring/ew_keyring.dart';
+import 'package:substrate_bip39/substrate_bip39.dart';
 
 abstract class KeyringUtils {
   static String serializeAccountData(List<KeyringAccountData> accounts) => jsonEncode(accounts);
@@ -8,5 +9,9 @@ abstract class KeyringUtils {
   static List<KeyringAccountData> deserializeAccountData(String accounts) {
     final list = jsonDecode(accounts) as List<dynamic>;
     return List<KeyringAccountData>.of(list.map((a) => KeyringAccountData.fromJson(a as Map<String, dynamic>)));
+  }
+
+  static Mnemonic generateMnemonic({int entropyLength = 128}) {
+    return Mnemonic.generate(Language.english, entropyLength: entropyLength);
   }
 }


### PR DESCRIPTION
Most account handling is already in dart since #1614, but we have still been creating them in JS, and then we extracted the seeds. Now we also create them in dart, and then import them into JS, where they are still used to sign extrinsics.

* Closes #1520
* Closes #1480
* Closes #606
* Closes #478, but only because it will be detected later, while sending extrinsics, that the webView has not been instantiated successfully.