### PR TITLE
[Democracy] fix proposal initial value sanitation

### DIFF
--- a/app/lib/page-encointer/democracy/widgets/proposal_tile.dart
+++ b/app/lib/page-encointer/democracy/widgets/proposal_tile.dart
@@ -58,9 +58,9 @@ class _ProposalTileState extends State<ProposalTile> {
     final l10n = context.l10n;
     final titleSmall = context.titleMedium;
 
-    final turnout = tally.turnout;
+    final turnout = tally.turnout.toInt();
     final electorateSize = proposal.electorateSize;
-    final threshold = approvalThreshold(electorateSize.toInt(), turnout.toInt());
+    final threshold = approvalThreshold(electorateSize.toInt(), turnout);
 
     return Container(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
@@ -87,8 +87,8 @@ class _ProposalTileState extends State<ProposalTile> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text('${l10n.proposalTurnout}: $turnout / $electorateSize'),
-                  if (threshold != 0) Text(l10n.proposalApprovalThreshold((threshold * 100).toStringAsFixed(2))),
-                  if (threshold != 0) passingOrFailingText(context, proposal, tally, widget.params),
+                  if (turnout != 0) Text(l10n.proposalApprovalThreshold((threshold * 100).toStringAsFixed(2))),
+                  if (turnout != 0) passingOrFailingText(context, proposal, tally, widget.params),
                 ],
               ),
             ),

--- a/app/lib/page-encointer/democracy/widgets/proposal_tile.dart
+++ b/app/lib/page-encointer/democracy/widgets/proposal_tile.dart
@@ -80,13 +80,17 @@ class _ProposalTileState extends State<ProposalTile> {
           ListTile(
             contentPadding: const EdgeInsets.symmetric(),
             leading: Text(widget.proposalId.toString(), style: titleSmall),
-            subtitle: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('${l10n.proposalTurnout}: $turnout / $electorateSize'),
-                Text(l10n.proposalApprovalThreshold((threshold * 100).toStringAsFixed(2))),
-                passingOrFailingText(context, proposal, tally, widget.params)
-              ],
+            subtitle: SizedBox(
+              // ensure constant height even for missing texts without turnout.
+              height: 60,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('${l10n.proposalTurnout}: $turnout / $electorateSize'),
+                  if (threshold != 0) Text(l10n.proposalApprovalThreshold((threshold * 100).toStringAsFixed(2))),
+                  if (threshold != 0) passingOrFailingText(context, proposal, tally, widget.params),
+                ],
+              ),
             ),
             trailing: voteButtonOrProposalStatus(context),
           ),


### PR DESCRIPTION
Closes #1715. 

Solution, simply hide the misleading texts in case there is 0 turnout. See:

![image](https://github.com/user-attachments/assets/e00e6d5d-b244-4e4e-9595-c15d4786c659)
