### PR TITLE
Improve PIN handling for creating and importing accounts

### DIFF
--- a/app/lib/modules/account/logic/key_type.dart
+++ b/app/lib/modules/account/logic/key_type.dart
@@ -1,9 +1,0 @@
-enum KeyType {
-  mnemonic('mnemonic'),
-  rawSeed('rawSeed'),
-  keystore('keystore');
-
-  const KeyType(this.key);
-
-  final String key;
-}

--- a/app/lib/modules/account/logic/new_account_result.dart
+++ b/app/lib/modules/account/logic/new_account_result.dart
@@ -12,4 +12,4 @@ class NewAccountResult {
   }
 }
 
-enum NewAccountResultType { ok, error, duplicateAccount, emptyPassword }
+enum NewAccountResultType { ok, error, duplicateAccount }

--- a/app/lib/modules/account/logic/new_account_store.dart
+++ b/app/lib/modules/account/logic/new_account_store.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
 
 import 'package:encointer_wallet/modules/modules.dart';
@@ -7,7 +6,6 @@ import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
 import 'package:ew_keyring/ew_keyring.dart';
-import 'package:provider/provider.dart';
 
 part 'new_account_store.g.dart';
 
@@ -24,9 +22,6 @@ abstract class _NewAccountStoreBase with Store {
   String? name;
 
   @observable
-  String? password;
-
-  @observable
   String? accountKey;
 
   @observable
@@ -39,42 +34,34 @@ abstract class _NewAccountStoreBase with Store {
   void setName(String? value) => name = value;
 
   @action
-  void setPassword(String? value) => password = value;
-
-  @action
   void setKey(String? value) => accountKey = value;
 
   @action
   void setKeyType(KeyType value) => keyType = value;
 
   @action
-  Future<NewAccountResult> generateAccount(BuildContext context) async {
-    final pin = password ?? context.read<LoginStore>().cachedPin;
-    if (pin == null) return const NewAccountResult(NewAccountResultType.emptyPassword);
-    return _generateAccount(context, pin);
+  Future<NewAccountResult> generateAccount() async {
+    return _generateAccount();
   }
 
   @action
-  Future<NewAccountResult> importAccount(BuildContext context) async {
-    final pin = password ?? context.read<LoginStore>().cachedPin;
-    if (pin == null) return const NewAccountResult(NewAccountResultType.emptyPassword);
-    return _importAccount(context, pin);
+  Future<NewAccountResult> importAccount() async {
+    return _importAccount();
   }
 
   @action
-  Future<NewAccountResult> _generateAccount(BuildContext context, String pin) async {
+  Future<NewAccountResult> _generateAccount() async {
     try {
       _loading = true;
       final keyringAccount = await KeyringAccount.generate(name!);
-      final result = await webApi.account.importAccount(key: keyringAccount.uri, password: pin);
+      // pin is ignored on JS-side
+      final result = await webApi.account.importAccount(key: keyringAccount.uri, password: '');
       if (result['error'] != null) {
         _loading = false;
         return const NewAccountResult(NewAccountResultType.error);
       }
 
-      await context.read<LoginStore>().setPin(pin);
-
-      return saveAccount(keyringAccount, pin);
+      return saveAccount(keyringAccount);
     } catch (e, s) {
       _loading = false;
       Log.e('generate account', '$e', s);
@@ -83,28 +70,26 @@ abstract class _NewAccountStoreBase with Store {
   }
 
   @action
-  Future<NewAccountResult> _importAccount(BuildContext context, String pin) async {
+  Future<NewAccountResult> _importAccount() async {
     try {
       _loading = true;
       assert(accountKey != null && accountKey!.isNotEmpty, 'accountKey can not be null or empty');
       final keyringAccount = await KeyringAccount.fromUri(name!, accountKey!);
       final result = await webApi.account.importAccount(
         key: accountKey!,
-        password: pin,
+        password: '', // this is ignored on JS-side
         keyType: keyType.name,
       );
       if (result['error'] != null) {
         _loading = false;
         return const NewAccountResult(NewAccountResultType.error);
       } else {
-        await context.read<LoginStore>().setPin(pin);
-
         final index = appStore.account.accountList.indexWhere((i) => i.pubKey == keyringAccount.pubKeyHex);
         if (index > -1) {
           _loading = false;
           return NewAccountResult(NewAccountResultType.duplicateAccount, newAccount: keyringAccount);
         }
-        return saveAccount(keyringAccount, pin);
+        return saveAccount(keyringAccount);
       }
     } catch (e, s) {
       _loading = false;
@@ -114,7 +99,7 @@ abstract class _NewAccountStoreBase with Store {
   }
 
   @action
-  Future<NewAccountResult> saveAccount(KeyringAccount account, String pin) async {
+  Future<NewAccountResult> saveAccount(KeyringAccount account) async {
     await appStore.addAccount(account);
     await appStore.setCurrentAccount(account.pubKeyHex);
     await appStore.loadAccountCache();

--- a/app/lib/modules/account/logic/new_account_store.dart
+++ b/app/lib/modules/account/logic/new_account_store.dart
@@ -1,7 +1,6 @@
 import 'package:mobx/mobx.dart';
 
 import 'package:encointer_wallet/modules/modules.dart';
-import 'package:encointer_wallet/modules/account/logic/key_type.dart';
 import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/store/app.dart';
@@ -24,9 +23,6 @@ abstract class _NewAccountStoreBase with Store {
   @observable
   String? accountKey;
 
-  @observable
-  KeyType keyType = KeyType.mnemonic;
-
   @readonly
   bool _loading = false;
 
@@ -35,9 +31,6 @@ abstract class _NewAccountStoreBase with Store {
 
   @action
   void setKey(String? value) => accountKey = value;
-
-  @action
-  void setKeyType(KeyType value) => keyType = value;
 
   @action
   Future<NewAccountResult> generateAccount() async {
@@ -78,7 +71,7 @@ abstract class _NewAccountStoreBase with Store {
       final result = await webApi.account.importAccount(
         key: accountKey!,
         password: '', // this is ignored on JS-side
-        keyType: keyType.name,
+        keyType: keyringAccount.seedType.name,
       );
       if (result['error'] != null) {
         _loading = false;

--- a/app/lib/modules/account/logic/new_account_store.g.dart
+++ b/app/lib/modules/account/logic/new_account_store.g.dart
@@ -39,21 +39,6 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
     });
   }
 
-  late final _$keyTypeAtom = Atom(name: '_NewAccountStoreBase.keyType', context: context);
-
-  @override
-  KeyType get keyType {
-    _$keyTypeAtom.reportRead();
-    return super.keyType;
-  }
-
-  @override
-  set keyType(KeyType value) {
-    _$keyTypeAtom.reportWrite(value, super.keyType, () {
-      super.keyType = value;
-    });
-  }
-
   late final _$_loadingAtom = Atom(name: '_NewAccountStoreBase._loading', context: context);
 
   bool get loading {
@@ -129,21 +114,10 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
   }
 
   @override
-  void setKeyType(KeyType value) {
-    final _$actionInfo = _$_NewAccountStoreBaseActionController.startAction(name: '_NewAccountStoreBase.setKeyType');
-    try {
-      return super.setKeyType(value);
-    } finally {
-      _$_NewAccountStoreBaseActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
   String toString() {
     return '''
 name: ${name},
-accountKey: ${accountKey},
-keyType: ${keyType}
+accountKey: ${accountKey}
     ''';
   }
 }

--- a/app/lib/modules/account/logic/new_account_store.g.dart
+++ b/app/lib/modules/account/logic/new_account_store.g.dart
@@ -24,21 +24,6 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
     });
   }
 
-  late final _$passwordAtom = Atom(name: '_NewAccountStoreBase.password', context: context);
-
-  @override
-  String? get password {
-    _$passwordAtom.reportRead();
-    return super.password;
-  }
-
-  @override
-  set password(String? value) {
-    _$passwordAtom.reportWrite(value, super.password, () {
-      super.password = value;
-    });
-  }
-
   late final _$accountKeyAtom = Atom(name: '_NewAccountStoreBase.accountKey', context: context);
 
   @override
@@ -89,36 +74,36 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
   late final _$generateAccountAsyncAction = AsyncAction('_NewAccountStoreBase.generateAccount', context: context);
 
   @override
-  Future<NewAccountResult> generateAccount(BuildContext context) {
-    return _$generateAccountAsyncAction.run(() => super.generateAccount(context));
+  Future<NewAccountResult> generateAccount() {
+    return _$generateAccountAsyncAction.run(() => super.generateAccount());
   }
 
   late final _$importAccountAsyncAction = AsyncAction('_NewAccountStoreBase.importAccount', context: context);
 
   @override
-  Future<NewAccountResult> importAccount(BuildContext context) {
-    return _$importAccountAsyncAction.run(() => super.importAccount(context));
+  Future<NewAccountResult> importAccount() {
+    return _$importAccountAsyncAction.run(() => super.importAccount());
   }
 
   late final _$_generateAccountAsyncAction = AsyncAction('_NewAccountStoreBase._generateAccount', context: context);
 
   @override
-  Future<NewAccountResult> _generateAccount(BuildContext context, String pin) {
-    return _$_generateAccountAsyncAction.run(() => super._generateAccount(context, pin));
+  Future<NewAccountResult> _generateAccount() {
+    return _$_generateAccountAsyncAction.run(() => super._generateAccount());
   }
 
   late final _$_importAccountAsyncAction = AsyncAction('_NewAccountStoreBase._importAccount', context: context);
 
   @override
-  Future<NewAccountResult> _importAccount(BuildContext context, String pin) {
-    return _$_importAccountAsyncAction.run(() => super._importAccount(context, pin));
+  Future<NewAccountResult> _importAccount() {
+    return _$_importAccountAsyncAction.run(() => super._importAccount());
   }
 
   late final _$saveAccountAsyncAction = AsyncAction('_NewAccountStoreBase.saveAccount', context: context);
 
   @override
-  Future<NewAccountResult> saveAccount(KeyringAccount account, String pin) {
-    return _$saveAccountAsyncAction.run(() => super.saveAccount(account, pin));
+  Future<NewAccountResult> saveAccount(KeyringAccount account) {
+    return _$saveAccountAsyncAction.run(() => super.saveAccount(account));
   }
 
   late final _$_NewAccountStoreBaseActionController = ActionController(name: '_NewAccountStoreBase', context: context);
@@ -128,16 +113,6 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
     final _$actionInfo = _$_NewAccountStoreBaseActionController.startAction(name: '_NewAccountStoreBase.setName');
     try {
       return super.setName(value);
-    } finally {
-      _$_NewAccountStoreBaseActionController.endAction(_$actionInfo);
-    }
-  }
-
-  @override
-  void setPassword(String? value) {
-    final _$actionInfo = _$_NewAccountStoreBaseActionController.startAction(name: '_NewAccountStoreBase.setPassword');
-    try {
-      return super.setPassword(value);
     } finally {
       _$_NewAccountStoreBaseActionController.endAction(_$actionInfo);
     }
@@ -167,7 +142,6 @@ mixin _$NewAccountStore on _NewAccountStoreBase, Store {
   String toString() {
     return '''
 name: ${name},
-password: ${password},
 accountKey: ${accountKey},
 keyType: ${keyType}
     ''';

--- a/app/lib/modules/account/view/add_account_view.dart
+++ b/app/lib/modules/account/view/add_account_view.dart
@@ -108,12 +108,15 @@ class AddAccountForm extends StatelessWidget with HandleNewAccountResultMixin {
           final newAccount = context.read<NewAccountStore>();
           if (_formKey.currentState!.validate() && !newAccount.loading) {
             newAccount.setName(_nameCtrl.text.trim());
-            final res = await newAccount.generateAccount();
-            await navigate(
-              context: context,
-              type: res.operationResult,
-              onOk: () => Navigator.of(context).popUntil((route) => route.isFirst),
-            );
+            final pin = await context.read<LoginStore>().getPin(context);
+            if (pin != null) {
+              final res = await newAccount.generateAccount();
+              await navigate(
+                context: context,
+                type: res.operationResult,
+                onOk: () => Navigator.of(context).popUntil((route) => route.isFirst),
+              );
+            }
           }
         },
         child: Row(

--- a/app/lib/modules/account/view/add_account_view.dart
+++ b/app/lib/modules/account/view/add_account_view.dart
@@ -108,7 +108,7 @@ class AddAccountForm extends StatelessWidget with HandleNewAccountResultMixin {
           final newAccount = context.read<NewAccountStore>();
           if (_formKey.currentState!.validate() && !newAccount.loading) {
             newAccount.setName(_nameCtrl.text.trim());
-            final res = await newAccount.generateAccount(context);
+            final res = await newAccount.generateAccount();
             await navigate(
               context: context,
               type: res.operationResult,

--- a/app/lib/modules/account/view/add_account_view.dart
+++ b/app/lib/modules/account/view/add_account_view.dart
@@ -32,15 +32,15 @@ class AddAccountView extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14),
         child: Provider(
           create: (context) => NewAccountStore(context.read<AppStore>()),
-          child: AddAcccountForm(),
+          child: AddAccountForm(),
         ),
       ),
     );
   }
 }
 
-class AddAcccountForm extends StatelessWidget with HandleNewAccountResultMixin {
-  AddAcccountForm({super.key});
+class AddAccountForm extends StatelessWidget with HandleNewAccountResultMixin {
+  AddAccountForm({super.key});
 
   final _formKey = GlobalKey<FormState>();
 

--- a/app/lib/modules/account/view/create_account_view.dart
+++ b/app/lib/modules/account/view/create_account_view.dart
@@ -29,15 +29,15 @@ class CreateAccountView extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14),
         child: Provider(
           create: (context) => NewAccountStore(context.read<AppStore>()),
-          child: CreateAcccountForm(),
+          child: CreateAccountForm(),
         ),
       ),
     );
   }
 }
 
-class CreateAcccountForm extends StatelessWidget with HandleNewAccountResultMixin {
-  CreateAcccountForm({super.key});
+class CreateAccountForm extends StatelessWidget with HandleNewAccountResultMixin {
+  CreateAccountForm({super.key});
 
   final _formKey = GlobalKey<FormState>();
 

--- a/app/lib/modules/account/view/create_pin_view.dart
+++ b/app/lib/modules/account/view/create_pin_view.dart
@@ -107,7 +107,7 @@ class CreatePinForm extends StatelessWidget with HandleNewAccountResultMixin {
           onPressed: () async {
             final newAccount = context.read<NewAccountStore>();
             if (_formKey.currentState!.validate() && !newAccount.loading) {
-              await context.read<LoginStore>().setPin(_passCtrl.text.trim());
+              await context.read<LoginStore>().persistNewPin(_passCtrl.text.trim());
               final res =
                   fromImportPage ? await newAccount.importAccount() : await newAccount.generateAccount();
               await navigate(

--- a/app/lib/modules/account/view/create_pin_view.dart
+++ b/app/lib/modules/account/view/create_pin_view.dart
@@ -108,8 +108,7 @@ class CreatePinForm extends StatelessWidget with HandleNewAccountResultMixin {
             final newAccount = context.read<NewAccountStore>();
             if (_formKey.currentState!.validate() && !newAccount.loading) {
               await context.read<LoginStore>().persistNewPin(_passCtrl.text.trim());
-              final res =
-                  fromImportPage ? await newAccount.importAccount() : await newAccount.generateAccount();
+              final res = fromImportPage ? await newAccount.importAccount() : await newAccount.generateAccount();
               await navigate(
                 context: context,
                 type: res.operationResult,

--- a/app/lib/modules/account/view/create_pin_view.dart
+++ b/app/lib/modules/account/view/create_pin_view.dart
@@ -107,9 +107,9 @@ class CreatePinForm extends StatelessWidget with HandleNewAccountResultMixin {
           onPressed: () async {
             final newAccount = context.read<NewAccountStore>();
             if (_formKey.currentState!.validate() && !newAccount.loading) {
-              newAccount.setPassword(_passCtrl.text.trim());
+              await context.read<LoginStore>().setPin(_passCtrl.text.trim());
               final res =
-                  fromImportPage ? await newAccount.importAccount(context) : await newAccount.generateAccount(context);
+                  fromImportPage ? await newAccount.importAccount() : await newAccount.generateAccount();
               await navigate(
                 context: context,
                 type: res.operationResult,

--- a/app/lib/modules/account/view/handle_new_account_result_mixin.dart
+++ b/app/lib/modules/account/view/handle_new_account_result_mixin.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import 'package:encointer_wallet/modules/modules.dart';
 import 'package:encointer_wallet/utils/alerts/app_alert.dart';
@@ -18,10 +17,6 @@ mixin HandleNewAccountResultMixin on Widget {
           context,
           errorText: context.l10n.createError,
           buttontext: context.l10n.ok,
-        ),
-      NewAccountResultType.emptyPassword => await LoginDialog.verifyPinOrBioAuth(
-          context,
-          onSuccess: (v) async => context.read<LoginStore>().setPin(v),
         ),
       NewAccountResultType.duplicateAccount => onDuplicateAccount != null ? onDuplicateAccount() : null,
     };

--- a/app/lib/modules/account/view/import_account_view.dart
+++ b/app/lib/modules/account/view/import_account_view.dart
@@ -15,7 +15,6 @@ import 'package:encointer_wallet/utils/alerts/app_alert.dart';
 import 'package:encointer_wallet/utils/format.dart';
 import 'package:encointer_wallet/utils/input_validation.dart';
 import 'package:encointer_wallet/l10n/l10.dart';
-import 'package:encointer_wallet/modules/account/logic/key_type.dart';
 import 'package:ew_keyring/ew_keyring.dart' show KeyringAccount, ValidateKeys;
 
 class ImportAccountView extends StatelessWidget {
@@ -88,12 +87,10 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
           validator: (String? value) {
             if (value == null || value.isEmpty) return l10n.importMustNotBeEmpty;
             if (ValidateKeys.isRawSeed(value)) {
-              context.read<NewAccountStore>().setKeyType(KeyType.rawSeed);
               return ValidateKeys.validateRawSeed(value) ? null : l10n.importInvalidRawSeed;
             } else if (ValidateKeys.isPrivateKey(value)) {
               return l10n.importPrivateKeyUnsupported;
             } else {
-              context.read<NewAccountStore>().setKeyType(KeyType.mnemonic);
               return ValidateKeys.validateMnemonic(value) ? null : l10n.importInvalidMnemonic;
             }
           },

--- a/app/lib/modules/account/view/import_account_view.dart
+++ b/app/lib/modules/account/view/import_account_view.dart
@@ -121,7 +121,7 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
                   ),
                 );
               } else {
-                final res = await newAccount.importAccount(context);
+                final res = await newAccount.importAccount();
                 await navigate(
                   context: context,
                   type: res.operationResult,
@@ -162,7 +162,7 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
           onPressed: () async {
             final pin = await context.read<LoginStore>().getPin(context);
             if (pin != null) {
-              await context.read<NewAccountStore>().saveAccount(acc, pin);
+              await context.read<NewAccountStore>().saveAccount(acc);
               Navigator.of(context).popUntil((route) => route.isFirst);
             }
           },

--- a/app/lib/modules/account/view/import_account_view.dart
+++ b/app/lib/modules/account/view/import_account_view.dart
@@ -121,13 +121,16 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
                   ),
                 );
               } else {
-                final res = await newAccount.importAccount();
-                await navigate(
-                  context: context,
-                  type: res.operationResult,
-                  onOk: () => Navigator.of(context).popUntil((route) => route.isFirst),
-                  onDuplicateAccount: () => _onDuplicateAccount(context, res.duplicateAccountData),
-                );
+                final pin = await context.read<LoginStore>().getPin(context);
+                if (pin != null) {
+                  final res = await newAccount.importAccount();
+                  await navigate(
+                    context: context,
+                    type: res.operationResult,
+                    onOk: () => Navigator.of(context).popUntil((route) => route.isFirst),
+                    onDuplicateAccount: () => _onDuplicateAccount(context, res.duplicateAccountData),
+                  );
+                }
               }
             }
           },
@@ -160,11 +163,8 @@ class ImportAccountForm extends StatelessWidget with HandleNewAccountResultMixin
         CupertinoButton(
           child: Text(l10n.ok),
           onPressed: () async {
-            final pin = await context.read<LoginStore>().getPin(context);
-            if (pin != null) {
-              await context.read<NewAccountStore>().saveAccount(acc);
-              Navigator.of(context).popUntil((route) => route.isFirst);
-            }
+            await context.read<NewAccountStore>().saveAccount(acc);
+            Navigator.of(context).popUntil((route) => route.isFirst);
           },
         ),
       ],

--- a/app/lib/modules/login/logic/login_store.dart
+++ b/app/lib/modules/login/logic/login_store.dart
@@ -33,9 +33,14 @@ abstract class _LoginStoreBase with Store {
     return cachedPin;
   }
 
-  Future<void> setPin(String pin) async {
+  /// Persists the new PIN in the secure storage.
+  ///
+  /// Attention: This function must be called *exclusively* upon:
+  /// * Setting the PIN initially
+  /// * Changing the PIN
+  Future<void> persistNewPin(String pin) async {
     cachedPin = pin;
-    await loginService.setPin(pin);
+    await loginService.persistPin(pin);
   }
 
   Future<bool> isValid(String input) async {

--- a/app/lib/modules/login/service/login_service.dart
+++ b/app/lib/modules/login/service/login_service.dart
@@ -46,7 +46,12 @@ final class LoginService with GetPin {
   @override
   Future<String?> getPin() => secureStorage.read(key: pinStorageKey);
 
-  Future<void> setPin(String pin) async {
+  /// Persists the new PIN in the secure storage.
+  ///
+  /// Attention: This function must be called *exclusively* upon:
+  /// * Setting the PIN initially
+  /// * Changing the PIN
+  Future<void> persistPin(String pin) async {
     await secureStorage.write(key: pinStorageKey, value: pin);
   }
 

--- a/app/lib/modules/login/view/login_dialog.dart
+++ b/app/lib/modules/login/view/login_dialog.dart
@@ -149,7 +149,6 @@ final class LoginDialog {
               loginStore.loading = true;
               final value = await _onOk(context, passCtrl.text.trim());
               if (value) {
-                if (loginStore.cachedPin == null) await loginStore.setPin(passCtrl.text.trim());
                 await onSuccess(passCtrl.text.trim());
                 if (autoCloseOnSuccess) Navigator.of(context).pop();
               } else {

--- a/app/lib/page/profile/account/change_password_page.dart
+++ b/app/lib/page/profile/account/change_password_page.dart
@@ -43,7 +43,7 @@ class _ChangePassword extends State<ChangePasswordPage> {
       final passNew = _passCtrl.text.trim();
       // check password
       if (await loginStore.isValid(passOld)) {
-        await context.read<LoginStore>().setPin(passNew);
+        await context.read<LoginStore>().persistNewPin(passNew);
         await showCupertinoDialog<void>(
           context: context,
           builder: (BuildContext context) {


### PR DESCRIPTION
I was about to investigate #1496, where I noticed that the account importing and the PIN querying was much more complicated and obfuscated than necessary (to be fair, parts of the simplifications were only possible after #1618).

Summary of changes:
* Remove responsibility of the `NewAccountStore` to also query the pin, as it is not even needed anymore to create new accounts. Simply ask for the PIN if not cached on the Create/Import page. Closes #1496.
* There were unnecessary calls to `setPin` in cases where we only wanted to (runtime-)cache the PIN, but `setPin` actually persists them to the secure storage. I removed all cases of `setPIN` except for when actually setting the PIN or changing the PIN.