### PR TITLE
Prevent submitting new proposals of a proposal type already pending enactment

### DIFF
--- a/app/lib/l10n/arb/app_de.arb
+++ b/app/lib/l10n/arb/app_de.arb
@@ -209,6 +209,7 @@
     "proposalNew": "Neuer Vorschlag",
     "proposalType": "Vorschlagstyp",
     "proposalTypeAddLocation": "Standort hinzufügen",
+    "proposalTypeRemoveLocation": "Standort entfernen",
     "proposalTypeUpdateDemurrage": "Demurrage aktualisieren",
     "proposalTypeUpdateNominalIncome": "Grundeinkommen aktualisieren",
     "proposalTypeSetInactivityTimeout": "Inaktivitätszeitlimit festlegen",

--- a/app/lib/l10n/arb/app_de.arb
+++ b/app/lib/l10n/arb/app_de.arb
@@ -246,6 +246,7 @@
     "proposalUpdateState": "Aktualisieren",
     "proposalUpdateExplanation": "Dies wird den Status des Vorschlags aktualisieren. Wenn er zu alt ist und nicht genügend Aye-Stimmen hat, wird er abgelehnt. Wenn er lange genug bestätigt wurde, wird er angenommen.",
     "proposalOnlyBootstrappersOrReputablesCanSubmit": "Nur Bootstrappers oder Reputables können einen Vorschlag einreichen.",
+    "proposalCannotSubmitProposalTypePendingEnactment": "Ein Vorschlag dieses Typs kann nicht eingereicht werden, da bereits einer auf die Umsetzung wartet.",
     "proposalSubmit": "Vorschlag einreichen",
     "proposalSuperseded": "Verdrängt",
     "proposalRejected": "Abgelehnt",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -209,6 +209,7 @@
     "proposalNew": "New Proposal",
     "proposalType": "Proposal Type",
     "proposalTypeAddLocation": "Add location",
+    "proposalTypeRemoveLocation": "Remove location",
     "proposalTypeUpdateDemurrage": "Update Demurrage",
     "proposalTypeUpdateNominalIncome": "Update Nominal Income",
     "proposalTypeSetInactivityTimeout": "Set Inactivity Timeout",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -243,6 +243,7 @@
     "proposalFieldErrorEnterInactivityTimeout": "Enter inactivity timeout",
     "proposalFieldErrorPositiveIntegerRange": "Must be a positive integer",
     "proposalOnlyBootstrappersOrReputablesCanSubmit": "Only bootstrappers or reputables can submit a proposal.",
+    "proposalCannotSubmitProposalTypePendingEnactment": "Cannot submit a proposal of this type, as there is already one pending enactment.",
     "proposalClose": "Close",
     "proposalUpdateState": "Update",
     "proposalUpdateExplanation": "This will update the proposal state. If it is too old and does not have enough Aye votes, it will be rejected. If it has been confirming long enough, it will pass.",

--- a/app/lib/l10n/arb/app_fr.arb
+++ b/app/lib/l10n/arb/app_fr.arb
@@ -209,6 +209,7 @@
     "proposalNew": "Nouvelle Proposition",
     "proposalType": "Type de proposition",
     "proposalTypeAddLocation": "Ajouter un lieu",
+    "proposalTypeRemoveLocation": "Retrancher un lieu",
     "proposalTypeUpdateDemurrage": "Mettre à jour la démurrage",
     "proposalTypeUpdateNominalIncome": "Mettre à jour le revenu nominal",
     "proposalTypeSetInactivityTimeout": "Définir le délai d'inactivité",

--- a/app/lib/l10n/arb/app_fr.arb
+++ b/app/lib/l10n/arb/app_fr.arb
@@ -243,6 +243,7 @@
     "proposalFieldErrorEnterInactivityTimeout": "Entrez le délai d'inactivité",
     "proposalFieldErrorPositiveIntegerRange": "Doit être un entier positif",
     "proposalOnlyBootstrappersOrReputablesCanSubmit": "Seuls les bootstrappers ou les Reputables peuvent soumettre une proposition.",
+    "proposalCannotSubmitProposalTypePendingEnactment": "Impossible de soumettre une proposition de ce type, car une autre est déjà en attente d'adoption.",
     "proposalClose": "Fermer",
     "proposalUpdateState": "Mettre à jour",
     "proposalUpdateExplanation": "Cela mettra à jour l'état de la proposition. Si elle est trop ancienne et n'a pas suffisamment de votes Aye, elle sera rejetée. Si elle a été confirmée assez longtemps, elle sera acceptée.",

--- a/app/lib/l10n/arb/app_ru.arb
+++ b/app/lib/l10n/arb/app_ru.arb
@@ -243,6 +243,7 @@
     "proposalFieldErrorEnterInactivityTimeout": "Введите тайм-аут неактивности",
     "proposalFieldErrorPositiveIntegerRange": "Должно быть положительное целое число",
     "proposalOnlyBootstrappersOrReputablesCanSubmit": "Только бутстраперы или уважаемые участники могут подать предложение.",
+    "proposalCannotSubmitProposalTypePendingEnactment": "Невозможно подать предложение этого типа, так как уже есть одно ожидающее принятия.",
     "proposalClose": "Закрыть",
     "proposalUpdateState": "Обновить",
     "proposalUpdateExplanation": "Это обновит статус предложения. Если оно слишком старое и не имеет достаточного количества голосов 'За', оно будет отклонено. Если оно подтверждается достаточно долго, оно будет принято.",

--- a/app/lib/l10n/arb/app_ru.arb
+++ b/app/lib/l10n/arb/app_ru.arb
@@ -209,6 +209,7 @@
     "proposalNew": "новое предложение",
     "proposalType": "Тип предложения",
     "proposalTypeAddLocation": "Добавить местоположение",
+    "proposalTypeRemoveLocation": "Удалить местоположение",
     "proposalTypeUpdateDemurrage": "Обновить демерредж",
     "proposalTypeUpdateNominalIncome": "Обновить номинальный доход",
     "proposalTypeSetInactivityTimeout": "Установить тайм-аут неактивности",

--- a/app/lib/l10n/arb/app_sw.arb
+++ b/app/lib/l10n/arb/app_sw.arb
@@ -209,6 +209,7 @@
     "proposalNew": "Mapendekezo mapya",
     "proposalType": "Aina ya pendekezo",
     "proposalTypeAddLocation": "Ongeza eneo",
+    "proposalTypeRemoveLocation": "Ondoa eneo",
     "proposalTypeUpdateDemurrage": "Sasisha ada ya kuchelewesha",
     "proposalTypeUpdateNominalIncome": "Sasisha mapato ya kawaida",
     "proposalTypeSetInactivityTimeout": "Weka muda wa kutokufanya kazi",

--- a/app/lib/l10n/arb/app_sw.arb
+++ b/app/lib/l10n/arb/app_sw.arb
@@ -243,6 +243,7 @@
     "proposalFieldErrorEnterInactivityTimeout": "Weka muda wa kutokufanya kazi",
     "proposalFieldErrorPositiveIntegerRange": "Lazima iwe namba kamili chanya",
     "proposalOnlyBootstrappersOrReputablesCanSubmit": "Ni bootstrappers au waheshimika pekee wanaoweza kuwasilisha pendekezo.",
+    "proposalCannotSubmitProposalTypePendingEnactment": "Haiwezi kuwasilisha pendekezo la aina hii kwa sababu tayari kuna moja linalosubiri kutekelezwa.",
     "proposalClose": "Funga",
     "proposalUpdateState": "Sasisha",
     "proposalUpdateExplanation": "Hii itasasisha hali ya pendekezo. Ikiwa ni la zamani sana na halina kura za kutosha za 'Ndio', litakataliwa. Ikiwa limekuwa likithibitishwa kwa muda wa kutosha, litakubaliwa.",

--- a/app/lib/page-encointer/democracy/proposal_page/helpers.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/helpers.dart
@@ -35,7 +35,7 @@ enum ProposalActionIdentifier {
 ProposalActionIdentifier proposalActionIdentifierFromPolkadartAction(et.ProposalAction action) {
   return switch (action.runtimeType) {
     et.AddLocation => ProposalActionIdentifier.addLocation,
-    et.RemoveLocation => throw UnimplementedError('Remove location is unsupported'),
+    et.RemoveLocation => ProposalActionIdentifier.removeLocation,
     et.UpdateDemurrage => ProposalActionIdentifier.updateDemurrage,
     et.UpdateNominalIncome => ProposalActionIdentifier.updateNominalIncome,
     et.SetInactivityTimeout => ProposalActionIdentifier.setInactivityTimeout,
@@ -84,7 +84,7 @@ extension PropsalActionExt on ProposalActionIdentifier {
   String localizedStr(AppLocalizations l10n) {
     return switch (this) {
       ProposalActionIdentifier.addLocation => l10n.proposalTypeAddLocation,
-      ProposalActionIdentifier.removeLocation => throw UnimplementedError('Remove location is unsupported'),
+      ProposalActionIdentifier.removeLocation => l10n.proposalTypeRemoveLocation,
       ProposalActionIdentifier.updateDemurrage => l10n.proposalTypeUpdateDemurrage,
       ProposalActionIdentifier.updateNominalIncome => l10n.proposalTypeUpdateNominalIncome,
       ProposalActionIdentifier.setInactivityTimeout => l10n.proposalTypeSetInactivityTimeout,

--- a/app/lib/page-encointer/democracy/proposal_page/helpers.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/helpers.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:encointer_wallet/l10n/l10.dart';
 
+import 'package:ew_polkadart/encointer_types.dart' as et;
+
 /// Enum for Scope selection
 enum ProposalScope { global, local }
 
@@ -21,12 +23,27 @@ extension ProposalScopeExt on ProposalScope {
 /// Enum representing different proposal actions
 enum ProposalActionIdentifier {
   addLocation,
+  removeLocation,
   updateDemurrage,
   updateNominalIncome,
   setInactivityTimeout,
   petition,
   spendNative,
   issueSwapNativeOption
+}
+
+ProposalActionIdentifier proposalActionIdentifierFromPolkadartAction(et.ProposalAction action) {
+  return switch (action.runtimeType) {
+    et.AddLocation => ProposalActionIdentifier.addLocation,
+    et.RemoveLocation => throw UnimplementedError('Remove location is unsupported'),
+    et.UpdateDemurrage => ProposalActionIdentifier.updateDemurrage,
+    et.UpdateNominalIncome => ProposalActionIdentifier.updateNominalIncome,
+    et.SetInactivityTimeout => ProposalActionIdentifier.setInactivityTimeout,
+    et.Petition => ProposalActionIdentifier.petition,
+    et.SpendNative => ProposalActionIdentifier.spendNative,
+    et.IssueSwapNativeOption => ProposalActionIdentifier.issueSwapNativeOption,
+    _ => throw UnimplementedError('Invalid Proposal Id Type'),
+  };
 }
 
 /// We still have to implement support for:
@@ -53,6 +70,7 @@ extension PropsalActionExt on ProposalActionIdentifier {
 
       // Only local proposals allowed
       ProposalActionIdentifier.addLocation => [ProposalScope.local],
+      ProposalActionIdentifier.removeLocation => [ProposalScope.local],
       ProposalActionIdentifier.updateDemurrage => [ProposalScope.local],
       ProposalActionIdentifier.updateNominalIncome => [ProposalScope.local],
       ProposalActionIdentifier.issueSwapNativeOption => [ProposalScope.local],
@@ -66,6 +84,7 @@ extension PropsalActionExt on ProposalActionIdentifier {
   String localizedStr(AppLocalizations l10n) {
     return switch (this) {
       ProposalActionIdentifier.addLocation => l10n.proposalTypeAddLocation,
+      ProposalActionIdentifier.removeLocation => throw UnimplementedError('Remove location is unsupported'),
       ProposalActionIdentifier.updateDemurrage => l10n.proposalTypeUpdateDemurrage,
       ProposalActionIdentifier.updateNominalIncome => l10n.proposalTypeUpdateNominalIncome,
       ProposalActionIdentifier.setInactivityTimeout => l10n.proposalTypeSetInactivityTimeout,

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -174,7 +174,8 @@ class _ProposePageState extends State<ProposePage> {
                   Text(l10n.proposalCannotSubmitProposalTypePendingEnactment, textAlign: TextAlign.center),
                 const SizedBox(height: 5),
                 SubmitButton(
-                  onPressed: isBootstrapperOrReputable(store, store.account.currentAddress) && !enactmentQueue.contains(selectedAction)
+                  onPressed: isBootstrapperOrReputable(store, store.account.currentAddress) &&
+                          !enactmentQueue.contains(selectedAction)
                       ? (context) async {
                           _formKey.currentState!.validate();
                           await _submitProposal();

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -171,7 +171,8 @@ class _ProposePageState extends State<ProposePage> {
                 if (!isBootstrapperOrReputable(store, store.account.currentAddress))
                   Text(l10n.proposalOnlyBootstrappersOrReputablesCanSubmit, textAlign: TextAlign.center),
                 if (enactmentQueue.contains(selectedAction))
-                  const Text('Cannot submit a Proposal of this type, as there is already one pending enactment'),
+                  Text(l10n.proposalCannotSubmitProposalTypePendingEnactment, textAlign: TextAlign.center),
+                const SizedBox(height: 5),
                 SubmitButton(
                   onPressed: isBootstrapperOrReputable(store, store.account.currentAddress) && !enactmentQueue.contains(selectedAction)
                       ? (context) async {

--- a/app/lib/service/substrate_api/encointer/encointer_api.dart
+++ b/app/lib/service/substrate_api/encointer/encointer_api.dart
@@ -733,6 +733,24 @@ class EncointerApi {
     }
   }
 
+  Future<List<et.ProposalAction>> getProposalEnactmentQueue({BlockHash? at}) async {
+    try {
+      final prefix = encointerKusama.query.encointerDemocracy.enactmentQueueMapPrefix();
+      final pairs = await encointerKusama.rpc.state.getPairs(prefix);
+
+      // Keys including storage prefix.
+      Log.d("[getProposalEnactmentQueue] storageKeys: ${pairs.map((pair) => '0x${hex.encode(pair.key)}')}");
+      Log.d("[getProposalEnactmentQueue] storageValues: ${pairs.map((pair) => '0x${hex.encode(pair.value!)}')}");
+
+      final proposalActions = pairs.map((pair) => et.ProposalAction.decode(ByteInput(pair.value!)));
+
+      return proposalActions.toList();
+    } catch (e, s) {
+      Log.e('[getProposalEnactmentQueue]', '$e', s);
+      return List.of([]);
+    }
+  }
+
   Future<Map<BigInt, Proposal>> getProposals(List<BigInt> proposalIds, {BlockHash? at}) async {
     try {
       Log.d('[getProposals] ProposalIds: $proposalIds');

--- a/app/lib/service/tx/lib/src/submit_to_inner.dart
+++ b/app/lib/service/tx/lib/src/submit_to_inner.dart
@@ -87,8 +87,6 @@ void _showErrorDialog(BuildContext context, ErrorNotificationMsg message) {
   final l10n = context.l10n;
   final languageCode = Localizations.localeOf(context).languageCode;
 
-  print('Should show error dialog');
-
   AppAlert.showDialog<void>(
     context,
     title: Text(message.title),

--- a/packages/ew_polkadart/lib/encointer_types.dart
+++ b/packages/ew_polkadart/lib/encointer_types.dart
@@ -34,6 +34,27 @@ export 'generated/encointer_kusama/types/encointer_primitives/communities/commun
 export 'generated/encointer_kusama/types/encointer_primitives/communities/community_rules.dart' show CommunityRules;
 export 'generated/encointer_kusama/types/encointer_primitives/communities/location.dart' show Location;
 
+// export types from democracy
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/proposal.dart' show Proposal;
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action.dart'
+    show
+        ProposalAction,
+        AddLocation,
+        RemoveLocation,
+        UpdateDemurrage,
+        UpdateNominalIncome,
+        SetInactivityTimeout,
+        Petition,
+        SpendNative,
+        IssueSwapNativeOption;
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action_identifier.dart'
+    show ProposalActionIdentifier;
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/proposal_state.dart'
+    show ProposalState, Ongoing, Rejected, SupersededBy, Approved, Confirming, Enacted;
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/tally.dart' show Tally;
+export 'generated/encointer_kusama/types/encointer_primitives/democracy/vote.dart' show Vote;
+export 'generated/encointer_kusama/types/encointer_primitives/treasuries/swap_native_option.dart' show SwapNativeOption;
+
 // export types from faucet
 export 'generated/encointer_kusama/types/encointer_primitives/faucet/faucet.dart' show Faucet;
 


### PR DESCRIPTION
We now check on the submit proposals type if there is already a proposal pending enactment of the currently selected proposal action it. If there is, we show a message, and disable the submit button. Related issue #1761.