### PR TITLE
[proposePage] properly limit the text size for the petition field and show current byte count

### DIFF
--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -6,6 +6,7 @@ import 'package:encointer_wallet/common/components/submit_button.dart';
 import 'package:encointer_wallet/config/consts.dart';
 import 'package:encointer_wallet/models/communities/community_identifier.dart';
 import 'package:encointer_wallet/page-encointer/democracy/proposal_page/helpers.dart';
+import 'package:encointer_wallet/page-encointer/democracy/proposal_page/utf8_limited_byte_field.dart';
 import 'package:encointer_wallet/service/substrate_api/api.dart';
 import 'package:encointer_wallet/service/tx/lib/src/error_notifications.dart';
 import 'package:encointer_wallet/service/tx/lib/src/submit_to_inner.dart';
@@ -410,12 +411,10 @@ class _ProposePageState extends State<ProposePage> {
   Widget petitionInput(BuildContext context) {
     final l10n = context.l10n;
 
-    return TextFormField(
+    return Utf8LimitedTextField(
       controller: petitionTextController,
-      decoration: InputDecoration(
-        labelText: l10n.proposalFieldPetitionText,
-        errorText: petitionError,
-      ),
+      labelText: l10n.proposalFieldPetitionText,
+      errorText: petitionError,
       validator: validatePetitionText,
       onChanged: (value) {
         setState(() {
@@ -425,6 +424,7 @@ class _ProposePageState extends State<ProposePage> {
       keyboardType: TextInputType.multiline,
       minLines: 5,
       maxLines: 10,
+      maxBytes: 256,
     );
   }
 

--- a/app/lib/page-encointer/democracy/proposal_page/utf8_limited_byte_field.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/utf8_limited_byte_field.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class Utf8LimitedTextField extends StatefulWidget {
+  const Utf8LimitedTextField({
+    super.key,
+    required this.controller,
+    required this.keyboardType,
+    required this.labelText,
+    required this.errorText,
+    required this.onChanged,
+    required this.maxBytes,
+    this.validator,
+    this.minLines = 1,
+    this.maxLines = 5,
+  });
+  final TextEditingController controller;
+  final TextInputType keyboardType;
+  final String? labelText;
+  final String? errorText;
+  final String? Function(String?)? validator;
+  final ValueChanged<String>? onChanged;
+  final int maxBytes;
+  final int minLines;
+  final int maxLines;
+
+  @override
+  Utf8LimitedTextFieldState createState() => Utf8LimitedTextFieldState();
+}
+
+class Utf8LimitedTextFieldState extends State<Utf8LimitedTextField> {
+  int _usedBytes = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_updateByteCount);
+  }
+
+  void _updateByteCount() {
+    setState(() {
+      _usedBytes = utf8.encode(widget.controller.text).length;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: widget.controller,
+      decoration: InputDecoration(
+        labelText: widget.labelText,
+        errorText: widget.errorText,
+        counterText: '$_usedBytes/${widget.maxBytes}',
+      ),
+      validator: widget.validator,
+      inputFormatters: [Utf8ByteLimitFormatter(widget.maxBytes)],
+      onChanged: (value) {
+        widget.onChanged?.call(value);
+        _updateByteCount();
+      },
+      keyboardType: TextInputType.multiline,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines,
+    );
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_updateByteCount);
+    super.dispose();
+  }
+}
+
+class Utf8ByteLimitFormatter extends TextInputFormatter {
+  Utf8ByteLimitFormatter(this.maxBytes);
+  final int maxBytes;
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    if (utf8.encode(newValue.text).length <= maxBytes) {
+      return newValue;
+    }
+
+    var trimmedText = newValue.text;
+    while (utf8.encode(trimmedText).length > maxBytes) {
+      trimmedText = trimmedText.substring(0, trimmedText.length - 1);
+    }
+
+    return TextEditingValue(
+      text: trimmedText,
+      selection: TextSelection.collapsed(offset: trimmedText.length),
+    );
+  }
+}

--- a/app/lib/page-encointer/democracy/proposal_page/utf8_limited_byte_field.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/utf8_limited_byte_field.dart
@@ -56,8 +56,8 @@ class Utf8LimitedTextFieldState extends State<Utf8LimitedTextField> {
       validator: widget.validator,
       inputFormatters: [Utf8ByteLimitFormatter(widget.maxBytes)],
       onChanged: (value) {
-        widget.onChanged?.call(value);
         _updateByteCount();
+        widget.onChanged?.call(value);
       },
       keyboardType: TextInputType.multiline,
       minLines: widget.minLines,


### PR DESCRIPTION
The reason why this did not work before was that `text.codeunits` returns utf16 instead of utf8 values. This is fixed now, and we also introduced a byte counter in the text field, which prevents exceeding the 256 byte limit. Closes #1766.