### PR TITLE
Build with ndk28; support 16KB memory page size

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -31,7 +31,7 @@ if (flutterVersionName == null) {
 android {
     namespace "org.encointer.wallet"
     compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    ndkVersion "28.2.13676358"
 
     compileOptions {
         // Flag to enable support for the new language API, see #1165.


### PR DESCRIPTION
* This PR actually fixes what we tried to achieve with the flutter update, see #1809.

The flutter ndk is on version 26, but as the ndk versions are backwards compatible this should not be an issue, and the app works locally.