### PR TITLE
[democracy] fix rate in swap native proposal (this time for real)

### DIFF
--- a/app/lib/page-encointer/democracy/helpers.dart
+++ b/app/lib/page-encointer/democracy/helpers.dart
@@ -93,7 +93,7 @@ String getProposalActionTitle(BuildContext context, ProposalAction action) {
 
       final allowance = Fmt.bigIntToDouble(swapNativeOption.nativeAllowance, ertDecimals);
       final rate = swapNativeOption.rate != null
-          ? i64F64Parser.toDouble(swapNativeOption.rate!.bits) / pow(10, ertDecimals)
+          ? i64F64Parser.toDouble(swapNativeOption.rate!.bits) * pow(10, ertDecimals)
           : null;
 
       // This won't be null until we introduce oracle based rates.

--- a/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
+++ b/app/lib/page-encointer/democracy/proposal_page/propose_page.dart
@@ -756,7 +756,7 @@ class _ProposePageState extends State<ProposePage> {
         final issueOption = SwapNativeOption(
           cid: cid,
           nativeAllowance: BigInt.from(amount * pow(10, 12)),
-          rate: fixedU128FromDouble(rate * pow(10, 12)),
+          rate: fixedU128FromDouble(rate * pow(10, -12)),
           doBurn: true,
         );
 


### PR DESCRIPTION
#1779 already tried to fix the `IssueSwapNative` rate in the proposal, but it applied the decimals into the wrong direction, leading to the `SwapOverflow` error observed in #1773.

This PR does now properly apply the fix, and it has been end-to-end tested on a local setup:

* Issue Swap Native Option: Exchange up to 10 KSM at a rate of 0.1
* Redeem 5 KSM → Properly deducted ~0.5 KSM. 👍