### PR TITLE
[proposePage] only bootstrappers or reputables can submit a proposal

### DIFF
--- a/app/lib/l10n/arb/app_de.arb
+++ b/app/lib/l10n/arb/app_de.arb
@@ -240,6 +240,7 @@
     "proposalFieldErrorPositiveNumberRange": "Muss eine positive Zahl sein",
     "proposalFieldErrorEnterInactivityTimeout": "Inaktivitätszeitlimit eingeben",
     "proposalFieldErrorPositiveIntegerRange": "Muss eine positive ganze Zahl sein",
+    "proposalOnlyBootstrappersOrReputablesCanSubmit": "Nur Bootstrappers oder Reputables können einen Vorschlag einreichen.",
     "proposalSubmit": "Vorschlag einreichen",
     "proposalSuperseded": "Verdrängt",
     "proposalRejected": "Abgelehnt",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -240,6 +240,7 @@
     "proposalFieldErrorPositiveNumberRange": "Must be a positive number",
     "proposalFieldErrorEnterInactivityTimeout": "Enter inactivity timeout",
     "proposalFieldErrorPositiveIntegerRange": "Must be a positive integer",
+    "proposalOnlyBootstrappersOrReputablesCanSubmit": "Only bootstrappers or reputables can submit a proposal.",
     "proposalSubmit": "Submit Proposal",
     "proposalSuperseded": "Superseded",
     "proposalRejected": "Rejected",

--- a/app/lib/l10n/arb/app_fr.arb
+++ b/app/lib/l10n/arb/app_fr.arb
@@ -240,6 +240,7 @@
     "proposalFieldErrorPositiveNumberRange": "Doit être un nombre positif",
     "proposalFieldErrorEnterInactivityTimeout": "Entrez le délai d'inactivité",
     "proposalFieldErrorPositiveIntegerRange": "Doit être un entier positif",
+    "proposalOnlyBootstrappersOrReputablesCanSubmit": "Seuls les bootstrappers ou les Reputables peuvent soumettre une proposition.",
     "proposalSubmit": "Soumettre une proposition",
     "proposalSuperseded": "Epargné",
     "proposalRejected": "Refusé",

--- a/app/lib/l10n/arb/app_ru.arb
+++ b/app/lib/l10n/arb/app_ru.arb
@@ -240,6 +240,7 @@
     "proposalFieldErrorPositiveNumberRange": "Должно быть положительное число",
     "proposalFieldErrorEnterInactivityTimeout": "Введите тайм-аут неактивности",
     "proposalFieldErrorPositiveIntegerRange": "Должно быть положительное целое число",
+    "proposalOnlyBootstrappersOrReputablesCanSubmit": "Только бутстраперы или уважаемые участники могут подать предложение.",
     "proposalSubmit": "Подать предложение",
     "proposalRejected": "Отменено",
     "proposalSuperseded": "заменен",

--- a/app/lib/l10n/arb/app_sw.arb
+++ b/app/lib/l10n/arb/app_sw.arb
@@ -240,6 +240,7 @@
     "proposalFieldErrorPositiveNumberRange": "Lazima iwe namba chanya",
     "proposalFieldErrorEnterInactivityTimeout": "Weka muda wa kutokufanya kazi",
     "proposalFieldErrorPositiveIntegerRange": "Lazima iwe namba kamili chanya",
+    "proposalOnlyBootstrappersOrReputablesCanSubmit": "Ni bootstrappers au waheshimika pekee wanaoweza kuwasilisha pendekezo.",
     "proposalSubmit": "Wasilisha Pendekezo",
     "proposalSuperseded": "Iliyopita",
     "proposalRejected": "Imekaataliwa",

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -92,7 +92,7 @@ class _ProposePageState extends State<ProposePage> {
 
   @override
   Widget build(BuildContext context) {
-    // final store = context.read<AppStore>();
+    final store = context.read<AppStore>();
     final l10n = context.l10n;
 
     return Scaffold(
@@ -158,12 +158,16 @@ class _ProposePageState extends State<ProposePage> {
 
                 // Submit Button
                 const Spacer(),
+                if (!isBootstrapperOrReputable(store, store.account.currentAddress))
+                  Text(l10n.proposalOnlyBootstrappersOrReputablesCanSubmit, textAlign: TextAlign.center),
                 SubmitButton(
-                  onPressed: (context) async {
-                    _formKey.currentState!.validate();
-                    await _submitProposal();
-                    Navigator.of(context).pop();
-                  },
+                  onPressed: isBootstrapperOrReputable(store, store.account.currentAddress)
+                      ? (context) async {
+                          _formKey.currentState!.validate();
+                          await _submitProposal();
+                          Navigator.of(context).pop();
+                        }
+                      : null, // disable button for non-bootstrappers/reputables
                   child: Text(l10n.proposalSubmit),
                 ),
               ],
@@ -504,6 +508,11 @@ class _ProposePageState extends State<ProposePage> {
         return null;
       }
     }
+  }
+
+  bool isBootstrapperOrReputable(AppStore store, String address) {
+    return store.encointer.community!.bootstrappers!.contains(address) ||
+        store.encointer.accountStores![address]!.verifiedReputations.isNotEmpty;
   }
 
   /// Validates Inactivity Timeout (Only positive integers)


### PR DESCRIPTION
* Closes #1758.

### Tests
* Tested manually that:
   - [x] submitting a proposal with a bootstrapper works
   - [x] submitting a proposal with a reputable works 
   - [x] submit button is disabled for non-bootstrapper/reputable aka newbie