### PR TITLE
[Announcements] parse links in community announcements and open the browser upon tapping

### DIFF
--- a/app/lib/page/assets/announcement/widgets/announcement_card.dart
+++ b/app/lib/page/assets/announcement/widgets/announcement_card.dart
@@ -1,8 +1,10 @@
+import 'package:encointer_wallet/service/launch/app_launch.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
 
 import 'package:encointer_wallet/page/assets/announcement/widgets/publisher_and_community_icon.dart';
 import 'package:encointer_wallet/page/assets/announcement/logic/announcement_card_store.dart';
@@ -58,8 +60,9 @@ class AnnouncementCard extends StatelessWidget {
             ),
             Padding(
               padding: const EdgeInsets.only(bottom: 20, right: 20, left: 20),
-              child: Text(
-                announcement.content,
+              child: Linkify(
+                onOpen: (link) => AppLaunch.launchURL(link.url),
+                text: announcement.content,
                 style: context.bodyMedium.copyWith(height: 1.5),
               ),
             ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -523,6 +523,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  flutter_linkify:
+    dependency: "direct main"
+    description:
+      name: flutter_linkify
+      sha256: "74669e06a8f358fee4512b4320c0b80e51cffc496607931de68d28f099254073"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -839,6 +847,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.0"
+  linkify:
+    dependency: transitive
+    description:
+      name: linkify
+      sha256: "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   lists:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   provider: ^6.1.1
   flutter_map_marker_popup: ^6.1.2
   flutter_map: ^6.1.0
+  flutter_linkify: ^6.0.0 # Automatically transform http(s) links to inline links.
   dart_geohash: ^2.0.2 # Todo: #1270: replace with alternative package
   iconsax: ^0.0.8 # Todo: #1271: replace with alternative package
   add_2_calendar: ^3.0.1


### PR DESCRIPTION
There is a test message in the dev feed that shows how it works: https://github.com/encointer/feed/commit/e03ae976f71aa20aec999e086e94b35e8e2ec95c. This dev message is displayed in dev mode.

Closes #1666

Follow-up issue to have more customizability with links: https://github.com/encointer/encointer-wallet-flutter/issues/1669