### PR TITLE
Fix app stale at sending extrinsics aka fix occasional invalid extrinsic

### DIFF
--- a/app/lib/service/tx/lib/src/send_tx_dart.dart
+++ b/app/lib/service/tx/lib/src/send_tx_dart.dart
@@ -127,7 +127,7 @@ class EWAuthorApi<P extends Provider> {
     String? blockHashHex;
 
     final sub = await submitAndWatchExtrinsic(extrinsic, (xtUpdate) async {
-      Log.d('ExtrinsicUpdate: ${xtUpdate.type}');
+      Log.d('ExtrinsicUpdate: type: ${xtUpdate.type}, value: ${xtUpdate.value}');
 
       if (xtUpdate.type == 'ready') {
         Log.p('Xt is ready');

--- a/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
+++ b/app/lib/service/tx/lib/src/submit_tx_wrappers.dart
@@ -78,7 +78,8 @@ Future<void> submitClaimRewards(
     onFinish: (BuildContext txPageContext, ExtrinsicReport report) {
       // Claiming the rewards creates a new reputation if successful.
       // Hence, we should update the state afterwards.
-      store.dataUpdate.setInvalidated();
+      store.encointer.getEncointerBalance();
+      webApi.encointer.getReputations();
       return report;
     },
   );

--- a/app/lib/service/tx/lib/src/tx_builder.dart
+++ b/app/lib/service/tx/lib/src/tx_builder.dart
@@ -32,7 +32,7 @@ class TxBuilder {
     // fetch recent relevant data from chain
     final runtimeVersion = await _getRuntimeVersion();
     final blockNumber = await _getBlockNumber();
-    final blockHash = await _getBlockHash();
+    final blockHash = await _getBlockHash(blockNumber: blockNumber);
     final genesisHash = await _getBlockHash(blockNumber: 0);
     final accountInfo = await encointerKusama.query.system.account(pair.publicKey.bytes);
 


### PR DESCRIPTION
This PR implements the idea from https://github.com/encointer/encointer-wallet-flutter/issues/1659#issuecomment-2008617012. In the signed extension, we use now the latest finalized block hash instead of the best block hash. This indeed fixes the invalid transaction if it is resubmitted from a retracted block. I did some extensive testing, namely did multiple meetups and sent arbitrary transactions, to ensure with high probability that the issue is fixed.

Closes #1659.