### PR TITLE
[proposePage] correctly show the txErrorDialog if there was an error 

### DIFF
--- a/app/lib/common/components/launch/send_to_trello_list_tile.dart
+++ b/app/lib/common/components/launch/send_to_trello_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:encointer_wallet/config/consts.dart';
 import 'package:flutter/material.dart';
 
 import 'package:encointer_wallet/theme/theme.dart';
@@ -15,7 +16,7 @@ class SendToTrelloListTile extends StatelessWidget {
         style: context.titleLarge.copyWith(color: AppColors.encointerGrey, fontSize: 19),
       ),
       onTap: () async => AppLaunch.sendEmail(
-        'bugreports@mail.encointer.org',
+        bugReportMail,
         snackBarText: context.l10n.checkEmailApp,
         context: context,
       ),

--- a/app/lib/config/consts.dart
+++ b/app/lib/config/consts.dart
@@ -28,6 +28,7 @@ const localePlaceHolder = 'LOCALE_PLACEHOLDER';
 const ceremonyInfoLinkBase = 'https://leu.zuerich/$localePlaceHolder/#zeremonien';
 const encointerLink = 'https://wallet.encointer.org/app/';
 const encointerApi = 'https://api.encointer.org/v1/';
+const bugReportMail = 'bugreports@mail.encointer.org';
 
 String toDeepLink([String? linkText]) => '$encointerLink${linkText?.replaceAll('\n', '_')}';
 String getTransactionHistoryUrl(String cid, String address, {DateTime? startTime, DateTime? endTime}) {

--- a/app/lib/l10n/arb/app_de.arb
+++ b/app/lib/l10n/arb/app_de.arb
@@ -139,6 +139,8 @@
     "insufficientBalance": "Ungenügender Saldo",
     "insufficientFundsErrorBody": "Du hast nicht genügend Geld auf diesem Konto. Schaue auf der Webseite deiner lokalen Gemeinschaft, wie du welches bekommen kannst.",
     "insufficientFundsErrorTitle": "Zu wenig Guthaben",
+    "invalidTransactionFormatErrorBody": "Die Transaktion hatte ein ungültiges Format, was ein Fehler in der Anwendung sein könnte. Wenn du denkst, dass es sich um einen Bug handelt, tippe einfach auf das entsprechende Feld unten.",
+    "invalidTransactionFormatErrorTitle": "Ungültiges Transaktionsformat",
     "invalidCommunity": "Ungültige Gemeinschaft",
     "invalidNetwork": "Ungültiges Netzwerk",
     "invoice": "Rechnungsbetrag",

--- a/app/lib/l10n/arb/app_en.arb
+++ b/app/lib/l10n/arb/app_en.arb
@@ -139,6 +139,8 @@
     "insufficientBalance": "Insufficient balance",
     "insufficientFundsErrorBody": "You do not have sufficient funds on this account. See on the website of your local community how to get some.",
     "insufficientFundsErrorTitle": "Insufficient Funds",
+    "invalidTransactionFormatErrorBody": "The transaction had an invalid format, which might be a bug. If you think this is a bug, please tap the corresponding field below.",
+    "invalidTransactionFormatErrorTitle": "Invalid Transaction Format",
     "invalidCommunity": "Invalid Community",
     "invalidNetwork": "Invalid Network",
     "invoice": "Invoice",

--- a/app/lib/l10n/arb/app_fr.arb
+++ b/app/lib/l10n/arb/app_fr.arb
@@ -139,6 +139,8 @@
     "insufficientBalance": "Solde insuffisant",
     "insufficientFundsErrorBody": "Tu n'as pas assez d'argent sur ce compte. Regarde sur le site web de ta communauté locale pour savoir comment en obtenir.",
     "insufficientFundsErrorTitle": "Trop peu de crédit",
+    "invalidTransactionFormatErrorBody": "La transaction avait un format invalide, ce qui pourrait être un bug dans l'application. Si tu penses que c'est un bug, clique sur le champ correspondant ci-dessous.",
+    "invalidTransactionFormatErrorTitle": "Format de transaction invalide",
     "invalidCommunity": "Communauté non valide.",
     "invalidNetwork": "Réseau non valide",
     "invoice": "Montant de la facture",

--- a/app/lib/l10n/arb/app_ru.arb
+++ b/app/lib/l10n/arb/app_ru.arb
@@ -139,6 +139,8 @@
     "insufficientBalance": "Недостаточный баланс",
     "insufficientFundsErrorBody": "У вас недостаточно средств на этом аккаунте. Посмотрите на веб-сайте вашего местного сообщества, как их получить.",
     "insufficientFundsErrorTitle": "Недостаточно средств",
+    "invalidTransactionFormatErrorBody": "У транзакции был неверный формат, возможно, это ошибка в приложении. Если ты считаешь, что это баг, просто нажми на соответствующее поле ниже.",
+    "invalidTransactionFormatErrorTitle": "Неверный формат транзакции",
     "invalidCommunity": "Несоотвествующая община",
     "invalidNetwork": "Неправильная сеть",
     "invoice": "Инвойс",

--- a/app/lib/l10n/arb/app_sw.arb
+++ b/app/lib/l10n/arb/app_sw.arb
@@ -139,6 +139,8 @@
     "insufficientBalance": "Kiasi hakitoshi",
     "insufficientFundsErrorBody": "Hauna mali za kutosha kwenye akaunti hii. Angalia kwenye tovuti ya jamii yako kuweza kupata kadhaa.",
     "insufficientFundsErrorTitle": "Mali hazitoshi",
+    "invalidTransactionFormatErrorBody": "Transaction ilikuwa na muundo usio sahihi, ambayo inaweza kuwa hitilafu katika programu. Ikiwa unadhani hii ni hitilafu, tafadhali bonyeza uwanja unaofaa chini.",
+    "invalidTransactionFormatErrorTitle": "Muundo wa Transaction Usio Sahihi",
     "invalidCommunity": "sio jamii sahihi",
     "invalidNetwork": "Mtandao sio sahihi",
     "invoice": "Ankara",

--- a/app/lib/page-encointer/ceremony_box/ceremony_box.dart
+++ b/app/lib/page-encointer/ceremony_box/ceremony_box.dart
@@ -88,7 +88,7 @@ class CeremonyBox extends StatelessWidget {
                             txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
                             onError: (dispatchError) {
                               final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-                              showTxErrorDialog(context, message);
+                              showTxErrorDialog(context, message, false);
                             },
                           );
                         }),
@@ -139,7 +139,7 @@ class CeremonyBox extends StatelessWidget {
                         txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
                         onError: (dispatchError) {
                           final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-                          showTxErrorDialog(context, message);
+                          showTxErrorDialog(context, message, false);
                         },
                       ),
                     ),

--- a/app/lib/page-encointer/ceremony_box/components/unregister_link_button.dart
+++ b/app/lib/page-encointer/ceremony_box/components/unregister_link_button.dart
@@ -45,7 +45,7 @@ class _UnregisteredLinkButtonState extends State<UnregisteredLinkButton> {
       txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
       onError: (dispatchError) {
         final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-        showTxErrorDialog(context, message);
+        showTxErrorDialog(context, message, false);
       },
     );
 

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -259,7 +259,6 @@ class _ProposePageState extends State<ProposePage> {
                                   ? (context) async {
                                       _formKey.currentState!.validate();
                                       await _submitProposal();
-                                      Navigator.of(context).pop();
                                     }
                                   : null,
                               // disable button for non-bootstrappers/reputables
@@ -700,8 +699,9 @@ class _ProposePageState extends State<ProposePage> {
         txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
         onError: (dispatchError) {
           final message = getLocalizedTxErrorMessage(l10n, dispatchError);
-          showTxErrorDialog(context, message);
-        },
+          showTxErrorDialog(context, message, false);
+      },
+        onFinish: (_, __) => Navigator.of(context).pop()
       );
     }
   }

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -700,8 +700,8 @@ class _ProposePageState extends State<ProposePage> {
         onError: (dispatchError) {
           final message = getLocalizedTxErrorMessage(l10n, dispatchError);
           showTxErrorDialog(context, message, false);
-      },
-        onFinish: (_, __) => Navigator.of(context).pop()
+        },
+        onFinish: (_, __) => Navigator.of(context).pop(),
       );
     }
   }

--- a/app/lib/page-encointer/meetup/ceremony_step3_finish.dart
+++ b/app/lib/page-encointer/meetup/ceremony_step3_finish.dart
@@ -104,7 +104,7 @@ class CeremonyStep3Finish extends StatelessWidget {
                         txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
                         onError: (dispatchError) {
                           final message = getLocalizedTxErrorMessage(l10n, dispatchError);
-                          showTxErrorDialog(context, message);
+                          showTxErrorDialog(context, message, false);
                         },
                       ),
                     );

--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -271,7 +271,7 @@ class _AssetsViewState extends State<AssetsView> {
                                   txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
                                   onError: (dispatchError) {
                                     final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-                                    showTxErrorDialog(context, message);
+                                    showTxErrorDialog(context, message, false);
                                   },
                                 ),
                               );

--- a/app/lib/page/profile/account/faucet_list_tile.dart
+++ b/app/lib/page/profile/account/faucet_list_tile.dart
@@ -148,7 +148,7 @@ class _FaucetListTileState extends State<FaucetListTile> {
       txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
       onError: (dispatchError) {
         final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-        showTxErrorDialog(context, message);
+        showTxErrorDialog(context, message, false);
       },
     );
   }

--- a/app/lib/page/profile/account/remark.dart
+++ b/app/lib/page/profile/account/remark.dart
@@ -86,7 +86,7 @@ class Remarks extends StatelessWidget {
       txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
       onError: (dispatchError) {
         final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-        showTxErrorDialog(context, message);
+        showTxErrorDialog(context, message, false);
       },
     );
   }

--- a/app/lib/page/profile/contacts/contact_detail_page.dart
+++ b/app/lib/page/profile/contacts/contact_detail_page.dart
@@ -300,7 +300,7 @@ class EndorseButton extends StatelessWidget {
         txPaymentAsset: store.encointer.getTxPaymentAsset(store.encointer.chosenCid),
         onError: (dispatchError) {
           final message = getLocalizedTxErrorMessage(context.l10n, dispatchError);
-          showTxErrorDialog(context, message);
+          showTxErrorDialog(context, message, false);
         },
       );
     }

--- a/app/lib/service/tx/lib/src/submit_to_inner.dart
+++ b/app/lib/service/tx/lib/src/submit_to_inner.dart
@@ -69,7 +69,8 @@ Future<void> submitTxInner(
         msg = ErrorNotificationMsg(title: l10n.insufficientFundsErrorTitle, body: l10n.insufficientFundsErrorBody);
         showTxErrorDialog(context, msg, false);
       } else if (e.toString().contains(invalidTransactionFormat)) {
-        msg = ErrorNotificationMsg(title: l10n.invalidTransactionFormatErrorTitle, body: l10n.invalidTransactionFormatErrorBody);
+        msg = ErrorNotificationMsg(
+            title: l10n.invalidTransactionFormatErrorTitle, body: l10n.invalidTransactionFormatErrorBody);
         showTxErrorDialog(context, msg, true);
       }
     }


### PR DESCRIPTION
The bug was very simple, we simply popped too fast so that we never saw the dialog. Additionally, there is no a field in the txErrorDialog to submit bug reports. In most cases this is hidden, as it is most likely a user error, but if it is a transaction format error, the button is shown.

* Closes #1761