### PR TITLE
run android integration tests on ubuntu as hardware acceleration is supported now

### DIFF
--- a/.github/workflows/android_integration_test.yml
+++ b/.github/workflows/android_integration_test.yml
@@ -25,7 +25,7 @@ jobs:
         # lower api-levels would be supported but the webView that is pre-installed on these images does not.
         api-level: [33]
         include:
-          - os: macos-12 # Macos 13 is broken currently.
+          - os: ubuntu-latest
             # needs to be the `id` from the devices given by `avdmanager list device`
             device: "pixel_3a"
             # disable for now. it takes ages to build and launch the app and the upper limit of
@@ -40,6 +40,12 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Install flutter wrapper
         run: ./scripts/install_flutter_wrapper.sh
@@ -72,11 +78,6 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-${{ matrix.device }}
-
-      - name: Start colima a docker runtime for MacOs
-        run: |
-          brew install docker
-          colima start
 
       - name: Run encointer-node
         run: ./scripts/docker_run_encointer_node_notee.sh &


### PR DESCRIPTION
This improves the CI speed and stability as the docker setup on macos was a pain in the ass