### PR TITLE
[Democracy] increase pruning threshold for Rejected proposals to 30 days

### DIFF
--- a/app/lib/page-encointer/democracy/democracy_page.dart
+++ b/app/lib/page-encointer/democracy/democracy_page.dart
@@ -35,7 +35,7 @@ class _DemocracyPageState extends State<DemocracyPage> {
   DemocracyParams? democracyParams;
 
   static const pruneApprovedProposalsDays = 150;
-  static const pruneRejectedProposalsDays = 10;
+  static const pruneRejectedProposalsDays = 30;
 
   @override
   void initState() {


### PR DESCRIPTION
On production rejection happens after 10 days, so the rejected proposals were never shown in the rejected proposals list. This PR increases the threshold to 30 days. So they are visible for 20 days after rejection.