### PR TITLE
[proposePage] fix: disallow sending same proposal for same scope

### DIFF
--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -78,7 +78,7 @@ class _ProposePageState extends State<ProposePage> {
   // Beneficiary in for the spendNative/issueSwapNativeOption
   AccountData? beneficiary;
 
-  List<ProposalActionIdentifier> enactmentQueue = [];
+  List<ProposalActionIdWithScope> enactmentQueue = [];
   BigInt globalTreasuryBalance = BigInt.zero;
   BigInt localTreasuryBalance = BigInt.zero;
 
@@ -145,7 +145,9 @@ class _ProposePageState extends State<ProposePage> {
     }
 
     setState(() {
-      // enactmentQueue = queue.map(proposalActionIdentifierFromPolkadartAction).toList();
+      enactmentQueue = queuedProposals.values
+          .map<ProposalActionIdWithScope>((a) => ProposalActionIdWithScope.fromProposalAction(a.action))
+          .toList();
       globalTreasuryBalance = globalTreasuryAccountData.free;
       localTreasuryBalance = localTreasuryAccountData.free;
 
@@ -243,7 +245,8 @@ class _ProposePageState extends State<ProposePage> {
 
                             if (!isBootstrapperOrReputable(store, store.account.currentAddress))
                               Text(l10n.proposalOnlyBootstrappersOrReputablesCanSubmit, textAlign: TextAlign.center),
-                            if (enactmentQueue.contains(selectedAction))
+                            if (hasSameProposalForSameScope(enactmentQueue, selectedAction,
+                                selectedScope.isLocal ? store.encointer.chosenCid! : null))
                               Text(l10n.proposalCannotSubmitProposalTypePendingEnactment, textAlign: TextAlign.center),
 
                             // Submit button

--- a/app/test/page_encointer/democracy/proposal_page/helpers.dart
+++ b/app/test/page_encointer/democracy/proposal_page/helpers.dart
@@ -7,18 +7,14 @@ void main() {
     test('returns true if same local proposal exists', () {
       final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
       const actionId = ProposalActionIdentifier.spendNative;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, cid
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, cid)];
 
       expect(hasSameProposalForSameScope(queue, actionId, cid), true);
     });
 
     test('returns true if same global proposal exists', () {
       const actionId = ProposalActionIdentifier.spendNative;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, null
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, null)];
 
       expect(hasSameProposalForSameScope(queue, actionId, null), true);
     });
@@ -26,9 +22,7 @@ void main() {
     test('returns false for different global proposal', () {
       const actionId = ProposalActionIdentifier.spendNative;
       const actionId2 = ProposalActionIdentifier.petition;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, null
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, null)];
 
       expect(hasSameProposalForSameScope(queue, actionId2, null), false);
     });
@@ -37,21 +31,16 @@ void main() {
       const actionId = ProposalActionIdentifier.spendNative;
       const actionId2 = ProposalActionIdentifier.petition;
       final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, cid
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, cid)];
 
       expect(hasSameProposalForSameScope(queue, actionId2, cid), false);
     });
-
 
     test('returns false for the same proposal id, but different community', () {
       final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
       final cid2 = CommunityIdentifier.fromFmtString('u0qj944rhWE');
       const actionId = ProposalActionIdentifier.spendNative;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, cid
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, cid)];
 
       expect(hasSameProposalForSameScope(queue, actionId, cid2), false);
     });
@@ -59,9 +48,7 @@ void main() {
     test('returns false for same proposal id but it is global', () {
       final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
       const actionId = ProposalActionIdentifier.petition;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, cid
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, cid)];
 
       expect(hasSameProposalForSameScope(queue, actionId, null), false);
     });
@@ -69,9 +56,7 @@ void main() {
     test('returns false for same proposal id but it is local', () {
       final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
       const actionId = ProposalActionIdentifier.petition;
-      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
-          actionId, null
-      )];
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(actionId, null)];
 
       expect(hasSameProposalForSameScope(queue, actionId, cid), false);
     });

--- a/app/test/page_encointer/democracy/proposal_page/helpers.dart
+++ b/app/test/page_encointer/democracy/proposal_page/helpers.dart
@@ -1,0 +1,79 @@
+import 'package:encointer_wallet/models/communities/community_identifier.dart';
+import 'package:encointer_wallet/page-encointer/democracy/proposal_page/helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('enactmentQueueCheckWorks', () {
+    test('returns true if same local proposal exists', () {
+      final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
+      const actionId = ProposalActionIdentifier.spendNative;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, cid
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId, cid), true);
+    });
+
+    test('returns true if same global proposal exists', () {
+      const actionId = ProposalActionIdentifier.spendNative;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, null
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId, null), true);
+    });
+
+    test('returns false for different global proposal', () {
+      const actionId = ProposalActionIdentifier.spendNative;
+      const actionId2 = ProposalActionIdentifier.petition;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, null
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId2, null), false);
+    });
+
+    test('returns false for different proposal, but same community', () {
+      const actionId = ProposalActionIdentifier.spendNative;
+      const actionId2 = ProposalActionIdentifier.petition;
+      final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, cid
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId2, cid), false);
+    });
+
+
+    test('returns false for the same proposal id, but different community', () {
+      final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
+      final cid2 = CommunityIdentifier.fromFmtString('u0qj944rhWE');
+      const actionId = ProposalActionIdentifier.spendNative;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, cid
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId, cid2), false);
+    });
+
+    test('returns false for same proposal id but it is global', () {
+      final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
+      const actionId = ProposalActionIdentifier.petition;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, cid
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId, null), false);
+    });
+
+    test('returns false for same proposal id but it is local', () {
+      final cid = CommunityIdentifier.fromFmtString('sqm1v79dF6b');
+      const actionId = ProposalActionIdentifier.petition;
+      final queue = <ProposalActionIdWithScope>[ProposalActionIdWithScope(
+          actionId, null
+      )];
+
+      expect(hasSameProposalForSameScope(queue, actionId, cid), false);
+    });
+  });
+}


### PR DESCRIPTION
Before this check did not take into account the community as a scope. Now it correctly checks:

* Disallow sending proposals for: same proposal id && same scope