### PR TITLE
[ReapVoucher] Minor refactoring and move reap voucher prechecks from JS to dart

### DIFF
--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -60,32 +60,6 @@ async function initKeys (accounts) {
   accounts.forEach((i) => keyring.addFromJson(i));
 }
 
-function getBlockTime (blocks) {
-  return new Promise((resolve) => {
-    const res = [];
-    Promise.all(
-      blocks.map((i) => {
-        res[res.length] = { id: i };
-        return api.rpc.chain.getBlockHash(i);
-      })
-    )
-      .then((hashs) =>
-        Promise.all(
-          hashs.map((i, index) => {
-            res[index].hash = i.toHex();
-            return api.query.timestamp.now.at(i.toHex());
-          })
-        )
-      )
-      .then((times) => {
-        times.forEach((i, index) => {
-          res[index].timestamp = i.toNumber();
-        });
-        resolve(JSON.stringify(res));
-      });
-  });
-}
-
 export async function txFeeEstimate (txInfo, paramList) {
   if (txInfo.module === 'encointerBalances' && txInfo.call === 'transfer') {
     paramList[1] = communityIdentifierFromString(api.registry, paramList[1]);
@@ -201,7 +175,6 @@ export async function _getXt (keyPair, txInfo, paramList) {
 export default {
   initKeys,
   recover,
-  getBlockTime,
   txFeeEstimate,
   sendTx,
   sendTxWithPair,

--- a/app/js_service_encointer/src/service/account.js
+++ b/app/js_service_encointer/src/service/account.js
@@ -60,17 +60,6 @@ async function initKeys (accounts) {
   accounts.forEach((i) => keyring.addFromJson(i));
 }
 
-async function addressFromUri(uri) {
-  const voucherPair = keyring.createFromUri(uri);
-  const pubKey = voucherPair.publicKey;
-  const ss58 = api.registry.getChainProperties().ss58Format
-
-  console.log(`[AddressFromUri] uri: ${uri}`);
-  console.log(`[AddressFromUri] ss58: ${ss58}`);
-
-  return keyring.encodeAddress(pubKey, ss58);
-}
-
 function getBlockTime (blocks) {
   return new Promise((resolve) => {
     const res = [];
@@ -211,7 +200,6 @@ export async function _getXt (keyPair, txInfo, paramList) {
 
 export default {
   initKeys,
-  addressFromUri,
   recover,
   getBlockTime,
   txFeeEstimate,

--- a/app/js_service_encointer/src/service/chain.js
+++ b/app/js_service_encointer/src/service/chain.js
@@ -1,9 +1,0 @@
-
-export async function getFinalizedHeader () {
-  const hash = await api.rpc.chain.getFinalizedHead();
-  return api.rpc.chain.getHeader(hash);
-}
-
-export default {
-  getFinalizedHeader,
-};

--- a/app/js_service_encointer/src/service/encointer.js
+++ b/app/js_service_encointer/src/service/encointer.js
@@ -5,6 +5,15 @@ import { keyring, sendTxWithPair } from './account.js';
 import { communityIdentifierToString } from '@encointer/util';
 import { submitAndWatchTx } from '@encointer/node-api';
 import { Keyring } from '@polkadot/keyring';
+import { parseEncointerBalance } from '@encointer/types';
+
+export async function getBalance (cid, address) {
+  const balanceEntry = await api.query.encointerBalances.balance(cid, address);
+  return {
+    principal: parseEncointerBalance(balanceEntry.principal.bits),
+    lastUpdate: balanceEntry.lastUpdate.toNumber()
+  };
+}
 
 /***
  * Reaps the voucher and transfers all funds to `recipientAddress`
@@ -117,6 +126,7 @@ export async function sendNextPhaseTx() {
 
 export default {
   getProofOfAttendance,
+  getBalance,
   sendNextPhaseTx,
   reapVoucher,
 };

--- a/app/js_service_encointer/src/service/encointer.js
+++ b/app/js_service_encointer/src/service/encointer.js
@@ -1,21 +1,10 @@
 import { assert, hexToU8a } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { createType } from '@polkadot/types';
-import { parseEncointerBalance } from '@encointer/types';
 import { keyring, sendTxWithPair } from './account.js';
 import { communityIdentifierToString } from '@encointer/util';
-import {
-  getDemurrage as _getDemurrage, submitAndWatchTx,
-} from '@encointer/node-api';
+import { submitAndWatchTx } from '@encointer/node-api';
 import { Keyring } from '@polkadot/keyring';
-
-export async function getBalance (cid, address) {
-  const balanceEntry = await api.query.encointerBalances.balance(cid, address);
-  return {
-    principal: parseEncointerBalance(balanceEntry.principal.bits),
-    lastUpdate: balanceEntry.lastUpdate.toNumber()
-  };
-}
 
 /***
  * Reaps the voucher and transfers all funds to `recipientAddress`
@@ -54,12 +43,6 @@ export function encointerTransferAll (fromPair, recipientAddress, cid) {
   };
 
   return sendTxWithPair(fromPair, txInfo, paramList);
-}
-
-export async function getDemurrage (cid) {
-  const cidT = api.createType('CommunityIdentifier', cid);
-
-  return _getDemurrage(api, cidT).then((demBits) => parseEncointerBalance(demBits));
 }
 
 /**
@@ -134,7 +117,6 @@ export async function sendNextPhaseTx() {
 
 export default {
   getProofOfAttendance,
-  getBalance,
   sendNextPhaseTx,
   reapVoucher,
 };

--- a/app/js_service_encointer/src/utils/utils.js
+++ b/app/js_service_encointer/src/utils/utils.js
@@ -1,12 +1,6 @@
 import { bnToU8a } from '@polkadot/util';
 import { stringToEncointerBalance } from '@encointer/types';
 
-export function applyDemurrage (balanceEntry, latestBlockNumber, demurrageRate) {
-  const elapsed = latestBlockNumber - balanceEntry.lastUpdate;
-  const exponent = -demurrageRate * elapsed;
-  return balanceEntry.principal * Math.pow(Math.E, exponent);
-}
-
 /**
  * Encodes a string representing a decimal number to a scale encoded U8a array that
  * can be put as is into an extrinsic.

--- a/app/lib/l10n/arb/app_de.arb
+++ b/app/lib/l10n/arb/app_de.arb
@@ -272,6 +272,7 @@
     "votesNotDependableErrorTitle": "Unzureichende Bestätigungen",
     "voucher": "Gutschein",
     "voucherBalance": "Gutscheinwert",
+    "voucherBalanceTooLow": "Der Gutschein hat zu wenig Geld um eingelöst zu werden.",
     "weHopeToSeeYouAtTheNextGathering": "Wir hoffen dich an der nächsten Versammlung wiederzusehen.",
     "wrongPin": "Falscher PIN",
     "wrongPinHint": "Konto konnte nicht entsperrt werden. Bitte überprüfe die eingegebene PIN.",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -272,7 +272,7 @@
     "votesNotDependableErrorTitle": "Votes not dependable",
     "voucher": "Voucher",
     "voucherBalance": "Voucher Balance",
-    "vocherBalanceTooLow": "The voucher has insufficient funds to be redeemed.",
+    "voucherBalanceTooLow": "The voucher has insufficient funds to be redeemed.",
     "weHopeToSeeYouAtTheNextGathering": "We hope to see you at the next gathering.",
     "wrongPin": "Wrong PIN",
     "wrongPinHint": "Failed to unlock account, please check PIN.",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -272,6 +272,7 @@
     "votesNotDependableErrorTitle": "Votes not dependable",
     "voucher": "Voucher",
     "voucherBalance": "Voucher Balance",
+    "vocherBalanceTooLow": "The voucher has insufficient funds to be redeemed.",
     "weHopeToSeeYouAtTheNextGathering": "We hope to see you at the next gathering.",
     "wrongPin": "Wrong PIN",
     "wrongPinHint": "Failed to unlock account, please check PIN.",

--- a/app/lib/l10n/arb/app_fr.arb
+++ b/app/lib/l10n/arb/app_fr.arb
@@ -272,6 +272,7 @@
     "votesNotDependableErrorTitle": "Confirmations insuffisantes",
     "voucher": "Bon d'achat",
     "voucherBalance": "Valeur du bon",
+    "voucherBalanceTooLow": "Le bon a trop peu d'argent pour être utilisé.",
     "weHopeToSeeYouAtTheNextGathering": "Nous espérons te revoir à la prochaine rencontre",
     "wrongPin": "Code NIP erroné",
     "wrongPinHint": "Le compte n'a pas pu être débloqué. Veuillez vérifier le code NIP saisi.",

--- a/app/lib/l10n/arb/app_ru.arb
+++ b/app/lib/l10n/arb/app_ru.arb
@@ -272,6 +272,7 @@
     "votesNotDependableErrorTitle": "Голоса недостоверны",
     "voucher": "Ваучер",
     "voucherBalance": "Баланс ваучера",
+    "voucherBalanceTooLow": "На ваучере слишком мало денег, чтобы его можно было выкупить.",
     "weHopeToSeeYouAtTheNextGathering": "Мы надеемся увидеть Вас на следующей встрече.",
     "wrongPin": "Неправильный PIN-код",
     "wrongPinHint": "Не удалось разблокировать аккаунт, пожалуйста, проверьте PIN-код",

--- a/app/lib/page/reap_voucher/dialogs.dart
+++ b/app/lib/page/reap_voucher/dialogs.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/page/reap_voucher/utils.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
@@ -114,7 +116,7 @@ Future<ChangeResult?> showChangeNetworkAndCommunityDialog(
             child: Text(l10n.ok),
             onPressed: () async {
               final result =
-                  await changeWithLoadingDialog(context, () => changeNetworkAndCommunity(store, api, network, cid));
+                  await changeWithLoadingDialog(context, changeNetworkAndCommunity(store, api, network, cid));
               Navigator.of(context).pop(result);
             },
           ),
@@ -126,19 +128,21 @@ Future<ChangeResult?> showChangeNetworkAndCommunityDialog(
 
 Future<ChangeResult> changeWithLoadingDialog(
   BuildContext context,
-  Future<ChangeResult> Function() changeFn,
+  Future<ChangeResult> changeFnFuture,
 ) async {
-  await showCupertinoDialog<void>(
-    context: context,
-    builder: (BuildContext context) {
-      return CupertinoAlertDialog(
-        title: Text(context.l10n.loading),
-        content: const SizedBox(height: 64, child: CupertinoActivityIndicator()),
-      );
-    },
+  unawaited(
+    showCupertinoDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return CupertinoAlertDialog(
+          title: Text(context.l10n.loading),
+          content: const SizedBox(height: 64, child: CupertinoActivityIndicator()),
+        );
+      },
+    ),
   );
 
-  final result = await changeFn();
+  final result = await changeFnFuture;
 
   // pop loading dialog
   Navigator.of(context).pop();
@@ -171,7 +175,7 @@ Future<ChangeResult?> showChangeCommunityDialog(
           CupertinoButton(
             child: Text(l10n.ok),
             onPressed: () async {
-              final result = await changeWithLoadingDialog(context, () => changeCommunity(store, api, network, cid));
+              final result = await changeWithLoadingDialog(context, changeCommunity(store, api, network, cid));
               Navigator.of(context).pop(result);
             },
           ),

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -61,17 +61,14 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
 
     setState(() {});
 
-      final voucherBalanceEntry = await api.encointer.getEncointerBalance(_voucherAddress!, cid);
-      if (store.chain.latestHeaderNumber != null) {
-        _voucherBalance = voucherBalanceEntry.applyDemurrage(
-          store.chain.latestHeaderNumber!,
-          store.encointer.community!.demurrage!,
-        );
+    final voucherBalanceEntry = await api.encointer.getEncointerBalance(_voucherAddress!, cid);
+    _voucherBalance = voucherBalanceEntry.applyDemurrage(
+      store.chain.latestHeaderNumber!,
+      store.encointer.community!.demurrage!,
+    );
 
-      _isReady = true;
-
-      setState(() {});
-    }
+    _isReady = true;
+    setState(() {});
   }
 
   @override
@@ -86,7 +83,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
         final result = await _changeNetworkAndCommunityIfNeeded(context, voucher.network, voucher.cid);
 
         if (result == ChangeResult.ok) {
-          await fetchVoucherData(widget.api,voucher.voucherUri, voucher.cid);
+          await fetchVoucherData(widget.api, voucher.voucherUri, voucher.cid);
         } else if (result == ChangeResult.invalidNetwork) {
           await showErrorDialog(context, l10n.invalidNetwork);
         } else if (result == ChangeResult.invalidCommunity) {
@@ -158,7 +155,9 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
               ),
             SubmitButton(
               key: const Key(EWTestKeys.submitVoucher),
-              onPressed: _isReady ? (context) => _submitReapVoucher(context, voucher.voucherUri, voucher.cid, recipient) : null,
+              onPressed: _isReady
+                  ? (context) => _submitReapVoucher(context, voucher.voucherUri, voucher.cid, recipient)
+                  : null,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -180,6 +179,8 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
     CommunityIdentifier cid,
     String recipientAddress,
   ) async {
+    if (_voucherBalance! < 0.04) return showRedeemFailedDialog(context, context.l10n.voucherBalanceTooLow);
+
     final res = await submitReapVoucher(widget.api, voucherUri, recipientAddress, cid);
 
     if (res['hash'] == null) {

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -10,7 +10,6 @@ import 'package:encointer_wallet/common/components/gradient_elements.dart';
 import 'package:encointer_wallet/common/components/secondary_button_wide.dart';
 import 'package:encointer_wallet/common/components/submit_button.dart';
 import 'package:encointer_wallet/theme/theme.dart';
-import 'package:encointer_wallet/modules/login/logic/login_store.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/page/assets/transfer/transfer_page.dart';
 import 'package:encointer_wallet/page/qr_scan/qr_codes/index.dart';
@@ -62,15 +61,12 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
 
     setState(() {});
 
-    final pin = await context.read<LoginStore>().getPin(context);
-    if (pin != null) {
       final voucherBalanceEntry = await api.encointer.getEncointerBalance(_voucherAddress!, cid);
       if (store.chain.latestHeaderNumber != null) {
         _voucherBalance = voucherBalanceEntry.applyDemurrage(
           store.chain.latestHeaderNumber!,
           store.encointer.community!.demurrage!,
         );
-      }
 
       _isReady = true;
 

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -179,6 +179,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
     CommunityIdentifier cid,
     String recipientAddress,
   ) async {
+    // Fixme, use proper threshold here: #589
     if (_voucherBalance! < 0.04) return showRedeemFailedDialog(context, context.l10n.voucherBalanceTooLow);
 
     final res = await submitReapVoucher(widget.api, voucherUri, recipientAddress, cid);

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -202,25 +202,20 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
     String networkInfo,
     CommunityIdentifier cid,
   ) async {
-    ChangeResult? result = ChangeResult.ok;
     final store = context.read<AppStore>();
 
     if (store.settings.endpoint.info != networkInfo) {
-      result = await showChangeNetworkAndCommunityDialog(
+      return showChangeNetworkAndCommunityDialog(
         context,
         store,
         widget.api,
         networkInfo,
         cid,
       );
-    }
-
-    if (result != ChangeResult.ok) {
-      return result;
     }
 
     if (store.encointer.chosenCid != cid) {
-      result = await showChangeCommunityDialog(
+      return showChangeCommunityDialog(
         context,
         store,
         widget.api,
@@ -229,7 +224,8 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
       );
     }
 
-    return result;
+    // We are already at the correct network and cid
+    return ChangeResult.ok;
   }
 }
 

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -108,11 +108,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
     final h4Grey = context.bodyLarge.copyWith(color: AppColors.encointerGrey);
 
     final voucher = widget.voucher;
-    final voucherUri = voucher.voucherUri;
-    final cid = voucher.cid;
-    final issuer = voucher.issuer;
     final recipient = store.account.currentAddress;
-    final showFundVoucher = widget.showFundVoucher;
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.voucher)),
@@ -127,7 +123,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
                   : const CupertinoActivityIndicator(),
             ),
             const SizedBox(height: 8),
-            Text(issuer, style: h2Grey),
+            Text(voucher.issuer, style: h2Grey),
             SizedBox(
               height: 80,
               child: _voucherBalance != null
@@ -148,7 +144,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
                 ),
               ),
             ),
-            if (showFundVoucher)
+            if (widget.showFundVoucher)
               Padding(
                 padding: const EdgeInsets.only(bottom: 8),
                 child: SecondaryButtonWide(
@@ -166,7 +162,7 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
               ),
             SubmitButton(
               key: const Key(EWTestKeys.submitVoucher),
-              onPressed: _isReady ? (context) => _submitReapVoucher(context, voucherUri, cid, recipient) : null,
+              onPressed: _isReady ? (context) => _submitReapVoucher(context, voucher.voucherUri, voucher.cid, recipient) : null,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [

--- a/app/lib/page/reap_voucher/reap_voucher_page.dart
+++ b/app/lib/page/reap_voucher/reap_voucher_page.dart
@@ -1,3 +1,4 @@
+import 'package:ew_keyring/ew_keyring.dart';
 import 'package:ew_test_keys/ew_test_keys.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -53,18 +54,20 @@ class _ReapVoucherPageState extends State<ReapVoucherPage> {
 
   Future<void> fetchVoucherData(Api api, String voucherUri, CommunityIdentifier cid) async {
     Log.d('Fetching voucher data...', 'ReapVoucherPage');
+    final store = context.read<AppStore>();
 
-    _voucherAddress = await api.account.addressFromUri(voucherUri);
+    final voucherPair = await KeyringAccount.fromUri('Voucher', voucherUri);
+    _voucherAddress = voucherPair.address(prefix: store.settings.endpoint.ss58 ?? 42).encode();
 
     setState(() {});
 
     final pin = await context.read<LoginStore>().getPin(context);
     if (pin != null) {
       final voucherBalanceEntry = await api.encointer.getEncointerBalance(_voucherAddress!, cid);
-      if (context.read<AppStore>().chain.latestHeaderNumber != null) {
+      if (store.chain.latestHeaderNumber != null) {
         _voucherBalance = voucherBalanceEntry.applyDemurrage(
-          context.read<AppStore>().chain.latestHeaderNumber!,
-          context.read<AppStore>().encointer.community!.demurrage!,
+          store.chain.latestHeaderNumber!,
+          store.encointer.community!.demurrage!,
         );
       }
 

--- a/app/lib/router/app_router.dart
+++ b/app/lib/router/app_router.dart
@@ -97,8 +97,9 @@ class AppRoute {
           settings: settings,
         );
       case ReapVoucherPage.route:
+        final params = settings.arguments! as ReapVoucherParams;
         return CupertinoPageRoute(
-          builder: (_) => ReapVoucherPage(webApi),
+          builder: (_) => ReapVoucherPage(webApi, params.voucher, params.showFundVoucher),
           settings: settings,
           fullscreenDialog: true,
         );

--- a/app/lib/service/substrate_api/account_api.dart
+++ b/app/lib/service/substrate_api/account_api.dart
@@ -33,13 +33,6 @@ class AccountApi {
     this.fetchAccountData = fetchAccountData;
   }
 
-  Future<String> addressFromUri(String uri) async {
-    final address = await jsApi.evalJavascript<String>('account.addressFromUri("$uri")');
-
-    Log.d('addressFromUri: $address', 'AccountApi');
-    return address;
-  }
-
   Future<void> changeCurrentAccount({
     String? pubKey,
     bool fetchData = false,

--- a/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -206,7 +206,6 @@ Future<void> submitFaucetDrip(
   );
 }
 
-// todo: replace this with `encointerBalances.transfer_all`, when we have it in the runtime.
 Future<Map<String, dynamic>> submitReapVoucher(
   Api api,
   String voucherUri,


### PR DESCRIPTION
* Closes #1580, only sending is still done in JS, which will be solved with #1540.

This also fixes a previously unknown issue that changing the network or the cid from the reap voucher page was hanging in an endless loop.