### PR TITLE
Fix: Refresh balance immediately after starting the app for the first time and when adding a new account

### DIFF
--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -447,18 +447,11 @@ class _AssetsViewState extends State<AssetsView> {
       Log.d('[home:refreshBalanceAndNotify] getEncointerBalance', 'Assets');
 
       final community = widget.store.encointer.community!;
-      final oldBalanceEntry =
-          widget.store.encointer.accountStores?[widget.store.account.currentAddress]?.balanceEntries[cidStr];
-      final demurrageRate = community.demurrage!;
-      final newBalance = community.applyDemurrage != null ? community.applyDemurrage!(balanceEntry) ?? 0 : 0;
-      final oldBalance = (community.applyDemurrage != null && oldBalanceEntry != null)
-          ? community.applyDemurrage!(oldBalanceEntry) ?? 0
-          : 0;
+      final demurrageRate = widget.store.encointer.community!.demurrage!;
 
-      final delta = newBalance - oldBalance;
-      widget.store.encointer.account?.addBalanceEntry(chosenCid, balanceEntry);
+      final delta = widget.store.encointer.account!
+          .addBalanceEntryAndReturnDelta(chosenCid, balanceEntry, community.applyDemurrage!);
 
-      Log.d('[home:refreshBalanceAndNotify] balance for $cidStr was $oldBalance, changed by $delta', 'Assets');
       if (delta.abs() > demurrageRate) {
         if (delta > demurrageRate) {
           final msg = l10n.incomingConfirmed(

--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -452,6 +452,8 @@ class _AssetsViewState extends State<AssetsView> {
       final delta = widget.store.encointer.account!
           .addBalanceEntryAndReturnDelta(chosenCid, balanceEntry, community.applyDemurrage!);
 
+      Log.d('[home:refreshBalanceAndNotify] getEncointerBalance balance delta: $delta', 'Assets');
+
       if (delta.abs() > demurrageRate) {
         if (delta > demurrageRate) {
           final msg = l10n.incomingConfirmed(

--- a/app/lib/store/encointer/encointer.dart
+++ b/app/lib/store/encointer/encointer.dart
@@ -348,6 +348,7 @@ abstract class _EncointerStore with Store {
       webApi.encointer.getReputations(),
       webApi.encointer.getMeetupTime(),
       webApi.encointer.getMeetupTimeOverride(),
+      getEncointerBalance(),
       updateAggregatedAccountData(),
     ]).timeout(const Duration(seconds: 15)).catchError((Object? e, s) {
       Log.e('Error executing update state: $e', 'EncointerStore');
@@ -358,6 +359,17 @@ abstract class _EncointerStore with Store {
     });
 
     await _updateStateFuture!;
+  }
+
+  Future<void> getEncointerBalance() async {
+    final currentAddress = _rootStore.account.currentAddress;
+
+    if (currentAddress.isEmpty || chosenCid == null) {
+      Log.d('[getEncointerBalance] address empty or chosenCid == null', 'EncointerStore');
+    }
+
+    final balanceEntry = await webApi.encointer.getEncointerBalance(currentAddress, chosenCid!);
+    _rootStore.encointer.account?.addBalanceEntry(chosenCid!, balanceEntry);
   }
 
   Future<void> updateAggregatedAccountData() async {

--- a/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
+++ b/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.dart
@@ -105,6 +105,25 @@ abstract class _EncointerAccountStore with Store {
   }
 
   @action
+  double addBalanceEntryAndReturnDelta(
+    CommunityIdentifier cid,
+    BalanceEntry balanceEntry,
+    double? Function(BalanceEntry) demurrageFn,
+  ) {
+    final cidStr = cid.toFmtString();
+    Log.d('balanceEntry $balanceEntry added to cid $cidStr added', 'EncointerAccountStore');
+
+    final oldBalanceEntry = balanceEntries[cidStr];
+    final oldBalance = oldBalanceEntry != null ? demurrageFn(oldBalanceEntry) ?? 0 : 0;
+    final newBalance = demurrageFn(balanceEntry) ?? 0;
+
+    balanceEntries[cid.toFmtString()] = balanceEntry;
+    writeToCache();
+
+    return newBalance - oldBalance;
+  }
+
+  @action
   Future<void> setReputations(Map<int, CommunityReputation> reps) async {
     reputations = reps;
     unawaited(writeToCache());

--- a/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.g.dart
+++ b/app/lib/store/encointer/sub_stores/encointer_account_store/encointer_account_store.g.dart
@@ -176,6 +176,18 @@ mixin _$EncointerAccountStore on _EncointerAccountStore, Store {
   }
 
   @override
+  double addBalanceEntryAndReturnDelta(
+      CommunityIdentifier cid, BalanceEntry balanceEntry, double? Function(BalanceEntry) demurrageFn) {
+    final _$actionInfo = _$_EncointerAccountStoreActionController.startAction(
+        name: '_EncointerAccountStore.addBalanceEntryAndReturnDelta');
+    try {
+      return super.addBalanceEntryAndReturnDelta(cid, balanceEntry, demurrageFn);
+    } finally {
+      _$_EncointerAccountStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   void purgeReputations() {
     final _$actionInfo =
         _$_EncointerAccountStoreActionController.startAction(name: '_EncointerAccountStore.purgeReputations');


### PR DESCRIPTION
This removes the kind of hacky balance watchdog we had implemented. The reason is that it was for some reason very slow to update, and that showing the notifications of incoming balance diffs was broken anyhow since some flutter update. I suggest re-introducing this notification with the indexer instead, such that we can actually show incoming transfers instead of incoming balance diffs, https://github.com/encointer/encointer-wallet-flutter/issues/1656. Also, this fixes the jumping balance after a network switch. Closes #1530.

I integrated the periodic update of the encointer balance into the overall state update. As the balance update is now blazingly fast, I simplified the getter to only fetch the balance for the currently chosen community instead of getting the non-zero balances of all communities. This removed quite some complexity o f the callback function. However, we might want to integrate the RPC to get all balances in another way: https://github.com/encointer/encointer-wallet-flutter/issues/1655