### PR TITLE
Fix notifications on Android

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -106,5 +106,5 @@ dependencies {
     // Bug: Failed to transform window-java-1.0.0-beta04.jar (androidx.window:window-java:1.0.0-beta04)
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
 }

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -42,10 +42,23 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- Enable display of schedule notifications       -->
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- local_auth -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <!-- Needed to persist scheduled notifications after reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <queries>
         <!-- Needed to open URLs as of Android 11 -->
         <intent>

--- a/app/lib/service/notification/lib/src/ceremony_notifications.dart
+++ b/app/lib/service/notification/lib/src/ceremony_notifications.dart
@@ -1,4 +1,5 @@
 import 'package:encointer_wallet/l10n/l10.dart';
+import 'package:encointer_wallet/service/log/log_service.dart';
 import 'package:encointer_wallet/service/notification/lib/notification.dart';
 
 /// Manages meetups reminder notifications.
@@ -47,6 +48,14 @@ class CeremonyNotifications {
     int numberOfCyclesToSchedule = 5,
     String? cid,
   }) async {
+    if (DateTime.now().isAfter(DateTime.fromMillisecondsSinceEpoch(nextRegisteringPhase))) {
+      // Doesn't happen except for occasionally on first app startup. So we don't care about it.
+      Log.e(
+        '[CeremonyNotifications] nextRegisteringPhase is in the past: ${DateTime.fromMillisecondsSinceEpoch(nextRegisteringPhase)}',
+      );
+      return;
+    }
+
     for (var i = 0; i < numberOfCyclesToSchedule; i++) {
       // calculate the scheduled date by adding i*ceremonyCycleDuration to nextRegisteringPhase
       final scheduledDate = DateTime.fromMillisecondsSinceEpoch(nextRegisteringPhase + i * ceremonyCycleDuration);

--- a/app/lib/service/notification/lib/src/ceremony_notifications.dart
+++ b/app/lib/service/notification/lib/src/ceremony_notifications.dart
@@ -49,7 +49,7 @@ class CeremonyNotifications {
     String? cid,
   }) async {
     if (DateTime.now().isAfter(DateTime.fromMillisecondsSinceEpoch(nextRegisteringPhase))) {
-      // Doesn't happen except for occasionally on first app startup. So we don't care about it.
+      // Doesn't happen except occasionally on first app startup. So we don't care about it.
       Log.e(
         '[CeremonyNotifications] nextRegisteringPhase is in the past: ${DateTime.fromMillisecondsSinceEpoch(nextRegisteringPhase)}',
       );

--- a/app/lib/service/notification/lib/src/notification_plugin.dart
+++ b/app/lib/service/notification/lib/src/notification_plugin.dart
@@ -118,7 +118,7 @@ class NotificationPlugin {
       tz.TZDateTime.from(scheduledDate, tz.local),
       _platformChannelSpecifics(body, cid: cid),
       uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      androidScheduleMode: AndroidScheduleMode.inexact,
     );
   }
 }

--- a/app/lib/service/notification/lib/src/notification_plugin.dart
+++ b/app/lib/service/notification/lib/src/notification_plugin.dart
@@ -39,7 +39,10 @@ class NotificationPlugin {
     Log.d('notification_plugin initialised: $initialised', 'main.dart');
   }
 
-  static void init(BuildContext context) => _requestIOSPermissions();
+  static void init(BuildContext context) {
+    _requestAndroidPermissions();
+    _requestIOSPermissions();
+  }
 
   static void _requestIOSPermissions() {
     flutterLocalNotificationsPlugin
@@ -49,6 +52,12 @@ class NotificationPlugin {
           badge: true,
           sound: true,
         );
+  }
+
+  static void _requestAndroidPermissions() {
+    flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
   }
 
   static AndroidNotificationDetails _androidPlatformChannelSpecifics(String body, String sound) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -542,26 +542,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: bb5cd63ff7c91d6efe452e41d0d0ae6348925c82eafd10ce170ef585ea04776e
+      sha256: "49eeef364fddb71515bc78d5a8c51435a68bccd6e4d68e25a942c5e47761ae71"
       url: "https://pub.dev"
     source: hosted
-    version: "16.2.0"
+    version: "17.2.3"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0+1"
+    version: "4.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0+1"
+    version: "7.2.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   mobx: ^2.3.0+1
   flutter_mobx: ^2.2.0+2
   shared_preferences: ^2.2.2
-  flutter_local_notifications: ^16.2.0
+  flutter_local_notifications: ^17.2.3
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
## Changes:
* For some reason, we didn't check if notification permissions were given on Android. This is now checked upon startup and the user is prompted to allow notifications.

### Fix Scheduled Notifications on Android
* Fix android manifest to show scheduled permissions and to persist scheduled notifications after a reboot
* Android > 13 doesn't allow exact scheduling of notifications, which resulted in an error.  We simply relaxed our scheduling to inexact, as we are not building a precise alarm app.

