### PR TITLE
Bump polkadart to get type safety in extrinsic call api

### DIFF
--- a/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -233,7 +233,7 @@ Future<void> submitAttestAttendees(
 
   final call = api.encointer.encointerKusama.tx.encointerCeremonies.attestAttendees(
     cid: chosenCid.toPolkadart(),
-    numberOfParticipantsVote: store.encointer.communityAccount!.participantCountVote,
+    numberOfParticipantsVote: store.encointer.communityAccount!.participantCountVote!,
     attestations: attestations,
   );
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1228,16 +1228,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.3.1"
+    version: "0.3.2"
   polkadart_keyring:
     dependency: "direct overridden"
     description:
       path: "packages/polkadart_keyring"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.0"
@@ -1246,7 +1246,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -1652,7 +1652,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_encointer_utils/pubspec.lock
+++ b/packages/ew_encointer_utils/pubspec.lock
@@ -362,16 +362,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.3.1"
+    version: "0.3.2"
   polkadart_keyring:
     dependency: "direct overridden"
     description:
       path: "packages/polkadart_keyring"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.0"
@@ -380,7 +380,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_keyring/pubspec.lock
+++ b/packages/ew_keyring/pubspec.lock
@@ -398,7 +398,7 @@ packages:
     description:
       path: "packages/polkadart_keyring"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.0"
@@ -407,7 +407,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/balances.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/balances.dart
@@ -6,12 +6,13 @@ import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
 import '../types/encointer_runtime/runtime_call.dart' as _i10;
-import '../types/pallet_balances/pallet/call.dart' as _i11;
+import '../types/pallet_balances/pallet/call.dart' as _i12;
 import '../types/pallet_balances/types/account_data.dart' as _i4;
 import '../types/pallet_balances/types/balance_lock.dart' as _i5;
 import '../types/pallet_balances/types/id_amount.dart' as _i7;
 import '../types/pallet_balances/types/reserve_data.dart' as _i6;
 import '../types/sp_core/crypto/account_id32.dart' as _i3;
+import '../types/sp_runtime/multiaddress/multi_address.dart' as _i11;
 
 class Queries {
   const Queries(this.__api);
@@ -286,10 +287,10 @@ class Txs {
 
   /// See [`Pallet::transfer_allow_death`].
   _i10.RuntimeCall transferAllowDeath({
-    required dest,
-    required value,
+    required _i11.MultiAddress dest,
+    required BigInt value,
   }) {
-    final _call = _i11.Call.values.transferAllowDeath(
+    final _call = _i12.Call.values.transferAllowDeath(
       dest: dest,
       value: value,
     );
@@ -298,11 +299,11 @@ class Txs {
 
   /// See [`Pallet::set_balance_deprecated`].
   _i10.RuntimeCall setBalanceDeprecated({
-    required who,
-    required newFree,
-    required oldReserved,
+    required _i11.MultiAddress who,
+    required BigInt newFree,
+    required BigInt oldReserved,
   }) {
-    final _call = _i11.Call.values.setBalanceDeprecated(
+    final _call = _i12.Call.values.setBalanceDeprecated(
       who: who,
       newFree: newFree,
       oldReserved: oldReserved,
@@ -312,11 +313,11 @@ class Txs {
 
   /// See [`Pallet::force_transfer`].
   _i10.RuntimeCall forceTransfer({
-    required source,
-    required dest,
-    required value,
+    required _i11.MultiAddress source,
+    required _i11.MultiAddress dest,
+    required BigInt value,
   }) {
-    final _call = _i11.Call.values.forceTransfer(
+    final _call = _i12.Call.values.forceTransfer(
       source: source,
       dest: dest,
       value: value,
@@ -326,10 +327,10 @@ class Txs {
 
   /// See [`Pallet::transfer_keep_alive`].
   _i10.RuntimeCall transferKeepAlive({
-    required dest,
-    required value,
+    required _i11.MultiAddress dest,
+    required BigInt value,
   }) {
-    final _call = _i11.Call.values.transferKeepAlive(
+    final _call = _i12.Call.values.transferKeepAlive(
       dest: dest,
       value: value,
     );
@@ -338,10 +339,10 @@ class Txs {
 
   /// See [`Pallet::transfer_all`].
   _i10.RuntimeCall transferAll({
-    required dest,
-    required keepAlive,
+    required _i11.MultiAddress dest,
+    required bool keepAlive,
   }) {
-    final _call = _i11.Call.values.transferAll(
+    final _call = _i12.Call.values.transferAll(
       dest: dest,
       keepAlive: keepAlive,
     );
@@ -350,10 +351,10 @@ class Txs {
 
   /// See [`Pallet::force_unreserve`].
   _i10.RuntimeCall forceUnreserve({
-    required who,
-    required amount,
+    required _i11.MultiAddress who,
+    required BigInt amount,
   }) {
-    final _call = _i11.Call.values.forceUnreserve(
+    final _call = _i12.Call.values.forceUnreserve(
       who: who,
       amount: amount,
     );
@@ -361,17 +362,17 @@ class Txs {
   }
 
   /// See [`Pallet::upgrade_accounts`].
-  _i10.RuntimeCall upgradeAccounts({required who}) {
-    final _call = _i11.Call.values.upgradeAccounts(who: who);
+  _i10.RuntimeCall upgradeAccounts({required List<_i3.AccountId32> who}) {
+    final _call = _i12.Call.values.upgradeAccounts(who: who);
     return _i10.RuntimeCall.values.balances(_call);
   }
 
   /// See [`Pallet::transfer`].
   _i10.RuntimeCall transfer({
-    required dest,
-    required value,
+    required _i11.MultiAddress dest,
+    required BigInt value,
   }) {
-    final _call = _i11.Call.values.transfer(
+    final _call = _i12.Call.values.transfer(
       dest: dest,
       value: value,
     );
@@ -380,10 +381,10 @@ class Txs {
 
   /// See [`Pallet::force_set_balance`].
   _i10.RuntimeCall forceSetBalance({
-    required who,
-    required newFree,
+    required _i11.MultiAddress who,
+    required BigInt newFree,
   }) {
-    final _call = _i11.Call.values.forceSetBalance(
+    final _call = _i12.Call.values.forceSetBalance(
       who: who,
       newFree: newFree,
     );

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/collective.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/collective.dart
@@ -193,9 +193,9 @@ class Txs {
 
   /// See [`Pallet::set_members`].
   _i4.RuntimeCall setMembers({
-    required newMembers,
-    prime,
-    required oldCount,
+    required List<_i6.AccountId32> newMembers,
+    _i6.AccountId32? prime,
+    required int oldCount,
   }) {
     final _call = _i9.Call.values.setMembers(
       newMembers: newMembers,
@@ -207,8 +207,8 @@ class Txs {
 
   /// See [`Pallet::execute`].
   _i4.RuntimeCall execute({
-    required proposal,
-    required lengthBound,
+    required _i4.RuntimeCall proposal,
+    required BigInt lengthBound,
   }) {
     final _call = _i9.Call.values.execute(
       proposal: proposal,
@@ -219,9 +219,9 @@ class Txs {
 
   /// See [`Pallet::propose`].
   _i4.RuntimeCall propose({
-    required threshold,
-    required proposal,
-    required lengthBound,
+    required BigInt threshold,
+    required _i4.RuntimeCall proposal,
+    required BigInt lengthBound,
   }) {
     final _call = _i9.Call.values.propose(
       threshold: threshold,
@@ -233,9 +233,9 @@ class Txs {
 
   /// See [`Pallet::vote`].
   _i4.RuntimeCall vote({
-    required proposal,
-    required index,
-    required approve,
+    required _i2.H256 proposal,
+    required BigInt index,
+    required bool approve,
   }) {
     final _call = _i9.Call.values.vote(
       proposal: proposal,
@@ -246,17 +246,17 @@ class Txs {
   }
 
   /// See [`Pallet::disapprove_proposal`].
-  _i4.RuntimeCall disapproveProposal({required proposalHash}) {
+  _i4.RuntimeCall disapproveProposal({required _i2.H256 proposalHash}) {
     final _call = _i9.Call.values.disapproveProposal(proposalHash: proposalHash);
     return _i4.RuntimeCall.values.collective(_call);
   }
 
   /// See [`Pallet::close`].
   _i4.RuntimeCall close({
-    required proposalHash,
-    required index,
-    required proposalWeightBound,
-    required lengthBound,
+    required _i2.H256 proposalHash,
+    required BigInt index,
+    required _i10.Weight proposalWeightBound,
+    required BigInt lengthBound,
   }) {
     final _call = _i9.Call.values.close(
       proposalHash: proposalHash,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/dmp_queue.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/dmp_queue.dart
@@ -184,8 +184,8 @@ class Txs {
 
   /// See [`Pallet::service_overweight`].
   _i9.RuntimeCall serviceOverweight({
-    required index,
-    required weightLimit,
+    required BigInt index,
+    required _i7.Weight weightLimit,
   }) {
     final _call = _i10.Call.values.serviceOverweight(
       index: index,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_balances.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_balances.dart
@@ -170,9 +170,9 @@ class Txs {
 
   /// See [`Pallet::transfer`].
   _i10.RuntimeCall transfer({
-    required dest,
-    required communityId,
-    required amount,
+    required _i4.AccountId32 dest,
+    required _i2.CommunityIdentifier communityId,
+    required _i8.FixedU128 amount,
   }) {
     final _call = _i11.Call.values.transfer(
       dest: dest,
@@ -183,15 +183,15 @@ class Txs {
   }
 
   /// See [`Pallet::set_fee_conversion_factor`].
-  _i10.RuntimeCall setFeeConversionFactor({required feeConversionFactor}) {
+  _i10.RuntimeCall setFeeConversionFactor({required BigInt feeConversionFactor}) {
     final _call = _i11.Call.values.setFeeConversionFactor(feeConversionFactor: feeConversionFactor);
     return _i10.RuntimeCall.values.encointerBalances(_call);
   }
 
   /// See [`Pallet::transfer_all`].
   _i10.RuntimeCall transferAll({
-    required dest,
-    required cid,
+    required _i4.AccountId32 dest,
+    required _i2.CommunityIdentifier cid,
   }) {
     final _call = _i11.Call.values.transferAll(
       dest: dest,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_bazaar.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_bazaar.dart
@@ -128,8 +128,8 @@ class Txs {
 
   /// See [`Pallet::create_business`].
   _i10.RuntimeCall createBusiness({
-    required cid,
-    required url,
+    required _i2.CommunityIdentifier cid,
+    required List<int> url,
   }) {
     final _call = _i11.Call.values.createBusiness(
       cid: cid,
@@ -140,8 +140,8 @@ class Txs {
 
   /// See [`Pallet::update_business`].
   _i10.RuntimeCall updateBusiness({
-    required cid,
-    required url,
+    required _i2.CommunityIdentifier cid,
+    required List<int> url,
   }) {
     final _call = _i11.Call.values.updateBusiness(
       cid: cid,
@@ -151,15 +151,15 @@ class Txs {
   }
 
   /// See [`Pallet::delete_business`].
-  _i10.RuntimeCall deleteBusiness({required cid}) {
+  _i10.RuntimeCall deleteBusiness({required _i2.CommunityIdentifier cid}) {
     final _call = _i11.Call.values.deleteBusiness(cid: cid);
     return _i10.RuntimeCall.values.encointerBazaar(_call);
   }
 
   /// See [`Pallet::create_offering`].
   _i10.RuntimeCall createOffering({
-    required cid,
-    required url,
+    required _i2.CommunityIdentifier cid,
+    required List<int> url,
   }) {
     final _call = _i11.Call.values.createOffering(
       cid: cid,
@@ -170,9 +170,9 @@ class Txs {
 
   /// See [`Pallet::update_offering`].
   _i10.RuntimeCall updateOffering({
-    required cid,
-    required oid,
-    required url,
+    required _i2.CommunityIdentifier cid,
+    required int oid,
+    required List<int> url,
   }) {
     final _call = _i11.Call.values.updateOffering(
       cid: cid,
@@ -184,8 +184,8 @@ class Txs {
 
   /// See [`Pallet::delete_offering`].
   _i10.RuntimeCall deleteOffering({
-    required cid,
-    required oid,
+    required _i2.CommunityIdentifier cid,
+    required int oid,
   }) {
     final _call = _i11.Call.values.deleteOffering(
       cid: cid,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_ceremonies.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_ceremonies.dart
@@ -9,10 +9,11 @@ import '../types/encointer_primitives/ceremonies/assignment.dart' as _i7;
 import '../types/encointer_primitives/ceremonies/assignment_count.dart' as _i6;
 import '../types/encointer_primitives/ceremonies/assignment_params.dart' as _i12;
 import '../types/encointer_primitives/ceremonies/meetup_result.dart' as _i10;
+import '../types/encointer_primitives/ceremonies/proof_of_attendance.dart' as _i15;
 import '../types/encointer_primitives/ceremonies/reputation.dart' as _i8;
 import '../types/encointer_primitives/communities/community_identifier.dart' as _i2;
 import '../types/encointer_runtime/runtime_call.dart' as _i14;
-import '../types/pallet_encointer_ceremonies/pallet/call.dart' as _i15;
+import '../types/pallet_encointer_ceremonies/pallet/call.dart' as _i16;
 import '../types/sp_core/crypto/account_id32.dart' as _i3;
 import '../types/substrate_fixed/fixed_u128.dart' as _i9;
 import '../types/tuples.dart' as _i5;
@@ -1489,10 +1490,10 @@ class Txs {
 
   /// See [`Pallet::register_participant`].
   _i14.RuntimeCall registerParticipant({
-    required cid,
-    proof,
+    required _i2.CommunityIdentifier cid,
+    _i15.ProofOfAttendance? proof,
   }) {
-    final _call = _i15.Call.values.registerParticipant(
+    final _call = _i16.Call.values.registerParticipant(
       cid: cid,
       proof: proof,
     );
@@ -1501,10 +1502,10 @@ class Txs {
 
   /// See [`Pallet::upgrade_registration`].
   _i14.RuntimeCall upgradeRegistration({
-    required cid,
-    required proof,
+    required _i2.CommunityIdentifier cid,
+    required _i15.ProofOfAttendance proof,
   }) {
-    final _call = _i15.Call.values.upgradeRegistration(
+    final _call = _i16.Call.values.upgradeRegistration(
       cid: cid,
       proof: proof,
     );
@@ -1513,10 +1514,10 @@ class Txs {
 
   /// See [`Pallet::unregister_participant`].
   _i14.RuntimeCall unregisterParticipant({
-    required cid,
-    maybeReputationCommunityCeremony,
+    required _i2.CommunityIdentifier cid,
+    _i5.Tuple2<_i2.CommunityIdentifier, int>? maybeReputationCommunityCeremony,
   }) {
-    final _call = _i15.Call.values.unregisterParticipant(
+    final _call = _i16.Call.values.unregisterParticipant(
       cid: cid,
       maybeReputationCommunityCeremony: maybeReputationCommunityCeremony,
     );
@@ -1525,11 +1526,11 @@ class Txs {
 
   /// See [`Pallet::attest_attendees`].
   _i14.RuntimeCall attestAttendees({
-    required cid,
-    required numberOfParticipantsVote,
-    required attestations,
+    required _i2.CommunityIdentifier cid,
+    required int numberOfParticipantsVote,
+    required List<_i3.AccountId32> attestations,
   }) {
-    final _call = _i15.Call.values.attestAttendees(
+    final _call = _i16.Call.values.attestAttendees(
       cid: cid,
       numberOfParticipantsVote: numberOfParticipantsVote,
       attestations: attestations,
@@ -1539,10 +1540,10 @@ class Txs {
 
   /// See [`Pallet::endorse_newcomer`].
   _i14.RuntimeCall endorseNewcomer({
-    required cid,
-    required newbie,
+    required _i2.CommunityIdentifier cid,
+    required _i3.AccountId32 newbie,
   }) {
-    final _call = _i15.Call.values.endorseNewcomer(
+    final _call = _i16.Call.values.endorseNewcomer(
       cid: cid,
       newbie: newbie,
     );
@@ -1551,10 +1552,10 @@ class Txs {
 
   /// See [`Pallet::claim_rewards`].
   _i14.RuntimeCall claimRewards({
-    required cid,
-    maybeMeetupIndex,
+    required _i2.CommunityIdentifier cid,
+    BigInt? maybeMeetupIndex,
   }) {
-    final _call = _i15.Call.values.claimRewards(
+    final _call = _i16.Call.values.claimRewards(
       cid: cid,
       maybeMeetupIndex: maybeMeetupIndex,
     );
@@ -1562,52 +1563,52 @@ class Txs {
   }
 
   /// See [`Pallet::set_inactivity_timeout`].
-  _i14.RuntimeCall setInactivityTimeout({required inactivityTimeout}) {
-    final _call = _i15.Call.values.setInactivityTimeout(inactivityTimeout: inactivityTimeout);
+  _i14.RuntimeCall setInactivityTimeout({required int inactivityTimeout}) {
+    final _call = _i16.Call.values.setInactivityTimeout(inactivityTimeout: inactivityTimeout);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_endorsement_tickets_per_bootstrapper`].
-  _i14.RuntimeCall setEndorsementTicketsPerBootstrapper({required endorsementTicketsPerBootstrapper}) {
-    final _call = _i15.Call.values
+  _i14.RuntimeCall setEndorsementTicketsPerBootstrapper({required int endorsementTicketsPerBootstrapper}) {
+    final _call = _i16.Call.values
         .setEndorsementTicketsPerBootstrapper(endorsementTicketsPerBootstrapper: endorsementTicketsPerBootstrapper);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_endorsement_tickets_per_reputable`].
-  _i14.RuntimeCall setEndorsementTicketsPerReputable({required endorsementTicketsPerReputable}) {
-    final _call = _i15.Call.values
+  _i14.RuntimeCall setEndorsementTicketsPerReputable({required int endorsementTicketsPerReputable}) {
+    final _call = _i16.Call.values
         .setEndorsementTicketsPerReputable(endorsementTicketsPerReputable: endorsementTicketsPerReputable);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_reputation_lifetime`].
-  _i14.RuntimeCall setReputationLifetime({required reputationLifetime}) {
-    final _call = _i15.Call.values.setReputationLifetime(reputationLifetime: reputationLifetime);
+  _i14.RuntimeCall setReputationLifetime({required int reputationLifetime}) {
+    final _call = _i16.Call.values.setReputationLifetime(reputationLifetime: reputationLifetime);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_meetup_time_offset`].
-  _i14.RuntimeCall setMeetupTimeOffset({required meetupTimeOffset}) {
-    final _call = _i15.Call.values.setMeetupTimeOffset(meetupTimeOffset: meetupTimeOffset);
+  _i14.RuntimeCall setMeetupTimeOffset({required int meetupTimeOffset}) {
+    final _call = _i16.Call.values.setMeetupTimeOffset(meetupTimeOffset: meetupTimeOffset);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_time_tolerance`].
-  _i14.RuntimeCall setTimeTolerance({required timeTolerance}) {
-    final _call = _i15.Call.values.setTimeTolerance(timeTolerance: timeTolerance);
+  _i14.RuntimeCall setTimeTolerance({required BigInt timeTolerance}) {
+    final _call = _i16.Call.values.setTimeTolerance(timeTolerance: timeTolerance);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::set_location_tolerance`].
-  _i14.RuntimeCall setLocationTolerance({required locationTolerance}) {
-    final _call = _i15.Call.values.setLocationTolerance(locationTolerance: locationTolerance);
+  _i14.RuntimeCall setLocationTolerance({required int locationTolerance}) {
+    final _call = _i16.Call.values.setLocationTolerance(locationTolerance: locationTolerance);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 
   /// See [`Pallet::purge_community_ceremony`].
-  _i14.RuntimeCall purgeCommunityCeremony({required communityCeremony}) {
-    final _call = _i15.Call.values.purgeCommunityCeremony(communityCeremony: communityCeremony);
+  _i14.RuntimeCall purgeCommunityCeremony({required _i5.Tuple2<_i2.CommunityIdentifier, int> communityCeremony}) {
+    final _call = _i16.Call.values.purgeCommunityCeremony(communityCeremony: communityCeremony);
     return _i14.RuntimeCall.values.encointerCeremonies(_call);
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_communities.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_communities.dart
@@ -11,8 +11,9 @@ import '../types/encointer_primitives/communities/community_rules.dart' as _i10;
 import '../types/encointer_primitives/communities/location.dart' as _i5;
 import '../types/encointer_runtime/runtime_call.dart' as _i12;
 import '../types/geohash/geo_hash.dart' as _i2;
-import '../types/pallet_encointer_communities/pallet/call.dart' as _i13;
+import '../types/pallet_encointer_communities/pallet/call.dart' as _i14;
 import '../types/sp_core/crypto/account_id32.dart' as _i6;
+import '../types/substrate_fixed/fixed_i128.dart' as _i13;
 import '../types/substrate_fixed/fixed_u128.dart' as _i8;
 
 class Queries {
@@ -364,13 +365,13 @@ class Txs {
 
   /// See [`Pallet::new_community`].
   _i12.RuntimeCall newCommunity({
-    required location,
-    required bootstrappers,
-    required communityMetadata,
-    demurrage,
-    nominalIncome,
+    required _i5.Location location,
+    required List<_i6.AccountId32> bootstrappers,
+    required _i7.CommunityMetadata communityMetadata,
+    _i13.FixedI128? demurrage,
+    _i8.FixedU128? nominalIncome,
   }) {
-    final _call = _i13.Call.values.newCommunity(
+    final _call = _i14.Call.values.newCommunity(
       location: location,
       bootstrappers: bootstrappers,
       communityMetadata: communityMetadata,
@@ -382,10 +383,10 @@ class Txs {
 
   /// See [`Pallet::add_location`].
   _i12.RuntimeCall addLocation({
-    required cid,
-    required location,
+    required _i3.CommunityIdentifier cid,
+    required _i5.Location location,
   }) {
-    final _call = _i13.Call.values.addLocation(
+    final _call = _i14.Call.values.addLocation(
       cid: cid,
       location: location,
     );
@@ -394,10 +395,10 @@ class Txs {
 
   /// See [`Pallet::remove_location`].
   _i12.RuntimeCall removeLocation({
-    required cid,
-    required location,
+    required _i3.CommunityIdentifier cid,
+    required _i5.Location location,
   }) {
-    final _call = _i13.Call.values.removeLocation(
+    final _call = _i14.Call.values.removeLocation(
       cid: cid,
       location: location,
     );
@@ -406,10 +407,10 @@ class Txs {
 
   /// See [`Pallet::update_community_metadata`].
   _i12.RuntimeCall updateCommunityMetadata({
-    required cid,
-    required communityMetadata,
+    required _i3.CommunityIdentifier cid,
+    required _i7.CommunityMetadata communityMetadata,
   }) {
-    final _call = _i13.Call.values.updateCommunityMetadata(
+    final _call = _i14.Call.values.updateCommunityMetadata(
       cid: cid,
       communityMetadata: communityMetadata,
     );
@@ -418,10 +419,10 @@ class Txs {
 
   /// See [`Pallet::update_demurrage`].
   _i12.RuntimeCall updateDemurrage({
-    required cid,
-    required demurrage,
+    required _i3.CommunityIdentifier cid,
+    required _i13.FixedI128 demurrage,
   }) {
-    final _call = _i13.Call.values.updateDemurrage(
+    final _call = _i14.Call.values.updateDemurrage(
       cid: cid,
       demurrage: demurrage,
     );
@@ -430,10 +431,10 @@ class Txs {
 
   /// See [`Pallet::update_nominal_income`].
   _i12.RuntimeCall updateNominalIncome({
-    required cid,
-    required nominalIncome,
+    required _i3.CommunityIdentifier cid,
+    required _i8.FixedU128 nominalIncome,
   }) {
-    final _call = _i13.Call.values.updateNominalIncome(
+    final _call = _i14.Call.values.updateNominalIncome(
       cid: cid,
       nominalIncome: nominalIncome,
     );
@@ -441,20 +442,20 @@ class Txs {
   }
 
   /// See [`Pallet::set_min_solar_trip_time_s`].
-  _i12.RuntimeCall setMinSolarTripTimeS({required minSolarTripTimeS}) {
-    final _call = _i13.Call.values.setMinSolarTripTimeS(minSolarTripTimeS: minSolarTripTimeS);
+  _i12.RuntimeCall setMinSolarTripTimeS({required int minSolarTripTimeS}) {
+    final _call = _i14.Call.values.setMinSolarTripTimeS(minSolarTripTimeS: minSolarTripTimeS);
     return _i12.RuntimeCall.values.encointerCommunities(_call);
   }
 
   /// See [`Pallet::set_max_speed_mps`].
-  _i12.RuntimeCall setMaxSpeedMps({required maxSpeedMps}) {
-    final _call = _i13.Call.values.setMaxSpeedMps(maxSpeedMps: maxSpeedMps);
+  _i12.RuntimeCall setMaxSpeedMps({required int maxSpeedMps}) {
+    final _call = _i14.Call.values.setMaxSpeedMps(maxSpeedMps: maxSpeedMps);
     return _i12.RuntimeCall.values.encointerCommunities(_call);
   }
 
   /// See [`Pallet::purge_community`].
-  _i12.RuntimeCall purgeCommunity({required cid}) {
-    final _call = _i13.Call.values.purgeCommunity(cid: cid);
+  _i12.RuntimeCall purgeCommunity({required _i3.CommunityIdentifier cid}) {
+    final _call = _i14.Call.values.purgeCommunity(cid: cid);
     return _i12.RuntimeCall.values.encointerCommunities(_call);
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_faucet.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_faucet.dart
@@ -5,10 +5,11 @@ import 'dart:typed_data' as _i6;
 import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i4;
 
+import '../types/encointer_primitives/communities/community_identifier.dart' as _i8;
 import '../types/encointer_primitives/faucet/faucet.dart' as _i3;
 import '../types/encointer_runtime/runtime_call.dart' as _i7;
-import '../types/frame_support/pallet_id.dart' as _i9;
-import '../types/pallet_encointer_faucet/pallet/call.dart' as _i8;
+import '../types/frame_support/pallet_id.dart' as _i10;
+import '../types/pallet_encointer_faucet/pallet/call.dart' as _i9;
 import '../types/sp_core/crypto/account_id32.dart' as _i2;
 
 class Queries {
@@ -80,12 +81,12 @@ class Txs {
 
   /// See [`Pallet::create_faucet`].
   _i7.RuntimeCall createFaucet({
-    required name,
-    required amount,
-    whitelist,
-    required dripAmount,
+    required List<int> name,
+    required BigInt amount,
+    List<_i8.CommunityIdentifier>? whitelist,
+    required BigInt dripAmount,
   }) {
-    final _call = _i8.Call.values.createFaucet(
+    final _call = _i9.Call.values.createFaucet(
       name: name,
       amount: amount,
       whitelist: whitelist,
@@ -96,11 +97,11 @@ class Txs {
 
   /// See [`Pallet::drip`].
   _i7.RuntimeCall drip({
-    required faucetAccount,
-    required cid,
-    required cindex,
+    required _i2.AccountId32 faucetAccount,
+    required _i8.CommunityIdentifier cid,
+    required int cindex,
   }) {
-    final _call = _i8.Call.values.drip(
+    final _call = _i9.Call.values.drip(
       faucetAccount: faucetAccount,
       cid: cid,
       cindex: cindex,
@@ -110,10 +111,10 @@ class Txs {
 
   /// See [`Pallet::dissolve_faucet`].
   _i7.RuntimeCall dissolveFaucet({
-    required faucetAccount,
-    required beneficiary,
+    required _i2.AccountId32 faucetAccount,
+    required _i2.AccountId32 beneficiary,
   }) {
-    final _call = _i8.Call.values.dissolveFaucet(
+    final _call = _i9.Call.values.dissolveFaucet(
       faucetAccount: faucetAccount,
       beneficiary: beneficiary,
     );
@@ -121,14 +122,14 @@ class Txs {
   }
 
   /// See [`Pallet::close_faucet`].
-  _i7.RuntimeCall closeFaucet({required faucetAccount}) {
-    final _call = _i8.Call.values.closeFaucet(faucetAccount: faucetAccount);
+  _i7.RuntimeCall closeFaucet({required _i2.AccountId32 faucetAccount}) {
+    final _call = _i9.Call.values.closeFaucet(faucetAccount: faucetAccount);
     return _i7.RuntimeCall.values.encointerFaucet(_call);
   }
 
   /// See [`Pallet::set_reserve_amount`].
-  _i7.RuntimeCall setReserveAmount({required reserveAmount}) {
-    final _call = _i8.Call.values.setReserveAmount(reserveAmount: reserveAmount);
+  _i7.RuntimeCall setReserveAmount({required BigInt reserveAmount}) {
+    final _call = _i9.Call.values.setReserveAmount(reserveAmount: reserveAmount);
     return _i7.RuntimeCall.values.encointerFaucet(_call);
   }
 }
@@ -136,7 +137,7 @@ class Txs {
 class Constants {
   Constants();
 
-  final _i9.PalletId palletId = const <int>[
+  final _i10.PalletId palletId = const <int>[
     101,
     99,
     116,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_reputation_commitments.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_reputation_commitments.dart
@@ -137,17 +137,17 @@ class Txs {
   const Txs();
 
   /// See [`Pallet::register_purpose`].
-  _i9.RuntimeCall registerPurpose({required descriptor}) {
+  _i9.RuntimeCall registerPurpose({required List<int> descriptor}) {
     final _call = _i10.Call.values.registerPurpose(descriptor: descriptor);
     return _i9.RuntimeCall.values.encointerReputationCommitments(_call);
   }
 
   /// See [`Pallet::commit_reputation`].
   _i9.RuntimeCall commitReputation({
-    required cid,
-    required cindex,
-    required purpose,
-    commitmentHash,
+    required _i4.CommunityIdentifier cid,
+    required int cindex,
+    required BigInt purpose,
+    _i6.H256? commitmentHash,
   }) {
     final _call = _i10.Call.values.commitReputation(
       cid: cid,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
@@ -163,8 +163,8 @@ class Txs {
 
   /// See [`Pallet::set_phase_duration`].
   _i6.RuntimeCall setPhaseDuration({
-    required ceremonyPhase,
-    required duration,
+    required _i3.CeremonyPhaseType ceremonyPhase,
+    required BigInt duration,
   }) {
     final _call = _i7.Call.values.setPhaseDuration(
       ceremonyPhase: ceremonyPhase,
@@ -174,7 +174,7 @@ class Txs {
   }
 
   /// See [`Pallet::set_next_phase_timestamp`].
-  _i6.RuntimeCall setNextPhaseTimestamp({required timestamp}) {
+  _i6.RuntimeCall setNextPhaseTimestamp({required BigInt timestamp}) {
     final _call = _i7.Call.values.setNextPhaseTimestamp(timestamp: timestamp);
     return _i6.RuntimeCall.values.encointerScheduler(_call);
   }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/membership.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/membership.dart
@@ -6,8 +6,9 @@ import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i3;
 
 import '../types/encointer_runtime/runtime_call.dart' as _i6;
-import '../types/pallet_membership/pallet/call.dart' as _i7;
+import '../types/pallet_membership/pallet/call.dart' as _i8;
 import '../types/sp_core/crypto/account_id32.dart' as _i2;
+import '../types/sp_runtime/multiaddress/multi_address.dart' as _i7;
 
 class Queries {
   const Queries(this.__api);
@@ -69,23 +70,23 @@ class Txs {
   const Txs();
 
   /// See [`Pallet::add_member`].
-  _i6.RuntimeCall addMember({required who}) {
-    final _call = _i7.Call.values.addMember(who: who);
+  _i6.RuntimeCall addMember({required _i7.MultiAddress who}) {
+    final _call = _i8.Call.values.addMember(who: who);
     return _i6.RuntimeCall.values.membership(_call);
   }
 
   /// See [`Pallet::remove_member`].
-  _i6.RuntimeCall removeMember({required who}) {
-    final _call = _i7.Call.values.removeMember(who: who);
+  _i6.RuntimeCall removeMember({required _i7.MultiAddress who}) {
+    final _call = _i8.Call.values.removeMember(who: who);
     return _i6.RuntimeCall.values.membership(_call);
   }
 
   /// See [`Pallet::swap_member`].
   _i6.RuntimeCall swapMember({
-    required remove,
-    required add,
+    required _i7.MultiAddress remove,
+    required _i7.MultiAddress add,
   }) {
-    final _call = _i7.Call.values.swapMember(
+    final _call = _i8.Call.values.swapMember(
       remove: remove,
       add: add,
     );
@@ -93,26 +94,26 @@ class Txs {
   }
 
   /// See [`Pallet::reset_members`].
-  _i6.RuntimeCall resetMembers({required members}) {
-    final _call = _i7.Call.values.resetMembers(members: members);
+  _i6.RuntimeCall resetMembers({required List<_i2.AccountId32> members}) {
+    final _call = _i8.Call.values.resetMembers(members: members);
     return _i6.RuntimeCall.values.membership(_call);
   }
 
   /// See [`Pallet::change_key`].
-  _i6.RuntimeCall changeKey({required new_}) {
-    final _call = _i7.Call.values.changeKey(new_: new_);
+  _i6.RuntimeCall changeKey({required _i7.MultiAddress new_}) {
+    final _call = _i8.Call.values.changeKey(new_: new_);
     return _i6.RuntimeCall.values.membership(_call);
   }
 
   /// See [`Pallet::set_prime`].
-  _i6.RuntimeCall setPrime({required who}) {
-    final _call = _i7.Call.values.setPrime(who: who);
+  _i6.RuntimeCall setPrime({required _i7.MultiAddress who}) {
+    final _call = _i8.Call.values.setPrime(who: who);
     return _i6.RuntimeCall.values.membership(_call);
   }
 
   /// See [`Pallet::clear_prime`].
   _i6.RuntimeCall clearPrime() {
-    final _call = _i7.Call.values.clearPrime();
+    final _call = _i8.Call.values.clearPrime();
     return _i6.RuntimeCall.values.membership(_call);
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/parachain_system.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/parachain_system.dart
@@ -6,15 +6,17 @@ import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
 import '../types/cumulus_pallet_parachain_system/code_upgrade_authorization.dart' as _i12;
-import '../types/cumulus_pallet_parachain_system/pallet/call.dart' as _i16;
+import '../types/cumulus_pallet_parachain_system/pallet/call.dart' as _i17;
 import '../types/cumulus_pallet_parachain_system/relay_state_snapshot/messaging_state_snapshot.dart' as _i6;
 import '../types/cumulus_primitives_parachain_inherent/message_queue_chain.dart' as _i8;
+import '../types/cumulus_primitives_parachain_inherent/parachain_inherent_data.dart' as _i16;
 import '../types/encointer_runtime/runtime_call.dart' as _i15;
 import '../types/polkadot_core_primitives/outbound_hrmp_message.dart' as _i10;
 import '../types/polkadot_parachain/primitives/id.dart' as _i9;
 import '../types/polkadot_primitives/v5/abridged_host_configuration.dart' as _i7;
 import '../types/polkadot_primitives/v5/persisted_validation_data.dart' as _i3;
 import '../types/polkadot_primitives/v5/upgrade_restriction.dart' as _i4;
+import '../types/primitive_types/h256.dart' as _i18;
 import '../types/sp_trie/storage_proof/storage_proof.dart' as _i5;
 import '../types/sp_weights/weight_v2/weight.dart' as _i11;
 
@@ -621,23 +623,23 @@ class Txs {
   const Txs();
 
   /// See [`Pallet::set_validation_data`].
-  _i15.RuntimeCall setValidationData({required data}) {
-    final _call = _i16.Call.values.setValidationData(data: data);
+  _i15.RuntimeCall setValidationData({required _i16.ParachainInherentData data}) {
+    final _call = _i17.Call.values.setValidationData(data: data);
     return _i15.RuntimeCall.values.parachainSystem(_call);
   }
 
   /// See [`Pallet::sudo_send_upward_message`].
-  _i15.RuntimeCall sudoSendUpwardMessage({required message}) {
-    final _call = _i16.Call.values.sudoSendUpwardMessage(message: message);
+  _i15.RuntimeCall sudoSendUpwardMessage({required List<int> message}) {
+    final _call = _i17.Call.values.sudoSendUpwardMessage(message: message);
     return _i15.RuntimeCall.values.parachainSystem(_call);
   }
 
   /// See [`Pallet::authorize_upgrade`].
   _i15.RuntimeCall authorizeUpgrade({
-    required codeHash,
-    required checkVersion,
+    required _i18.H256 codeHash,
+    required bool checkVersion,
   }) {
-    final _call = _i16.Call.values.authorizeUpgrade(
+    final _call = _i17.Call.values.authorizeUpgrade(
       codeHash: codeHash,
       checkVersion: checkVersion,
     );
@@ -645,8 +647,8 @@ class Txs {
   }
 
   /// See [`Pallet::enact_authorized_upgrade`].
-  _i15.RuntimeCall enactAuthorizedUpgrade({required code}) {
-    final _call = _i16.Call.values.enactAuthorizedUpgrade(code: code);
+  _i15.RuntimeCall enactAuthorizedUpgrade({required List<int> code}) {
+    final _call = _i17.Call.values.enactAuthorizedUpgrade(code: code);
     return _i15.RuntimeCall.values.parachainSystem(_call);
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/polkadot_xcm.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/polkadot_xcm.dart
@@ -6,7 +6,7 @@ import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
 import '../types/encointer_runtime/runtime_call.dart' as _i14;
-import '../types/pallet_xcm/pallet/call.dart' as _i15;
+import '../types/pallet_xcm/pallet/call.dart' as _i16;
 import '../types/pallet_xcm/pallet/query_status.dart' as _i3;
 import '../types/pallet_xcm/pallet/remote_locked_fungible_record.dart' as _i11;
 import '../types/pallet_xcm/pallet/version_migration_stage.dart' as _i8;
@@ -14,8 +14,13 @@ import '../types/primitive_types/h256.dart' as _i4;
 import '../types/sp_core/crypto/account_id32.dart' as _i9;
 import '../types/sp_weights/weight_v2/weight.dart' as _i7;
 import '../types/tuples.dart' as _i6;
+import '../types/xcm/v3/multilocation/multi_location.dart' as _i19;
+import '../types/xcm/v3/weight_limit.dart' as _i20;
 import '../types/xcm/versioned_asset_id.dart' as _i10;
+import '../types/xcm/versioned_multi_assets.dart' as _i17;
 import '../types/xcm/versioned_multi_location.dart' as _i5;
+import '../types/xcm/versioned_xcm_1.dart' as _i15;
+import '../types/xcm/versioned_xcm_2.dart' as _i18;
 
 class Queries {
   const Queries(this.__api);
@@ -469,10 +474,10 @@ class Txs {
 
   /// See [`Pallet::send`].
   _i14.RuntimeCall send({
-    required dest,
-    required message,
+    required _i5.VersionedMultiLocation dest,
+    required _i15.VersionedXcm message,
   }) {
-    final _call = _i15.Call.values.send(
+    final _call = _i16.Call.values.send(
       dest: dest,
       message: message,
     );
@@ -481,12 +486,12 @@ class Txs {
 
   /// See [`Pallet::teleport_assets`].
   _i14.RuntimeCall teleportAssets({
-    required dest,
-    required beneficiary,
-    required assets,
-    required feeAssetItem,
+    required _i5.VersionedMultiLocation dest,
+    required _i5.VersionedMultiLocation beneficiary,
+    required _i17.VersionedMultiAssets assets,
+    required int feeAssetItem,
   }) {
-    final _call = _i15.Call.values.teleportAssets(
+    final _call = _i16.Call.values.teleportAssets(
       dest: dest,
       beneficiary: beneficiary,
       assets: assets,
@@ -497,12 +502,12 @@ class Txs {
 
   /// See [`Pallet::reserve_transfer_assets`].
   _i14.RuntimeCall reserveTransferAssets({
-    required dest,
-    required beneficiary,
-    required assets,
-    required feeAssetItem,
+    required _i5.VersionedMultiLocation dest,
+    required _i5.VersionedMultiLocation beneficiary,
+    required _i17.VersionedMultiAssets assets,
+    required int feeAssetItem,
   }) {
-    final _call = _i15.Call.values.reserveTransferAssets(
+    final _call = _i16.Call.values.reserveTransferAssets(
       dest: dest,
       beneficiary: beneficiary,
       assets: assets,
@@ -513,10 +518,10 @@ class Txs {
 
   /// See [`Pallet::execute`].
   _i14.RuntimeCall execute({
-    required message,
-    required maxWeight,
+    required _i18.VersionedXcm message,
+    required _i7.Weight maxWeight,
   }) {
-    final _call = _i15.Call.values.execute(
+    final _call = _i16.Call.values.execute(
       message: message,
       maxWeight: maxWeight,
     );
@@ -525,10 +530,10 @@ class Txs {
 
   /// See [`Pallet::force_xcm_version`].
   _i14.RuntimeCall forceXcmVersion({
-    required location,
-    required version,
+    required _i19.MultiLocation location,
+    required int version,
   }) {
-    final _call = _i15.Call.values.forceXcmVersion(
+    final _call = _i16.Call.values.forceXcmVersion(
       location: location,
       version: version,
     );
@@ -536,32 +541,32 @@ class Txs {
   }
 
   /// See [`Pallet::force_default_xcm_version`].
-  _i14.RuntimeCall forceDefaultXcmVersion({maybeXcmVersion}) {
-    final _call = _i15.Call.values.forceDefaultXcmVersion(maybeXcmVersion: maybeXcmVersion);
+  _i14.RuntimeCall forceDefaultXcmVersion({int? maybeXcmVersion}) {
+    final _call = _i16.Call.values.forceDefaultXcmVersion(maybeXcmVersion: maybeXcmVersion);
     return _i14.RuntimeCall.values.polkadotXcm(_call);
   }
 
   /// See [`Pallet::force_subscribe_version_notify`].
-  _i14.RuntimeCall forceSubscribeVersionNotify({required location}) {
-    final _call = _i15.Call.values.forceSubscribeVersionNotify(location: location);
+  _i14.RuntimeCall forceSubscribeVersionNotify({required _i5.VersionedMultiLocation location}) {
+    final _call = _i16.Call.values.forceSubscribeVersionNotify(location: location);
     return _i14.RuntimeCall.values.polkadotXcm(_call);
   }
 
   /// See [`Pallet::force_unsubscribe_version_notify`].
-  _i14.RuntimeCall forceUnsubscribeVersionNotify({required location}) {
-    final _call = _i15.Call.values.forceUnsubscribeVersionNotify(location: location);
+  _i14.RuntimeCall forceUnsubscribeVersionNotify({required _i5.VersionedMultiLocation location}) {
+    final _call = _i16.Call.values.forceUnsubscribeVersionNotify(location: location);
     return _i14.RuntimeCall.values.polkadotXcm(_call);
   }
 
   /// See [`Pallet::limited_reserve_transfer_assets`].
   _i14.RuntimeCall limitedReserveTransferAssets({
-    required dest,
-    required beneficiary,
-    required assets,
-    required feeAssetItem,
-    required weightLimit,
+    required _i5.VersionedMultiLocation dest,
+    required _i5.VersionedMultiLocation beneficiary,
+    required _i17.VersionedMultiAssets assets,
+    required int feeAssetItem,
+    required _i20.WeightLimit weightLimit,
   }) {
-    final _call = _i15.Call.values.limitedReserveTransferAssets(
+    final _call = _i16.Call.values.limitedReserveTransferAssets(
       dest: dest,
       beneficiary: beneficiary,
       assets: assets,
@@ -573,13 +578,13 @@ class Txs {
 
   /// See [`Pallet::limited_teleport_assets`].
   _i14.RuntimeCall limitedTeleportAssets({
-    required dest,
-    required beneficiary,
-    required assets,
-    required feeAssetItem,
-    required weightLimit,
+    required _i5.VersionedMultiLocation dest,
+    required _i5.VersionedMultiLocation beneficiary,
+    required _i17.VersionedMultiAssets assets,
+    required int feeAssetItem,
+    required _i20.WeightLimit weightLimit,
   }) {
-    final _call = _i15.Call.values.limitedTeleportAssets(
+    final _call = _i16.Call.values.limitedTeleportAssets(
       dest: dest,
       beneficiary: beneficiary,
       assets: assets,
@@ -590,8 +595,8 @@ class Txs {
   }
 
   /// See [`Pallet::force_suspension`].
-  _i14.RuntimeCall forceSuspension({required suspended}) {
-    final _call = _i15.Call.values.forceSuspension(suspended: suspended);
+  _i14.RuntimeCall forceSuspension({required bool suspended}) {
+    final _call = _i16.Call.values.forceSuspension(suspended: suspended);
     return _i14.RuntimeCall.values.polkadotXcm(_call);
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/proxy.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/proxy.dart
@@ -5,11 +5,14 @@ import 'dart:typed_data' as _i8;
 import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i5;
 
+import '../types/encointer_runtime/proxy_type.dart' as _i11;
 import '../types/encointer_runtime/runtime_call.dart' as _i9;
 import '../types/pallet_proxy/announcement.dart' as _i6;
-import '../types/pallet_proxy/pallet/call.dart' as _i10;
+import '../types/pallet_proxy/pallet/call.dart' as _i12;
 import '../types/pallet_proxy/proxy_definition.dart' as _i4;
+import '../types/primitive_types/h256.dart' as _i13;
 import '../types/sp_core/crypto/account_id32.dart' as _i2;
+import '../types/sp_runtime/multiaddress/multi_address.dart' as _i10;
 import '../types/tuples.dart' as _i3;
 
 class Queries {
@@ -108,11 +111,11 @@ class Txs {
 
   /// See [`Pallet::proxy`].
   _i9.RuntimeCall proxy({
-    required real,
-    forceProxyType,
-    required call,
+    required _i10.MultiAddress real,
+    _i11.ProxyType? forceProxyType,
+    required _i9.RuntimeCall call,
   }) {
-    final _call = _i10.Call.values.proxy(
+    final _call = _i12.Call.values.proxy(
       real: real,
       forceProxyType: forceProxyType,
       call: call,
@@ -122,11 +125,11 @@ class Txs {
 
   /// See [`Pallet::add_proxy`].
   _i9.RuntimeCall addProxy({
-    required delegate,
-    required proxyType,
-    required delay,
+    required _i10.MultiAddress delegate,
+    required _i11.ProxyType proxyType,
+    required int delay,
   }) {
-    final _call = _i10.Call.values.addProxy(
+    final _call = _i12.Call.values.addProxy(
       delegate: delegate,
       proxyType: proxyType,
       delay: delay,
@@ -136,11 +139,11 @@ class Txs {
 
   /// See [`Pallet::remove_proxy`].
   _i9.RuntimeCall removeProxy({
-    required delegate,
-    required proxyType,
-    required delay,
+    required _i10.MultiAddress delegate,
+    required _i11.ProxyType proxyType,
+    required int delay,
   }) {
-    final _call = _i10.Call.values.removeProxy(
+    final _call = _i12.Call.values.removeProxy(
       delegate: delegate,
       proxyType: proxyType,
       delay: delay,
@@ -150,17 +153,17 @@ class Txs {
 
   /// See [`Pallet::remove_proxies`].
   _i9.RuntimeCall removeProxies() {
-    final _call = _i10.Call.values.removeProxies();
+    final _call = _i12.Call.values.removeProxies();
     return _i9.RuntimeCall.values.proxy(_call);
   }
 
   /// See [`Pallet::create_pure`].
   _i9.RuntimeCall createPure({
-    required proxyType,
-    required delay,
-    required index,
+    required _i11.ProxyType proxyType,
+    required int delay,
+    required int index,
   }) {
-    final _call = _i10.Call.values.createPure(
+    final _call = _i12.Call.values.createPure(
       proxyType: proxyType,
       delay: delay,
       index: index,
@@ -170,13 +173,13 @@ class Txs {
 
   /// See [`Pallet::kill_pure`].
   _i9.RuntimeCall killPure({
-    required spawner,
-    required proxyType,
-    required index,
-    required height,
-    required extIndex,
+    required _i10.MultiAddress spawner,
+    required _i11.ProxyType proxyType,
+    required int index,
+    required BigInt height,
+    required BigInt extIndex,
   }) {
-    final _call = _i10.Call.values.killPure(
+    final _call = _i12.Call.values.killPure(
       spawner: spawner,
       proxyType: proxyType,
       index: index,
@@ -188,10 +191,10 @@ class Txs {
 
   /// See [`Pallet::announce`].
   _i9.RuntimeCall announce({
-    required real,
-    required callHash,
+    required _i10.MultiAddress real,
+    required _i13.H256 callHash,
   }) {
-    final _call = _i10.Call.values.announce(
+    final _call = _i12.Call.values.announce(
       real: real,
       callHash: callHash,
     );
@@ -200,10 +203,10 @@ class Txs {
 
   /// See [`Pallet::remove_announcement`].
   _i9.RuntimeCall removeAnnouncement({
-    required real,
-    required callHash,
+    required _i10.MultiAddress real,
+    required _i13.H256 callHash,
   }) {
-    final _call = _i10.Call.values.removeAnnouncement(
+    final _call = _i12.Call.values.removeAnnouncement(
       real: real,
       callHash: callHash,
     );
@@ -212,10 +215,10 @@ class Txs {
 
   /// See [`Pallet::reject_announcement`].
   _i9.RuntimeCall rejectAnnouncement({
-    required delegate,
-    required callHash,
+    required _i10.MultiAddress delegate,
+    required _i13.H256 callHash,
   }) {
-    final _call = _i10.Call.values.rejectAnnouncement(
+    final _call = _i12.Call.values.rejectAnnouncement(
       delegate: delegate,
       callHash: callHash,
     );
@@ -224,12 +227,12 @@ class Txs {
 
   /// See [`Pallet::proxy_announced`].
   _i9.RuntimeCall proxyAnnounced({
-    required delegate,
-    required real,
-    forceProxyType,
-    required call,
+    required _i10.MultiAddress delegate,
+    required _i10.MultiAddress real,
+    _i11.ProxyType? forceProxyType,
+    required _i9.RuntimeCall call,
   }) {
-    final _call = _i10.Call.values.proxyAnnounced(
+    final _call = _i12.Call.values.proxyAnnounced(
       delegate: delegate,
       real: real,
       forceProxyType: forceProxyType,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/scheduler.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/scheduler.dart
@@ -122,10 +122,10 @@ class Txs {
 
   /// See [`Pallet::schedule`].
   _i7.RuntimeCall schedule({
-    required when,
-    maybePeriodic,
-    required priority,
-    required call,
+    required int when,
+    _i4.Tuple2<int, int>? maybePeriodic,
+    required int priority,
+    required _i7.RuntimeCall call,
   }) {
     final _call = _i8.Call.values.schedule(
       when: when,
@@ -138,8 +138,8 @@ class Txs {
 
   /// See [`Pallet::cancel`].
   _i7.RuntimeCall cancel({
-    required when,
-    required index,
+    required int when,
+    required int index,
   }) {
     final _call = _i8.Call.values.cancel(
       when: when,
@@ -150,11 +150,11 @@ class Txs {
 
   /// See [`Pallet::schedule_named`].
   _i7.RuntimeCall scheduleNamed({
-    required id,
-    required when,
-    maybePeriodic,
-    required priority,
-    required call,
+    required List<int> id,
+    required int when,
+    _i4.Tuple2<int, int>? maybePeriodic,
+    required int priority,
+    required _i7.RuntimeCall call,
   }) {
     final _call = _i8.Call.values.scheduleNamed(
       id: id,
@@ -167,17 +167,17 @@ class Txs {
   }
 
   /// See [`Pallet::cancel_named`].
-  _i7.RuntimeCall cancelNamed({required id}) {
+  _i7.RuntimeCall cancelNamed({required List<int> id}) {
     final _call = _i8.Call.values.cancelNamed(id: id);
     return _i7.RuntimeCall.values.scheduler(_call);
   }
 
   /// See [`Pallet::schedule_after`].
   _i7.RuntimeCall scheduleAfter({
-    required after,
-    maybePeriodic,
-    required priority,
-    required call,
+    required int after,
+    _i4.Tuple2<int, int>? maybePeriodic,
+    required int priority,
+    required _i7.RuntimeCall call,
   }) {
     final _call = _i8.Call.values.scheduleAfter(
       after: after,
@@ -190,11 +190,11 @@ class Txs {
 
   /// See [`Pallet::schedule_named_after`].
   _i7.RuntimeCall scheduleNamedAfter({
-    required id,
-    required after,
-    maybePeriodic,
-    required priority,
-    required call,
+    required List<int> id,
+    required int after,
+    _i4.Tuple2<int, int>? maybePeriodic,
+    required int priority,
+    required _i7.RuntimeCall call,
   }) {
     final _call = _i8.Call.values.scheduleNamedAfter(
       id: id,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/system.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/system.dart
@@ -537,45 +537,45 @@ class Txs {
   const Txs();
 
   /// See [`Pallet::remark`].
-  _i16.RuntimeCall remark({required remark}) {
+  _i16.RuntimeCall remark({required List<int> remark}) {
     final _call = _i17.Call.values.remark(remark: remark);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::set_heap_pages`].
-  _i16.RuntimeCall setHeapPages({required pages}) {
+  _i16.RuntimeCall setHeapPages({required BigInt pages}) {
     final _call = _i17.Call.values.setHeapPages(pages: pages);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::set_code`].
-  _i16.RuntimeCall setCode({required code}) {
+  _i16.RuntimeCall setCode({required List<int> code}) {
     final _call = _i17.Call.values.setCode(code: code);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::set_code_without_checks`].
-  _i16.RuntimeCall setCodeWithoutChecks({required code}) {
+  _i16.RuntimeCall setCodeWithoutChecks({required List<int> code}) {
     final _call = _i17.Call.values.setCodeWithoutChecks(code: code);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::set_storage`].
-  _i16.RuntimeCall setStorage({required items}) {
+  _i16.RuntimeCall setStorage({required List<_i9.Tuple2<List<int>, List<int>>> items}) {
     final _call = _i17.Call.values.setStorage(items: items);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::kill_storage`].
-  _i16.RuntimeCall killStorage({required keys}) {
+  _i16.RuntimeCall killStorage({required List<List<int>> keys}) {
     final _call = _i17.Call.values.killStorage(keys: keys);
     return _i16.RuntimeCall.values.system(_call);
   }
 
   /// See [`Pallet::kill_prefix`].
   _i16.RuntimeCall killPrefix({
-    required prefix,
-    required subkeys,
+    required List<int> prefix,
+    required int subkeys,
   }) {
     final _call = _i17.Call.values.killPrefix(
       prefix: prefix,
@@ -585,7 +585,7 @@ class Txs {
   }
 
   /// See [`Pallet::remark_with_event`].
-  _i16.RuntimeCall remarkWithEvent({required remark}) {
+  _i16.RuntimeCall remarkWithEvent({required List<int> remark}) {
     final _call = _i17.Call.values.remarkWithEvent(remark: remark);
     return _i16.RuntimeCall.values.system(_call);
   }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/timestamp.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/timestamp.dart
@@ -68,7 +68,7 @@ class Txs {
   const Txs();
 
   /// See [`Pallet::set`].
-  _i5.RuntimeCall set({required now}) {
+  _i5.RuntimeCall set({required BigInt now}) {
     final _call = _i6.Call.values.set(now: now);
     return _i5.RuntimeCall.values.timestamp(_call);
   }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/treasury.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/treasury.dart
@@ -6,10 +6,11 @@ import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
 import '../types/encointer_runtime/runtime_call.dart' as _i6;
-import '../types/frame_support/pallet_id.dart' as _i9;
-import '../types/pallet_treasury/pallet/call.dart' as _i7;
+import '../types/frame_support/pallet_id.dart' as _i10;
+import '../types/pallet_treasury/pallet/call.dart' as _i8;
 import '../types/pallet_treasury/proposal.dart' as _i3;
-import '../types/sp_arithmetic/per_things/permill.dart' as _i8;
+import '../types/sp_arithmetic/per_things/permill.dart' as _i9;
+import '../types/sp_runtime/multiaddress/multi_address.dart' as _i7;
 
 class Queries {
   const Queries(this.__api);
@@ -136,10 +137,10 @@ class Txs {
 
   /// See [`Pallet::propose_spend`].
   _i6.RuntimeCall proposeSpend({
-    required value,
-    required beneficiary,
+    required BigInt value,
+    required _i7.MultiAddress beneficiary,
   }) {
-    final _call = _i7.Call.values.proposeSpend(
+    final _call = _i8.Call.values.proposeSpend(
       value: value,
       beneficiary: beneficiary,
     );
@@ -147,23 +148,23 @@ class Txs {
   }
 
   /// See [`Pallet::reject_proposal`].
-  _i6.RuntimeCall rejectProposal({required proposalId}) {
-    final _call = _i7.Call.values.rejectProposal(proposalId: proposalId);
+  _i6.RuntimeCall rejectProposal({required BigInt proposalId}) {
+    final _call = _i8.Call.values.rejectProposal(proposalId: proposalId);
     return _i6.RuntimeCall.values.treasury(_call);
   }
 
   /// See [`Pallet::approve_proposal`].
-  _i6.RuntimeCall approveProposal({required proposalId}) {
-    final _call = _i7.Call.values.approveProposal(proposalId: proposalId);
+  _i6.RuntimeCall approveProposal({required BigInt proposalId}) {
+    final _call = _i8.Call.values.approveProposal(proposalId: proposalId);
     return _i6.RuntimeCall.values.treasury(_call);
   }
 
   /// See [`Pallet::spend`].
   _i6.RuntimeCall spend({
-    required amount,
-    required beneficiary,
+    required BigInt amount,
+    required _i7.MultiAddress beneficiary,
   }) {
-    final _call = _i7.Call.values.spend(
+    final _call = _i8.Call.values.spend(
       amount: amount,
       beneficiary: beneficiary,
     );
@@ -171,8 +172,8 @@ class Txs {
   }
 
   /// See [`Pallet::remove_approval`].
-  _i6.RuntimeCall removeApproval({required proposalId}) {
-    final _call = _i7.Call.values.removeApproval(proposalId: proposalId);
+  _i6.RuntimeCall removeApproval({required BigInt proposalId}) {
+    final _call = _i8.Call.values.removeApproval(proposalId: proposalId);
     return _i6.RuntimeCall.values.treasury(_call);
   }
 }
@@ -182,7 +183,7 @@ class Constants {
 
   /// Fraction of a proposal's value that should be bonded in order to place the proposal.
   /// An accepted proposal gets these back. A rejected proposal does not.
-  final _i8.Permill proposalBond = 50000;
+  final _i9.Permill proposalBond = 50000;
 
   /// Minimum amount of funds that should be placed in a deposit for making a proposal.
   final BigInt proposalBondMinimum = BigInt.from(33333300);
@@ -194,10 +195,10 @@ class Constants {
   final int spendPeriod = 43200;
 
   /// Percentage of spare funds (if any) that are burnt per spend period.
-  final _i8.Permill burn = 0;
+  final _i9.Permill burn = 0;
 
   /// The treasury's pallet id, used for deriving its sovereign account ID.
-  final _i9.PalletId palletId = const <int>[
+  final _i10.PalletId palletId = const <int>[
     112,
     121,
     47,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/utility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/utility.dart
@@ -1,20 +1,22 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import '../types/encointer_runtime/origin_caller.dart' as _i3;
 import '../types/encointer_runtime/runtime_call.dart' as _i1;
 import '../types/pallet_utility/pallet/call.dart' as _i2;
+import '../types/sp_weights/weight_v2/weight.dart' as _i4;
 
 class Txs {
   const Txs();
 
   /// See [`Pallet::batch`].
-  _i1.RuntimeCall batch({required calls}) {
+  _i1.RuntimeCall batch({required List<_i1.RuntimeCall> calls}) {
     final _call = _i2.Call.values.batch(calls: calls);
     return _i1.RuntimeCall.values.utility(_call);
   }
 
   /// See [`Pallet::as_derivative`].
   _i1.RuntimeCall asDerivative({
-    required index,
-    required call,
+    required int index,
+    required _i1.RuntimeCall call,
   }) {
     final _call = _i2.Call.values.asDerivative(
       index: index,
@@ -24,15 +26,15 @@ class Txs {
   }
 
   /// See [`Pallet::batch_all`].
-  _i1.RuntimeCall batchAll({required calls}) {
+  _i1.RuntimeCall batchAll({required List<_i1.RuntimeCall> calls}) {
     final _call = _i2.Call.values.batchAll(calls: calls);
     return _i1.RuntimeCall.values.utility(_call);
   }
 
   /// See [`Pallet::dispatch_as`].
   _i1.RuntimeCall dispatchAs({
-    required asOrigin,
-    required call,
+    required _i3.OriginCaller asOrigin,
+    required _i1.RuntimeCall call,
   }) {
     final _call = _i2.Call.values.dispatchAs(
       asOrigin: asOrigin,
@@ -42,15 +44,15 @@ class Txs {
   }
 
   /// See [`Pallet::force_batch`].
-  _i1.RuntimeCall forceBatch({required calls}) {
+  _i1.RuntimeCall forceBatch({required List<_i1.RuntimeCall> calls}) {
     final _call = _i2.Call.values.forceBatch(calls: calls);
     return _i1.RuntimeCall.values.utility(_call);
   }
 
   /// See [`Pallet::with_weight`].
   _i1.RuntimeCall withWeight({
-    required call,
-    required weight,
+    required _i1.RuntimeCall call,
+    required _i4.Weight weight,
   }) {
     final _call = _i2.Call.values.withWeight(
       call: call,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/xcmp_queue.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/xcmp_queue.dart
@@ -383,8 +383,8 @@ class Txs {
 
   /// See [`Pallet::service_overweight`].
   _i11.RuntimeCall serviceOverweight({
-    required index,
-    required weightLimit,
+    required BigInt index,
+    required _i9.Weight weightLimit,
   }) {
     final _call = _i12.Call.values.serviceOverweight(
       index: index,
@@ -406,37 +406,37 @@ class Txs {
   }
 
   /// See [`Pallet::update_suspend_threshold`].
-  _i11.RuntimeCall updateSuspendThreshold({required new_}) {
+  _i11.RuntimeCall updateSuspendThreshold({required int new_}) {
     final _call = _i12.Call.values.updateSuspendThreshold(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }
 
   /// See [`Pallet::update_drop_threshold`].
-  _i11.RuntimeCall updateDropThreshold({required new_}) {
+  _i11.RuntimeCall updateDropThreshold({required int new_}) {
     final _call = _i12.Call.values.updateDropThreshold(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }
 
   /// See [`Pallet::update_resume_threshold`].
-  _i11.RuntimeCall updateResumeThreshold({required new_}) {
+  _i11.RuntimeCall updateResumeThreshold({required int new_}) {
     final _call = _i12.Call.values.updateResumeThreshold(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }
 
   /// See [`Pallet::update_threshold_weight`].
-  _i11.RuntimeCall updateThresholdWeight({required new_}) {
+  _i11.RuntimeCall updateThresholdWeight({required _i9.Weight new_}) {
     final _call = _i12.Call.values.updateThresholdWeight(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }
 
   /// See [`Pallet::update_weight_restrict_decay`].
-  _i11.RuntimeCall updateWeightRestrictDecay({required new_}) {
+  _i11.RuntimeCall updateWeightRestrictDecay({required _i9.Weight new_}) {
     final _call = _i12.Call.values.updateWeightRestrictDecay(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }
 
   /// See [`Pallet::update_xcmp_max_individual_weight`].
-  _i11.RuntimeCall updateXcmpMaxIndividualWeight({required new_}) {
+  _i11.RuntimeCall updateXcmpMaxIndividualWeight({required _i9.Weight new_}) {
     final _call = _i12.Call.values.updateXcmpMaxIndividualWeight(new_: new_);
     return _i11.RuntimeCall.values.xcmpQueue(_call);
   }

--- a/packages/ew_polkadart/pubspec.lock
+++ b/packages/ew_polkadart/pubspec.lock
@@ -366,16 +366,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.3.1"
+    version: "0.3.2"
   polkadart_cli:
     dependency: "direct dev"
     description:
       path: "packages/polkadart_cli"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.1"
@@ -384,7 +384,7 @@ packages:
     description:
       path: "packages/polkadart_keyring"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.0"
@@ -393,7 +393,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"
@@ -570,7 +570,7 @@ packages:
     description:
       path: "packages/substrate_metadata"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"

--- a/packages/ew_primitives/pubspec.lock
+++ b/packages/ew_primitives/pubspec.lock
@@ -355,16 +355,16 @@ packages:
     description:
       path: "packages/polkadart"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
-    version: "0.3.1"
+    version: "0.3.2"
   polkadart_keyring:
     dependency: "direct overridden"
     description:
       path: "packages/polkadart_keyring"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "0.3.0"
@@ -373,7 +373,7 @@ packages:
     description:
       path: "packages/polkadart_scale_codec"
       ref: "cl/encointer-signed-extensions"
-      resolved-ref: e49a0ed2c89208c008889ef0f4fe9ad04422bf38
+      resolved-ref: "553ad7f8c2281182a62707c8b2af46aee4f8f32a"
       url: "https://github.com/encointer/polkadart"
     source: git
     version: "1.1.2"


### PR DESCRIPTION
Bump polkadart to get PR https://github.com/leonardocustodio/polkadart/pull/409, and regenerate types afterwards.

This gives us compile time type safety, before those types were implicitly dynamic.
