### PR TITLE
Update generated types for Kusama Asset Hub treasury spends

### DIFF
--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_democracy.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_democracy.dart
@@ -337,7 +337,7 @@ class Constants {
   final int maxReputationCount = 64;
 
   /// The Period in which the proposal has to be in passing state before it is approved.
-  final BigInt confirmationPeriod = BigInt.from(300000);
+  final BigInt confirmationPeriod = BigInt.from(172800000);
 
   /// The total lifetime of a proposal.
   ///
@@ -345,9 +345,9 @@ class Constants {
   ///
   /// Note: In cycles this must be smaller than `ReputationLifetime`, otherwise the eligible
   /// electorate will be 0.
-  final BigInt proposalLifetime = BigInt.from(1200000);
+  final BigInt proposalLifetime = BigInt.from(777600000);
 
   /// Minimum turnout in perthousand for a proposal to be considered as passing and entering
   /// the `Confirming` state.
-  final BigInt minTurnout = BigInt.one;
+  final BigInt minTurnout = BigInt.from(50);
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
@@ -5,7 +5,7 @@ import 'dart:typed_data' as _i5;
 import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
-import '../types/encointer_node_notee_runtime/runtime_call.dart' as _i6;
+import '../types/encointer_kusama_runtime/runtime_call.dart' as _i6;
 import '../types/encointer_primitives/scheduler/ceremony_phase_type.dart' as _i3;
 import '../types/pallet_encointer_scheduler/pallet/call.dart' as _i7;
 

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_scheduler.dart
@@ -5,7 +5,7 @@ import 'dart:typed_data' as _i5;
 import 'package:polkadart/polkadart.dart' as _i1;
 import 'package:polkadart/scale_codec.dart' as _i2;
 
-import '../types/encointer_kusama_runtime/runtime_call.dart' as _i6;
+import '../types/encointer_node_notee_runtime/runtime_call.dart' as _i6;
 import '../types/encointer_primitives/scheduler/ceremony_phase_type.dart' as _i3;
 import '../types/pallet_encointer_scheduler/pallet/call.dart' as _i7;
 

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_treasuries.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/pallets/encointer_treasuries.dart
@@ -1,14 +1,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i5;
-import 'dart:typed_data' as _i6;
+import 'dart:async' as _i6;
+import 'dart:typed_data' as _i7;
 
 import 'package:polkadart/polkadart.dart' as _i1;
 
-import '../types/encointer_node_notee_runtime/runtime_call.dart' as _i7;
+import '../types/encointer_node_notee_runtime/runtime_call.dart' as _i8;
 import '../types/encointer_primitives/communities/community_identifier.dart' as _i2;
+import '../types/encointer_primitives/treasuries/swap_asset_option.dart' as _i5;
 import '../types/encointer_primitives/treasuries/swap_native_option.dart' as _i4;
-import '../types/frame_support/pallet_id.dart' as _i9;
-import '../types/pallet_encointer_treasuries/pallet/call.dart' as _i8;
+import '../types/frame_support/pallet_id.dart' as _i10;
+import '../types/pallet_encointer_treasuries/pallet/call.dart' as _i9;
 import '../types/sp_core/crypto/account_id32.dart' as _i3;
 
 class Queries {
@@ -25,7 +26,16 @@ class Queries {
     hasher2: _i1.StorageHasher.blake2b128Concat(_i3.AccountId32Codec()),
   );
 
-  _i5.Future<_i4.SwapNativeOption?> swapNativeOptions(
+  final _i1.StorageDoubleMap<_i2.CommunityIdentifier, _i3.AccountId32, _i5.SwapAssetOption> _swapAssetOptions =
+      const _i1.StorageDoubleMap<_i2.CommunityIdentifier, _i3.AccountId32, _i5.SwapAssetOption>(
+    prefix: 'EncointerTreasuries',
+    storage: 'SwapAssetOptions',
+    valueCodec: _i5.SwapAssetOption.codec,
+    hasher1: _i1.StorageHasher.blake2b128Concat(_i2.CommunityIdentifier.codec),
+    hasher2: _i1.StorageHasher.blake2b128Concat(_i3.AccountId32Codec()),
+  );
+
+  _i6.Future<_i4.SwapNativeOption?> swapNativeOptions(
     _i2.CommunityIdentifier key1,
     _i3.AccountId32 key2, {
     _i1.BlockHash? at,
@@ -44,8 +54,27 @@ class Queries {
     return null; /* Nullable */
   }
 
+  _i6.Future<_i5.SwapAssetOption?> swapAssetOptions(
+    _i2.CommunityIdentifier key1,
+    _i3.AccountId32 key2, {
+    _i1.BlockHash? at,
+  }) async {
+    final hashedKey = _swapAssetOptions.hashedKeyFor(
+      key1,
+      key2,
+    );
+    final bytes = await __api.getStorage(
+      hashedKey,
+      at: at,
+    );
+    if (bytes != null) {
+      return _swapAssetOptions.decodeValue(bytes);
+    }
+    return null; /* Nullable */
+  }
+
   /// Returns the storage key for `swapNativeOptions`.
-  _i6.Uint8List swapNativeOptionsKey(
+  _i7.Uint8List swapNativeOptionsKey(
     _i2.CommunityIdentifier key1,
     _i3.AccountId32 key2,
   ) {
@@ -56,9 +85,27 @@ class Queries {
     return hashedKey;
   }
 
+  /// Returns the storage key for `swapAssetOptions`.
+  _i7.Uint8List swapAssetOptionsKey(
+    _i2.CommunityIdentifier key1,
+    _i3.AccountId32 key2,
+  ) {
+    final hashedKey = _swapAssetOptions.hashedKeyFor(
+      key1,
+      key2,
+    );
+    return hashedKey;
+  }
+
   /// Returns the storage map key prefix for `swapNativeOptions`.
-  _i6.Uint8List swapNativeOptionsMapPrefix(_i2.CommunityIdentifier key1) {
+  _i7.Uint8List swapNativeOptionsMapPrefix(_i2.CommunityIdentifier key1) {
     final hashedKey = _swapNativeOptions.mapPrefix(key1);
+    return hashedKey;
+  }
+
+  /// Returns the storage map key prefix for `swapAssetOptions`.
+  _i7.Uint8List swapAssetOptionsMapPrefix(_i2.CommunityIdentifier key1) {
+    final hashedKey = _swapAssetOptions.mapPrefix(key1);
     return hashedKey;
   }
 }
@@ -68,13 +115,25 @@ class Txs {
 
   /// swap native tokens for community currency subject to an existing swap option for the
   /// sender account.
-  _i7.EncointerTreasuries swapNative({
+  _i8.EncointerTreasuries swapNative({
     required _i2.CommunityIdentifier cid,
     required BigInt desiredNativeAmount,
   }) {
-    return _i7.EncointerTreasuries(_i8.SwapNative(
+    return _i8.EncointerTreasuries(_i9.SwapNative(
       cid: cid,
       desiredNativeAmount: desiredNativeAmount,
+    ));
+  }
+
+  /// swap native tokens for community currency subject to an existing swap option for the
+  /// sender account.
+  _i8.EncointerTreasuries swapAsset({
+    required _i2.CommunityIdentifier cid,
+    required BigInt desiredAssetAmount,
+  }) {
+    return _i8.EncointerTreasuries(_i9.SwapAsset(
+      cid: cid,
+      desiredAssetAmount: desiredAssetAmount,
     ));
   }
 }
@@ -83,7 +142,7 @@ class Constants {
   Constants();
 
   /// The treasuries' pallet id, used for deriving sovereign account IDs per community.
-  final _i9.PalletId palletId = const <int>[
+  final _i10.PalletId palletId = const <int>[
     116,
     114,
     115,

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/cow_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/cow_1.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+typedef Cow = String;
+
+class CowCodec with _i1.Codec<Cow> {
+  const CowCodec();
+
+  @override
+  Cow decode(_i1.Input input) {
+    return _i1.StrCodec.codec.decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Cow value,
+    _i1.Output output,
+  ) {
+    _i1.StrCodec.codec.encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Cow value) {
+    return _i1.StrCodec.codec.sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/cow_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/cow_2.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'tuples.dart' as _i1;
+
+typedef Cow = List<_i1.Tuple2<List<int>, int>>;
+
+class CowCodec with _i2.Codec<Cow> {
+  const CowCodec();
+
+  @override
+  Cow decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Tuple2<List<int>, int>>(_i1.Tuple2Codec<List<int>, int>(
+      _i2.U8ArrayCodec(8),
+      _i2.U32Codec.codec,
+    )).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Cow value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Tuple2<List<int>, int>>(_i1.Tuple2Codec<List<int>, int>(
+      _i2.U8ArrayCodec(8),
+      _i2.U32Codec.codec,
+    )).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Cow value) {
+    return const _i2.SequenceCodec<_i1.Tuple2<List<int>, int>>(_i1.Tuple2Codec<List<int>, int>(
+      _i2.U8ArrayCodec(8),
+      _i2.U32Codec.codec,
+    )).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal.dart
@@ -25,7 +25,7 @@ class Proposal {
   /// CeremonyIndexType
   final int startCindex;
 
-  /// ProposalAction<AccountId, Balance, Moment>
+  /// ProposalAction<AccountId, Balance, Moment, AssetId>
   final _i2.ProposalAction action;
 
   /// ProposalState<Moment>

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action.dart
@@ -2,14 +2,16 @@
 import 'dart:typed_data' as _i2;
 
 import 'package:polkadart/scale_codec.dart' as _i1;
-import 'package:quiver/collection.dart' as _i10;
+import 'package:quiver/collection.dart' as _i12;
 
+import '../../polkadot_runtime_common/impls/versioned_locatable_asset.dart' as _i10;
 import '../../sp_core/crypto/account_id32.dart' as _i8;
 import '../../substrate_fixed/fixed_i128.dart' as _i6;
 import '../../substrate_fixed/fixed_u128.dart' as _i7;
 import '../communities/community_identifier.dart' as _i3;
 import '../communities/community_metadata.dart' as _i5;
 import '../communities/location.dart' as _i4;
+import '../treasuries/swap_asset_option.dart' as _i11;
 import '../treasuries/swap_native_option.dart' as _i9;
 
 abstract class ProposalAction {
@@ -126,6 +128,32 @@ class $ProposalAction {
       value2,
     );
   }
+
+  SpendAsset spendAsset(
+    _i3.CommunityIdentifier? value0,
+    _i8.AccountId32 value1,
+    BigInt value2,
+    _i10.VersionedLocatableAsset value3,
+  ) {
+    return SpendAsset(
+      value0,
+      value1,
+      value2,
+      value3,
+    );
+  }
+
+  IssueSwapAssetOption issueSwapAssetOption(
+    _i3.CommunityIdentifier value0,
+    _i8.AccountId32 value1,
+    _i11.SwapAssetOption value2,
+  ) {
+    return IssueSwapAssetOption(
+      value0,
+      value1,
+      value2,
+    );
+  }
 }
 
 class $ProposalActionCodec with _i1.Codec<ProposalAction> {
@@ -153,6 +181,10 @@ class $ProposalActionCodec with _i1.Codec<ProposalAction> {
         return SpendNative._decode(input);
       case 8:
         return IssueSwapNativeOption._decode(input);
+      case 9:
+        return SpendAsset._decode(input);
+      case 10:
+        return IssueSwapAssetOption._decode(input);
       default:
         throw Exception('ProposalAction: Invalid variant index: "$index"');
     }
@@ -191,6 +223,12 @@ class $ProposalActionCodec with _i1.Codec<ProposalAction> {
       case IssueSwapNativeOption:
         (value as IssueSwapNativeOption).encodeTo(output);
         break;
+      case SpendAsset:
+        (value as SpendAsset).encodeTo(output);
+        break;
+      case IssueSwapAssetOption:
+        (value as IssueSwapAssetOption).encodeTo(output);
+        break;
       default:
         throw Exception('ProposalAction: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -217,6 +255,10 @@ class $ProposalActionCodec with _i1.Codec<ProposalAction> {
         return (value as SpendNative)._sizeHint();
       case IssueSwapNativeOption:
         return (value as IssueSwapNativeOption)._sizeHint();
+      case SpendAsset:
+        return (value as SpendAsset)._sizeHint();
+      case IssueSwapAssetOption:
+        return (value as IssueSwapAssetOption)._sizeHint();
       default:
         throw Exception('ProposalAction: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -642,7 +684,7 @@ class Petition extends ProposalAction {
       ) ||
       other is Petition &&
           other.value0 == value0 &&
-          _i10.listsEqual(
+          _i12.listsEqual(
             other.value1,
             value1,
           );
@@ -722,7 +764,7 @@ class SpendNative extends ProposalAction {
       ) ||
       other is SpendNative &&
           other.value0 == value0 &&
-          _i10.listsEqual(
+          _i12.listsEqual(
             other.value1,
             value1,
           ) &&
@@ -804,7 +846,184 @@ class IssueSwapNativeOption extends ProposalAction {
       ) ||
       other is IssueSwapNativeOption &&
           other.value0 == value0 &&
-          _i10.listsEqual(
+          _i12.listsEqual(
+            other.value1,
+            value1,
+          ) &&
+          other.value2 == value2;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+      );
+}
+
+class SpendAsset extends ProposalAction {
+  const SpendAsset(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+  );
+
+  factory SpendAsset._decode(_i1.Input input) {
+    return SpendAsset(
+      const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).decode(input),
+      const _i1.U8ArrayCodec(32).decode(input),
+      _i1.U128Codec.codec.decode(input),
+      _i10.VersionedLocatableAsset.codec.decode(input),
+    );
+  }
+
+  /// Option<CommunityIdentifier>
+  final _i3.CommunityIdentifier? value0;
+
+  /// AccountId
+  final _i8.AccountId32 value1;
+
+  /// Balance
+  final BigInt value2;
+
+  /// AssetId
+  final _i10.VersionedLocatableAsset value3;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {
+        'SpendAsset': [
+          value0?.toJson(),
+          value1.toList(),
+          value2,
+          value3.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).sizeHint(value0);
+    size = size + const _i8.AccountId32Codec().sizeHint(value1);
+    size = size + _i1.U128Codec.codec.sizeHint(value2);
+    size = size + _i10.VersionedLocatableAsset.codec.sizeHint(value3);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).encodeTo(
+      value0,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value1,
+      output,
+    );
+    _i1.U128Codec.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i10.VersionedLocatableAsset.codec.encodeTo(
+      value3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SpendAsset &&
+          other.value0 == value0 &&
+          _i12.listsEqual(
+            other.value1,
+            value1,
+          ) &&
+          other.value2 == value2 &&
+          other.value3 == value3;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+      );
+}
+
+class IssueSwapAssetOption extends ProposalAction {
+  const IssueSwapAssetOption(
+    this.value0,
+    this.value1,
+    this.value2,
+  );
+
+  factory IssueSwapAssetOption._decode(_i1.Input input) {
+    return IssueSwapAssetOption(
+      _i3.CommunityIdentifier.codec.decode(input),
+      const _i1.U8ArrayCodec(32).decode(input),
+      _i11.SwapAssetOption.codec.decode(input),
+    );
+  }
+
+  /// CommunityIdentifier
+  final _i3.CommunityIdentifier value0;
+
+  /// AccountId
+  final _i8.AccountId32 value1;
+
+  /// SwapAssetOption<Balance, Moment, AssetId>
+  final _i11.SwapAssetOption value2;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {
+        'IssueSwapAssetOption': [
+          value0.toJson(),
+          value1.toList(),
+          value2.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.CommunityIdentifier.codec.sizeHint(value0);
+    size = size + const _i8.AccountId32Codec().sizeHint(value1);
+    size = size + _i11.SwapAssetOption.codec.sizeHint(value2);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+    _i3.CommunityIdentifier.codec.encodeTo(
+      value0,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value1,
+      output,
+    );
+    _i11.SwapAssetOption.codec.encodeTo(
+      value2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is IssueSwapAssetOption &&
+          other.value0 == value0 &&
+          _i12.listsEqual(
             other.value1,
             value1,
           ) &&

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action_identifier.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/democracy/proposal_action_identifier.dart
@@ -67,6 +67,14 @@ class $ProposalActionIdentifier {
   IssueSwapNativeOption issueSwapNativeOption(_i3.CommunityIdentifier value0) {
     return IssueSwapNativeOption(value0);
   }
+
+  SpendAsset spendAsset(_i3.CommunityIdentifier? value0) {
+    return SpendAsset(value0);
+  }
+
+  IssueSwapAssetOption issueSwapAssetOption(_i3.CommunityIdentifier value0) {
+    return IssueSwapAssetOption(value0);
+  }
 }
 
 class $ProposalActionIdentifierCodec with _i1.Codec<ProposalActionIdentifier> {
@@ -94,6 +102,10 @@ class $ProposalActionIdentifierCodec with _i1.Codec<ProposalActionIdentifier> {
         return SpendNative._decode(input);
       case 8:
         return IssueSwapNativeOption._decode(input);
+      case 9:
+        return SpendAsset._decode(input);
+      case 10:
+        return IssueSwapAssetOption._decode(input);
       default:
         throw Exception('ProposalActionIdentifier: Invalid variant index: "$index"');
     }
@@ -132,6 +144,12 @@ class $ProposalActionIdentifierCodec with _i1.Codec<ProposalActionIdentifier> {
       case IssueSwapNativeOption:
         (value as IssueSwapNativeOption).encodeTo(output);
         break;
+      case SpendAsset:
+        (value as SpendAsset).encodeTo(output);
+        break;
+      case IssueSwapAssetOption:
+        (value as IssueSwapAssetOption).encodeTo(output);
+        break;
       default:
         throw Exception('ProposalActionIdentifier: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -158,6 +176,10 @@ class $ProposalActionIdentifierCodec with _i1.Codec<ProposalActionIdentifier> {
         return (value as SpendNative)._sizeHint();
       case IssueSwapNativeOption:
         return (value as IssueSwapNativeOption)._sizeHint();
+      case SpendAsset:
+        return (value as SpendAsset)._sizeHint();
+      case IssueSwapAssetOption:
+        return (value as IssueSwapAssetOption)._sizeHint();
       default:
         throw Exception('ProposalActionIdentifier: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -515,6 +537,90 @@ class IssueSwapNativeOption extends ProposalActionIdentifier {
         other,
       ) ||
       other is IssueSwapNativeOption && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SpendAsset extends ProposalActionIdentifier {
+  const SpendAsset(this.value0);
+
+  factory SpendAsset._decode(_i1.Input input) {
+    return SpendAsset(const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).decode(input));
+  }
+
+  /// Option<CommunityIdentifier>
+  final _i3.CommunityIdentifier? value0;
+
+  @override
+  Map<String, Map<String, List<int>>?> toJson() => {'SpendAsset': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    const _i1.OptionCodec<_i3.CommunityIdentifier>(_i3.CommunityIdentifier.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SpendAsset && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class IssueSwapAssetOption extends ProposalActionIdentifier {
+  const IssueSwapAssetOption(this.value0);
+
+  factory IssueSwapAssetOption._decode(_i1.Input input) {
+    return IssueSwapAssetOption(_i3.CommunityIdentifier.codec.decode(input));
+  }
+
+  /// CommunityIdentifier
+  final _i3.CommunityIdentifier value0;
+
+  @override
+  Map<String, Map<String, List<int>>> toJson() => {'IssueSwapAssetOption': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.CommunityIdentifier.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+    _i3.CommunityIdentifier.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is IssueSwapAssetOption && other.value0 == value0;
 
   @override
   int get hashCode => value0.hashCode;

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/treasuries/swap_asset_option.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/encointer_primitives/treasuries/swap_asset_option.dart
@@ -1,0 +1,152 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i5;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../polkadot_runtime_common/impls/versioned_locatable_asset.dart' as _i3;
+import '../../substrate_fixed/fixed_u128.dart' as _i4;
+import '../communities/community_identifier.dart' as _i2;
+
+class SwapAssetOption {
+  const SwapAssetOption({
+    required this.cid,
+    required this.assetId,
+    required this.assetAllowance,
+    this.rate,
+    required this.doBurn,
+    this.validFrom,
+    this.validUntil,
+  });
+
+  factory SwapAssetOption.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// CommunityIdentifier
+  final _i2.CommunityIdentifier cid;
+
+  /// AssetId
+  final _i3.VersionedLocatableAsset assetId;
+
+  /// NativeBalance
+  final BigInt assetAllowance;
+
+  /// Option<BalanceType>
+  final _i4.FixedU128? rate;
+
+  /// bool
+  final bool doBurn;
+
+  /// Option<Moment>
+  final BigInt? validFrom;
+
+  /// Option<Moment>
+  final BigInt? validUntil;
+
+  static const $SwapAssetOptionCodec codec = $SwapAssetOptionCodec();
+
+  _i5.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'cid': cid.toJson(),
+        'assetId': assetId.toJson(),
+        'assetAllowance': assetAllowance,
+        'rate': rate?.toJson(),
+        'doBurn': doBurn,
+        'validFrom': validFrom,
+        'validUntil': validUntil,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SwapAssetOption &&
+          other.cid == cid &&
+          other.assetId == assetId &&
+          other.assetAllowance == assetAllowance &&
+          other.rate == rate &&
+          other.doBurn == doBurn &&
+          other.validFrom == validFrom &&
+          other.validUntil == validUntil;
+
+  @override
+  int get hashCode => Object.hash(
+        cid,
+        assetId,
+        assetAllowance,
+        rate,
+        doBurn,
+        validFrom,
+        validUntil,
+      );
+}
+
+class $SwapAssetOptionCodec with _i1.Codec<SwapAssetOption> {
+  const $SwapAssetOptionCodec();
+
+  @override
+  void encodeTo(
+    SwapAssetOption obj,
+    _i1.Output output,
+  ) {
+    _i2.CommunityIdentifier.codec.encodeTo(
+      obj.cid,
+      output,
+    );
+    _i3.VersionedLocatableAsset.codec.encodeTo(
+      obj.assetId,
+      output,
+    );
+    _i1.U128Codec.codec.encodeTo(
+      obj.assetAllowance,
+      output,
+    );
+    const _i1.OptionCodec<_i4.FixedU128>(_i4.FixedU128.codec).encodeTo(
+      obj.rate,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      obj.doBurn,
+      output,
+    );
+    const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).encodeTo(
+      obj.validFrom,
+      output,
+    );
+    const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).encodeTo(
+      obj.validUntil,
+      output,
+    );
+  }
+
+  @override
+  SwapAssetOption decode(_i1.Input input) {
+    return SwapAssetOption(
+      cid: _i2.CommunityIdentifier.codec.decode(input),
+      assetId: _i3.VersionedLocatableAsset.codec.decode(input),
+      assetAllowance: _i1.U128Codec.codec.decode(input),
+      rate: const _i1.OptionCodec<_i4.FixedU128>(_i4.FixedU128.codec).decode(input),
+      doBurn: _i1.BoolCodec.codec.decode(input),
+      validFrom: const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).decode(input),
+      validUntil: const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(SwapAssetOption obj) {
+    int size = 0;
+    size = size + _i2.CommunityIdentifier.codec.sizeHint(obj.cid);
+    size = size + _i3.VersionedLocatableAsset.codec.sizeHint(obj.assetId);
+    size = size + _i1.U128Codec.codec.sizeHint(obj.assetAllowance);
+    size = size + const _i1.OptionCodec<_i4.FixedU128>(_i4.FixedU128.codec).sizeHint(obj.rate);
+    size = size + _i1.BoolCodec.codec.sizeHint(obj.doBurn);
+    size = size + const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).sizeHint(obj.validFrom);
+    size = size + const _i1.OptionCodec<BigInt>(_i1.U64Codec.codec).sizeHint(obj.validUntil);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_democracy/pallet/call.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_democracy/pallet/call.dart
@@ -118,7 +118,8 @@ class SubmitProposal extends Call {
     return SubmitProposal(proposalAction: _i3.ProposalAction.codec.decode(input));
   }
 
-  /// ProposalAction<T::AccountId, BalanceOf<T>, T::Moment>
+  /// Box<ProposalAction<T::AccountId, BalanceOf<T>, T::Moment,
+  ///AssetKindOf<T>>,>
   final _i3.ProposalAction proposalAction;
 
   @override

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_democracy/pallet/event.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_democracy/pallet/event.dart
@@ -247,7 +247,8 @@ class ProposalSubmitted extends Event {
   /// ProposalIdType
   final BigInt proposalId;
 
-  /// ProposalAction<T::AccountId, BalanceOf<T>, T::Moment>
+  /// ProposalAction<T::AccountId, BalanceOf<T>, T::Moment, AssetKindOf<
+  ///T>>
   final _i3.ProposalAction proposalAction;
 
   @override

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/call.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/call.dart
@@ -42,6 +42,16 @@ class $Call {
       desiredNativeAmount: desiredNativeAmount,
     );
   }
+
+  SwapAsset swapAsset({
+    required _i3.CommunityIdentifier cid,
+    required BigInt desiredAssetAmount,
+  }) {
+    return SwapAsset(
+      cid: cid,
+      desiredAssetAmount: desiredAssetAmount,
+    );
+  }
 }
 
 class $CallCodec with _i1.Codec<Call> {
@@ -53,6 +63,8 @@ class $CallCodec with _i1.Codec<Call> {
     switch (index) {
       case 0:
         return SwapNative._decode(input);
+      case 1:
+        return SwapAsset._decode(input);
       default:
         throw Exception('Call: Invalid variant index: "$index"');
     }
@@ -67,6 +79,9 @@ class $CallCodec with _i1.Codec<Call> {
       case SwapNative:
         (value as SwapNative).encodeTo(output);
         break;
+      case SwapAsset:
+        (value as SwapAsset).encodeTo(output);
+        break;
       default:
         throw Exception('Call: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -77,6 +92,8 @@ class $CallCodec with _i1.Codec<Call> {
     switch (value.runtimeType) {
       case SwapNative:
         return (value as SwapNative)._sizeHint();
+      case SwapAsset:
+        return (value as SwapAsset)._sizeHint();
       default:
         throw Exception('Call: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -146,5 +163,71 @@ class SwapNative extends Call {
   int get hashCode => Object.hash(
         cid,
         desiredNativeAmount,
+      );
+}
+
+/// swap native tokens for community currency subject to an existing swap option for the
+/// sender account.
+class SwapAsset extends Call {
+  const SwapAsset({
+    required this.cid,
+    required this.desiredAssetAmount,
+  });
+
+  factory SwapAsset._decode(_i1.Input input) {
+    return SwapAsset(
+      cid: _i3.CommunityIdentifier.codec.decode(input),
+      desiredAssetAmount: _i1.U128Codec.codec.decode(input),
+    );
+  }
+
+  /// CommunityIdentifier
+  final _i3.CommunityIdentifier cid;
+
+  /// BalanceOf<T>
+  final BigInt desiredAssetAmount;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'swap_asset': {
+          'cid': cid.toJson(),
+          'desiredAssetAmount': desiredAssetAmount,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.CommunityIdentifier.codec.sizeHint(cid);
+    size = size + _i1.U128Codec.codec.sizeHint(desiredAssetAmount);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.CommunityIdentifier.codec.encodeTo(
+      cid,
+      output,
+    );
+    _i1.U128Codec.codec.encodeTo(
+      desiredAssetAmount,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SwapAsset && other.cid == cid && other.desiredAssetAmount == desiredAssetAmount;
+
+  @override
+  int get hashCode => Object.hash(
+        cid,
+        desiredAssetAmount,
       );
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/error.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/error.dart
@@ -10,7 +10,8 @@ enum Error {
   swapRateNotDefined('SwapRateNotDefined', 1),
   swapOverflow('SwapOverflow', 2),
   insufficientNativeFunds('InsufficientNativeFunds', 3),
-  insufficientAllowance('InsufficientAllowance', 4);
+  insufficientAllowance('InsufficientAllowance', 4),
+  payoutError('PayoutError', 5);
 
   const Error(
     this.variantName,
@@ -51,6 +52,8 @@ class $ErrorCodec with _i1.Codec<Error> {
         return Error.insufficientNativeFunds;
       case 4:
         return Error.insufficientAllowance;
+      case 5:
+        return Error.payoutError;
       default:
         throw Exception('Error: Invalid variant index: "$index"');
     }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/event.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/pallet_encointer_treasuries/pallet/event.dart
@@ -2,9 +2,10 @@
 import 'dart:typed_data' as _i2;
 
 import 'package:polkadart/scale_codec.dart' as _i1;
-import 'package:quiver/collection.dart' as _i5;
+import 'package:quiver/collection.dart' as _i6;
 
-import '../../encointer_primitives/communities/community_identifier.dart' as _i4;
+import '../../encointer_primitives/communities/community_identifier.dart' as _i5;
+import '../../polkadot_runtime_common/impls/versioned_locatable_asset.dart' as _i4;
 import '../../sp_core/crypto/account_id32.dart' as _i3;
 
 /// The `Event` enum of this pallet
@@ -47,13 +48,39 @@ class $Event {
     );
   }
 
+  SpentAsset spentAsset({
+    required _i3.AccountId32 treasury,
+    required _i3.AccountId32 beneficiary,
+    required _i4.VersionedLocatableAsset assetId,
+    required BigInt amount,
+  }) {
+    return SpentAsset(
+      treasury: treasury,
+      beneficiary: beneficiary,
+      assetId: assetId,
+      amount: amount,
+    );
+  }
+
   GrantedSwapNativeOption grantedSwapNativeOption({
-    required _i4.CommunityIdentifier cid,
+    required _i5.CommunityIdentifier cid,
     required _i3.AccountId32 who,
   }) {
     return GrantedSwapNativeOption(
       cid: cid,
       who: who,
+    );
+  }
+
+  GrantedSwapAssetOption grantedSwapAssetOption({
+    required _i5.CommunityIdentifier cid,
+    required _i3.AccountId32 who,
+    required _i4.VersionedLocatableAsset assetId,
+  }) {
+    return GrantedSwapAssetOption(
+      cid: cid,
+      who: who,
+      assetId: assetId,
     );
   }
 }
@@ -68,7 +95,11 @@ class $EventCodec with _i1.Codec<Event> {
       case 0:
         return SpentNative._decode(input);
       case 1:
+        return SpentAsset._decode(input);
+      case 2:
         return GrantedSwapNativeOption._decode(input);
+      case 3:
+        return GrantedSwapAssetOption._decode(input);
       default:
         throw Exception('Event: Invalid variant index: "$index"');
     }
@@ -83,8 +114,14 @@ class $EventCodec with _i1.Codec<Event> {
       case SpentNative:
         (value as SpentNative).encodeTo(output);
         break;
+      case SpentAsset:
+        (value as SpentAsset).encodeTo(output);
+        break;
       case GrantedSwapNativeOption:
         (value as GrantedSwapNativeOption).encodeTo(output);
+        break;
+      case GrantedSwapAssetOption:
+        (value as GrantedSwapAssetOption).encodeTo(output);
         break;
       default:
         throw Exception('Event: Unsupported "$value" of type "${value.runtimeType}"');
@@ -96,8 +133,12 @@ class $EventCodec with _i1.Codec<Event> {
     switch (value.runtimeType) {
       case SpentNative:
         return (value as SpentNative)._sizeHint();
+      case SpentAsset:
+        return (value as SpentAsset)._sizeHint();
       case GrantedSwapNativeOption:
         return (value as GrantedSwapNativeOption)._sizeHint();
+      case GrantedSwapAssetOption:
+        return (value as GrantedSwapAssetOption)._sizeHint();
       default:
         throw Exception('Event: Unsupported "$value" of type "${value.runtimeType}"');
     }
@@ -172,11 +213,11 @@ class SpentNative extends Event {
         other,
       ) ||
       other is SpentNative &&
-          _i5.listsEqual(
+          _i6.listsEqual(
             other.treasury,
             treasury,
           ) &&
-          _i5.listsEqual(
+          _i6.listsEqual(
             other.beneficiary,
             beneficiary,
           ) &&
@@ -190,6 +231,104 @@ class SpentNative extends Event {
       );
 }
 
+class SpentAsset extends Event {
+  const SpentAsset({
+    required this.treasury,
+    required this.beneficiary,
+    required this.assetId,
+    required this.amount,
+  });
+
+  factory SpentAsset._decode(_i1.Input input) {
+    return SpentAsset(
+      treasury: const _i1.U8ArrayCodec(32).decode(input),
+      beneficiary: const _i1.U8ArrayCodec(32).decode(input),
+      assetId: _i4.VersionedLocatableAsset.codec.decode(input),
+      amount: _i1.U128Codec.codec.decode(input),
+    );
+  }
+
+  /// T::AccountId
+  final _i3.AccountId32 treasury;
+
+  /// T::AccountId
+  final _i3.AccountId32 beneficiary;
+
+  /// T::AssetKind
+  final _i4.VersionedLocatableAsset assetId;
+
+  /// BalanceOf<T>
+  final BigInt amount;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SpentAsset': {
+          'treasury': treasury.toList(),
+          'beneficiary': beneficiary.toList(),
+          'assetId': assetId.toJson(),
+          'amount': amount,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AccountId32Codec().sizeHint(treasury);
+    size = size + const _i3.AccountId32Codec().sizeHint(beneficiary);
+    size = size + _i4.VersionedLocatableAsset.codec.sizeHint(assetId);
+    size = size + _i1.U128Codec.codec.sizeHint(amount);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      treasury,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      beneficiary,
+      output,
+    );
+    _i4.VersionedLocatableAsset.codec.encodeTo(
+      assetId,
+      output,
+    );
+    _i1.U128Codec.codec.encodeTo(
+      amount,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SpentAsset &&
+          _i6.listsEqual(
+            other.treasury,
+            treasury,
+          ) &&
+          _i6.listsEqual(
+            other.beneficiary,
+            beneficiary,
+          ) &&
+          other.assetId == assetId &&
+          other.amount == amount;
+
+  @override
+  int get hashCode => Object.hash(
+        treasury,
+        beneficiary,
+        assetId,
+        amount,
+      );
+}
+
 class GrantedSwapNativeOption extends Event {
   const GrantedSwapNativeOption({
     required this.cid,
@@ -198,13 +337,13 @@ class GrantedSwapNativeOption extends Event {
 
   factory GrantedSwapNativeOption._decode(_i1.Input input) {
     return GrantedSwapNativeOption(
-      cid: _i4.CommunityIdentifier.codec.decode(input),
+      cid: _i5.CommunityIdentifier.codec.decode(input),
       who: const _i1.U8ArrayCodec(32).decode(input),
     );
   }
 
   /// CommunityIdentifier
-  final _i4.CommunityIdentifier cid;
+  final _i5.CommunityIdentifier cid;
 
   /// T::AccountId
   final _i3.AccountId32 who;
@@ -219,17 +358,17 @@ class GrantedSwapNativeOption extends Event {
 
   int _sizeHint() {
     int size = 1;
-    size = size + _i4.CommunityIdentifier.codec.sizeHint(cid);
+    size = size + _i5.CommunityIdentifier.codec.sizeHint(cid);
     size = size + const _i3.AccountId32Codec().sizeHint(who);
     return size;
   }
 
   void encodeTo(_i1.Output output) {
     _i1.U8Codec.codec.encodeTo(
-      1,
+      2,
       output,
     );
-    _i4.CommunityIdentifier.codec.encodeTo(
+    _i5.CommunityIdentifier.codec.encodeTo(
       cid,
       output,
     );
@@ -247,7 +386,7 @@ class GrantedSwapNativeOption extends Event {
       ) ||
       other is GrantedSwapNativeOption &&
           other.cid == cid &&
-          _i5.listsEqual(
+          _i6.listsEqual(
             other.who,
             who,
           );
@@ -256,5 +395,87 @@ class GrantedSwapNativeOption extends Event {
   int get hashCode => Object.hash(
         cid,
         who,
+      );
+}
+
+class GrantedSwapAssetOption extends Event {
+  const GrantedSwapAssetOption({
+    required this.cid,
+    required this.who,
+    required this.assetId,
+  });
+
+  factory GrantedSwapAssetOption._decode(_i1.Input input) {
+    return GrantedSwapAssetOption(
+      cid: _i5.CommunityIdentifier.codec.decode(input),
+      who: const _i1.U8ArrayCodec(32).decode(input),
+      assetId: _i4.VersionedLocatableAsset.codec.decode(input),
+    );
+  }
+
+  /// CommunityIdentifier
+  final _i5.CommunityIdentifier cid;
+
+  /// T::AccountId
+  final _i3.AccountId32 who;
+
+  /// T::AssetKind
+  final _i4.VersionedLocatableAsset assetId;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'GrantedSwapAssetOption': {
+          'cid': cid.toJson(),
+          'who': who.toList(),
+          'assetId': assetId.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i5.CommunityIdentifier.codec.sizeHint(cid);
+    size = size + const _i3.AccountId32Codec().sizeHint(who);
+    size = size + _i4.VersionedLocatableAsset.codec.sizeHint(assetId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i5.CommunityIdentifier.codec.encodeTo(
+      cid,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      who,
+      output,
+    );
+    _i4.VersionedLocatableAsset.codec.encodeTo(
+      assetId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GrantedSwapAssetOption &&
+          other.cid == cid &&
+          _i6.listsEqual(
+            other.who,
+            who,
+          ) &&
+          other.assetId == assetId;
+
+  @override
+  int get hashCode => Object.hash(
+        cid,
+        who,
+        assetId,
       );
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/polkadot_runtime_common/impls/versioned_locatable_asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/polkadot_runtime_common/impls/versioned_locatable_asset.dart
@@ -1,0 +1,314 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../staging_xcm/v3/multilocation/multi_location.dart' as _i3;
+import '../../staging_xcm/v4/asset/asset_id.dart' as _i6;
+import '../../staging_xcm/v4/location/location.dart' as _i5;
+import '../../staging_xcm/v5/asset/asset_id.dart' as _i8;
+import '../../staging_xcm/v5/location/location.dart' as _i7;
+import '../../xcm/v3/multiasset/asset_id.dart' as _i4;
+
+abstract class VersionedLocatableAsset {
+  const VersionedLocatableAsset();
+
+  factory VersionedLocatableAsset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedLocatableAssetCodec codec = $VersionedLocatableAssetCodec();
+
+  static const $VersionedLocatableAsset values = $VersionedLocatableAsset();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, Map<String, dynamic>>> toJson();
+}
+
+class $VersionedLocatableAsset {
+  const $VersionedLocatableAsset();
+
+  V3 v3({
+    required _i3.MultiLocation location,
+    required _i4.AssetId assetId,
+  }) {
+    return V3(
+      location: location,
+      assetId: assetId,
+    );
+  }
+
+  V4 v4({
+    required _i5.Location location,
+    required _i6.AssetId assetId,
+  }) {
+    return V4(
+      location: location,
+      assetId: assetId,
+    );
+  }
+
+  V5 v5({
+    required _i7.Location location,
+    required _i8.AssetId assetId,
+  }) {
+    return V5(
+      location: location,
+      assetId: assetId,
+    );
+  }
+}
+
+class $VersionedLocatableAssetCodec with _i1.Codec<VersionedLocatableAsset> {
+  const $VersionedLocatableAssetCodec();
+
+  @override
+  VersionedLocatableAsset decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedLocatableAsset: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedLocatableAsset value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedLocatableAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedLocatableAsset value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedLocatableAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedLocatableAsset {
+  const V3({
+    required this.location,
+    required this.assetId,
+  });
+
+  factory V3._decode(_i1.Input input) {
+    return V3(
+      location: _i3.MultiLocation.codec.decode(input),
+      assetId: _i4.AssetId.codec.decode(input),
+    );
+  }
+
+  /// xcm::v3::Location
+  final _i3.MultiLocation location;
+
+  /// xcm::v3::AssetId
+  final _i4.AssetId assetId;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'V3': {
+          'location': location.toJson(),
+          'assetId': assetId.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.MultiLocation.codec.sizeHint(location);
+    size = size + _i4.AssetId.codec.sizeHint(assetId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.MultiLocation.codec.encodeTo(
+      location,
+      output,
+    );
+    _i4.AssetId.codec.encodeTo(
+      assetId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 && other.location == location && other.assetId == assetId;
+
+  @override
+  int get hashCode => Object.hash(
+        location,
+        assetId,
+      );
+}
+
+class V4 extends VersionedLocatableAsset {
+  const V4({
+    required this.location,
+    required this.assetId,
+  });
+
+  factory V4._decode(_i1.Input input) {
+    return V4(
+      location: _i5.Location.codec.decode(input),
+      assetId: _i5.Location.codec.decode(input),
+    );
+  }
+
+  /// xcm::v4::Location
+  final _i5.Location location;
+
+  /// xcm::v4::AssetId
+  final _i6.AssetId assetId;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'V4': {
+          'location': location.toJson(),
+          'assetId': assetId.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i5.Location.codec.sizeHint(location);
+    size = size + const _i6.AssetIdCodec().sizeHint(assetId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      location,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      assetId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 && other.location == location && other.assetId == assetId;
+
+  @override
+  int get hashCode => Object.hash(
+        location,
+        assetId,
+      );
+}
+
+class V5 extends VersionedLocatableAsset {
+  const V5({
+    required this.location,
+    required this.assetId,
+  });
+
+  factory V5._decode(_i1.Input input) {
+    return V5(
+      location: _i7.Location.codec.decode(input),
+      assetId: _i7.Location.codec.decode(input),
+    );
+  }
+
+  /// xcm::v5::Location
+  final _i7.Location location;
+
+  /// xcm::v5::AssetId
+  final _i8.AssetId assetId;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'V5': {
+          'location': location.toJson(),
+          'assetId': assetId.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i7.Location.codec.sizeHint(location);
+    size = size + const _i8.AssetIdCodec().sizeHint(assetId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i7.Location.codec.encodeTo(
+      location,
+      output,
+    );
+    _i7.Location.codec.encodeTo(
+      assetId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 && other.location == location && other.assetId == assetId;
+
+  @override
+  int get hashCode => Object.hash(
+        location,
+        assetId,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v3/multilocation/multi_location.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v3/multilocation/multi_location.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i3;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../../xcm/v3/junctions/junctions.dart' as _i2;
+
+class MultiLocation {
+  const MultiLocation({
+    required this.parents,
+    required this.interior,
+  });
+
+  factory MultiLocation.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u8
+  final int parents;
+
+  /// Junctions
+  final _i2.Junctions interior;
+
+  static const $MultiLocationCodec codec = $MultiLocationCodec();
+
+  _i3.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'parents': parents,
+        'interior': interior.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is MultiLocation && other.parents == parents && other.interior == interior;
+
+  @override
+  int get hashCode => Object.hash(
+        parents,
+        interior,
+      );
+}
+
+class $MultiLocationCodec with _i1.Codec<MultiLocation> {
+  const $MultiLocationCodec();
+
+  @override
+  void encodeTo(
+    MultiLocation obj,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      obj.parents,
+      output,
+    );
+    _i2.Junctions.codec.encodeTo(
+      obj.interior,
+      output,
+    );
+  }
+
+  @override
+  MultiLocation decode(_i1.Input input) {
+    return MultiLocation(
+      parents: _i1.U8Codec.codec.decode(input),
+      interior: _i2.Junctions.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(MultiLocation obj) {
+    int size = 0;
+    size = size + _i1.U8Codec.codec.sizeHint(obj.parents);
+    size = size + _i2.Junctions.codec.sizeHint(obj.interior);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset.dart
@@ -1,0 +1,85 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../location/location.dart' as _i5;
+import 'asset_id.dart' as _i2;
+import 'fungibility.dart' as _i3;
+
+class Asset {
+  const Asset({
+    required this.id,
+    required this.fun,
+  });
+
+  factory Asset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// AssetId
+  final _i2.AssetId id;
+
+  /// Fungibility
+  final _i3.Fungibility fun;
+
+  static const $AssetCodec codec = $AssetCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson() => {
+        'id': id.toJson(),
+        'fun': fun.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Asset && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class $AssetCodec with _i1.Codec<Asset> {
+  const $AssetCodec();
+
+  @override
+  void encodeTo(
+    Asset obj,
+    _i1.Output output,
+  ) {
+    _i5.Location.codec.encodeTo(
+      obj.id,
+      output,
+    );
+    _i3.Fungibility.codec.encodeTo(
+      obj.fun,
+      output,
+    );
+  }
+
+  @override
+  Asset decode(_i1.Input input) {
+    return Asset(
+      id: _i5.Location.codec.decode(input),
+      fun: _i3.Fungibility.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Asset obj) {
+    int size = 0;
+    size = size + const _i2.AssetIdCodec().sizeHint(obj.id);
+    size = size + _i3.Fungibility.codec.sizeHint(obj.fun);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_filter.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_filter.dart
@@ -1,0 +1,180 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import 'asset.dart' as _i5;
+import 'assets.dart' as _i3;
+import 'wild_asset.dart' as _i4;
+
+abstract class AssetFilter {
+  const AssetFilter();
+
+  factory AssetFilter.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetFilterCodec codec = $AssetFilterCodec();
+
+  static const $AssetFilter values = $AssetFilter();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetFilter {
+  const $AssetFilter();
+
+  Definite definite(_i3.Assets value0) {
+    return Definite(value0);
+  }
+
+  Wild wild(_i4.WildAsset value0) {
+    return Wild(value0);
+  }
+}
+
+class $AssetFilterCodec with _i1.Codec<AssetFilter> {
+  const $AssetFilterCodec();
+
+  @override
+  AssetFilter decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Definite._decode(input);
+      case 1:
+        return Wild._decode(input);
+      default:
+        throw Exception('AssetFilter: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetFilter value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Definite:
+        (value as Definite).encodeTo(output);
+        break;
+      case Wild:
+        (value as Wild).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetFilter value) {
+    switch (value.runtimeType) {
+      case Definite:
+        return (value as Definite)._sizeHint();
+      case Wild:
+        return (value as Wild)._sizeHint();
+      default:
+        throw Exception('AssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Definite extends AssetFilter {
+  const Definite(this.value0);
+
+  factory Definite._decode(_i1.Input input) {
+    return Definite(const _i1.SequenceCodec<_i5.Asset>(_i5.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Definite': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i5.Asset>(_i5.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Definite &&
+          _i6.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Wild extends AssetFilter {
+  const Wild(this.value0);
+
+  factory Wild._decode(_i1.Input input) {
+    return Wild(_i4.WildAsset.codec.decode(input));
+  }
+
+  /// WildAsset
+  final _i4.WildAsset value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Wild': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.WildAsset.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i4.WildAsset.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Wild && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_id.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import '../location/location.dart' as _i1;
+
+typedef AssetId = _i1.Location;
+
+class AssetIdCodec with _i2.Codec<AssetId> {
+  const AssetIdCodec();
+
+  @override
+  AssetId decode(_i2.Input input) {
+    return _i1.Location.codec.decode(input);
+  }
+
+  @override
+  void encodeTo(
+    AssetId value,
+    _i2.Output output,
+  ) {
+    _i1.Location.codec.encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(AssetId value) {
+    return _i1.Location.codec.sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_instance.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/asset_instance.dart
@@ -1,0 +1,377 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class AssetInstance {
+  const AssetInstance();
+
+  factory AssetInstance.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetInstanceCodec codec = $AssetInstanceCodec();
+
+  static const $AssetInstance values = $AssetInstance();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetInstance {
+  const $AssetInstance();
+
+  Undefined undefined() {
+    return Undefined();
+  }
+
+  Index index(BigInt value0) {
+    return Index(value0);
+  }
+
+  Array4 array4(List<int> value0) {
+    return Array4(value0);
+  }
+
+  Array8 array8(List<int> value0) {
+    return Array8(value0);
+  }
+
+  Array16 array16(List<int> value0) {
+    return Array16(value0);
+  }
+
+  Array32 array32(List<int> value0) {
+    return Array32(value0);
+  }
+}
+
+class $AssetInstanceCodec with _i1.Codec<AssetInstance> {
+  const $AssetInstanceCodec();
+
+  @override
+  AssetInstance decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Undefined();
+      case 1:
+        return Index._decode(input);
+      case 2:
+        return Array4._decode(input);
+      case 3:
+        return Array8._decode(input);
+      case 4:
+        return Array16._decode(input);
+      case 5:
+        return Array32._decode(input);
+      default:
+        throw Exception('AssetInstance: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetInstance value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Undefined:
+        (value as Undefined).encodeTo(output);
+        break;
+      case Index:
+        (value as Index).encodeTo(output);
+        break;
+      case Array4:
+        (value as Array4).encodeTo(output);
+        break;
+      case Array8:
+        (value as Array8).encodeTo(output);
+        break;
+      case Array16:
+        (value as Array16).encodeTo(output);
+        break;
+      case Array32:
+        (value as Array32).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetInstance value) {
+    switch (value.runtimeType) {
+      case Undefined:
+        return 1;
+      case Index:
+        return (value as Index)._sizeHint();
+      case Array4:
+        return (value as Array4)._sizeHint();
+      case Array8:
+        return (value as Array8)._sizeHint();
+      case Array16:
+        return (value as Array16)._sizeHint();
+      case Array32:
+        return (value as Array32)._sizeHint();
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Undefined extends AssetInstance {
+  const Undefined();
+
+  @override
+  Map<String, dynamic> toJson() => {'Undefined': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Undefined;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Index extends AssetInstance {
+  const Index(this.value0);
+
+  factory Index._decode(_i1.Input input) {
+    return Index(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Index': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Index && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array4 extends AssetInstance {
+  const Array4(this.value0);
+
+  factory Array4._decode(_i1.Input input) {
+    return Array4(const _i1.U8ArrayCodec(4).decode(input));
+  }
+
+  /// [u8; 4]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array4': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(4).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.U8ArrayCodec(4).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array4 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array8 extends AssetInstance {
+  const Array8(this.value0);
+
+  factory Array8._decode(_i1.Input input) {
+    return Array8(const _i1.U8ArrayCodec(8).decode(input));
+  }
+
+  /// [u8; 8]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array8': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(8).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.U8ArrayCodec(8).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array8 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array16 extends AssetInstance {
+  const Array16(this.value0);
+
+  factory Array16._decode(_i1.Input input) {
+    return Array16(const _i1.U8ArrayCodec(16).decode(input));
+  }
+
+  /// [u8; 16]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array16': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(16).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.U8ArrayCodec(16).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array16 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array32 extends AssetInstance {
+  const Array32(this.value0);
+
+  factory Array32._decode(_i1.Input input) {
+    return Array32(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array32': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array32 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/assets.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/assets.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'asset.dart' as _i1;
+
+typedef Assets = List<_i1.Asset>;
+
+class AssetsCodec with _i2.Codec<Assets> {
+  const AssetsCodec();
+
+  @override
+  Assets decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Assets value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Assets value) {
+    return const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/fungibility.dart
@@ -1,0 +1,172 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_instance.dart' as _i3;
+
+abstract class Fungibility {
+  const Fungibility();
+
+  factory Fungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $FungibilityCodec codec = $FungibilityCodec();
+
+  static const $Fungibility values = $Fungibility();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Fungibility {
+  const $Fungibility();
+
+  Fungible fungible(BigInt value0) {
+    return Fungible(value0);
+  }
+
+  NonFungible nonFungible(_i3.AssetInstance value0) {
+    return NonFungible(value0);
+  }
+}
+
+class $FungibilityCodec with _i1.Codec<Fungibility> {
+  const $FungibilityCodec();
+
+  @override
+  Fungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Fungible._decode(input);
+      case 1:
+        return NonFungible._decode(input);
+      default:
+        throw Exception('Fungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Fungibility value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Fungible:
+        (value as Fungible).encodeTo(output);
+        break;
+      case NonFungible:
+        (value as NonFungible).encodeTo(output);
+        break;
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Fungibility value) {
+    switch (value.runtimeType) {
+      case Fungible:
+        return (value as Fungible)._sizeHint();
+      case NonFungible:
+        return (value as NonFungible)._sizeHint();
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Fungible extends Fungibility {
+  const Fungible(this.value0);
+
+  factory Fungible._decode(_i1.Input input) {
+    return Fungible(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Fungible': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Fungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class NonFungible extends Fungibility {
+  const NonFungible(this.value0);
+
+  factory NonFungible._decode(_i1.Input input) {
+    return NonFungible(_i3.AssetInstance.codec.decode(input));
+  }
+
+  /// AssetInstance
+  final _i3.AssetInstance value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'NonFungible': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetInstance.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.AssetInstance.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NonFungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/wild_asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/wild_asset.dart
@@ -1,0 +1,328 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../location/location.dart' as _i5;
+import 'asset_id.dart' as _i3;
+import 'wild_fungibility.dart' as _i4;
+
+abstract class WildAsset {
+  const WildAsset();
+
+  factory WildAsset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $WildAssetCodec codec = $WildAssetCodec();
+
+  static const $WildAsset values = $WildAsset();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $WildAsset {
+  const $WildAsset();
+
+  All all() {
+    return All();
+  }
+
+  AllOf allOf({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+  }) {
+    return AllOf(
+      id: id,
+      fun: fun,
+    );
+  }
+
+  AllCounted allCounted(BigInt value0) {
+    return AllCounted(value0);
+  }
+
+  AllOfCounted allOfCounted({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+    required BigInt count,
+  }) {
+    return AllOfCounted(
+      id: id,
+      fun: fun,
+      count: count,
+    );
+  }
+}
+
+class $WildAssetCodec with _i1.Codec<WildAsset> {
+  const $WildAssetCodec();
+
+  @override
+  WildAsset decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const All();
+      case 1:
+        return AllOf._decode(input);
+      case 2:
+        return AllCounted._decode(input);
+      case 3:
+        return AllOfCounted._decode(input);
+      default:
+        throw Exception('WildAsset: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildAsset value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case All:
+        (value as All).encodeTo(output);
+        break;
+      case AllOf:
+        (value as AllOf).encodeTo(output);
+        break;
+      case AllCounted:
+        (value as AllCounted).encodeTo(output);
+        break;
+      case AllOfCounted:
+        (value as AllOfCounted).encodeTo(output);
+        break;
+      default:
+        throw Exception('WildAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(WildAsset value) {
+    switch (value.runtimeType) {
+      case All:
+        return 1;
+      case AllOf:
+        return (value as AllOf)._sizeHint();
+      case AllCounted:
+        return (value as AllCounted)._sizeHint();
+      case AllOfCounted:
+        return (value as AllOfCounted)._sizeHint();
+      default:
+        throw Exception('WildAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class All extends WildAsset {
+  const All();
+
+  @override
+  Map<String, dynamic> toJson() => {'All': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is All;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AllOf extends WildAsset {
+  const AllOf({
+    required this.id,
+    required this.fun,
+  });
+
+  factory AllOf._decode(_i1.Input input) {
+    return AllOf(
+      id: _i5.Location.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOf': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetIdCodec().sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOf && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class AllCounted extends WildAsset {
+  const AllCounted(this.value0);
+
+  factory AllCounted._decode(_i1.Input input) {
+    return AllCounted(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'AllCounted': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllCounted && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AllOfCounted extends WildAsset {
+  const AllOfCounted({
+    required this.id,
+    required this.fun,
+    required this.count,
+  });
+
+  factory AllOfCounted._decode(_i1.Input input) {
+    return AllOfCounted(
+      id: _i5.Location.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+      count: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  /// u32
+  final BigInt count;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOfCounted': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+          'count': count,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetIdCodec().sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(count);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      count,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOfCounted && other.id == id && other.fun == fun && other.count == count;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+        count,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/wild_fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/asset/wild_fungibility.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+enum WildFungibility {
+  fungible('Fungible', 0),
+  nonFungible('NonFungible', 1);
+
+  const WildFungibility(
+    this.variantName,
+    this.codecIndex,
+  );
+
+  factory WildFungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  final String variantName;
+
+  final int codecIndex;
+
+  static const $WildFungibilityCodec codec = $WildFungibilityCodec();
+
+  String toJson() => variantName;
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+}
+
+class $WildFungibilityCodec with _i1.Codec<WildFungibility> {
+  const $WildFungibilityCodec();
+
+  @override
+  WildFungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WildFungibility.fungible;
+      case 1:
+        return WildFungibility.nonFungible;
+      default:
+        throw Exception('WildFungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildFungibility value,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      value.codecIndex,
+      output,
+    );
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/instruction_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/instruction_1.dart
@@ -1,0 +1,3470 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i20;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../tuples.dart' as _i15;
+import '../../xcm/double_encoded/double_encoded_1.dart' as _i9;
+import '../../xcm/v3/maybe_error_code.dart' as _i17;
+import '../../xcm/v3/origin_kind.dart' as _i8;
+import '../../xcm/v3/traits/error.dart' as _i16;
+import '../../xcm/v3/weight_limit.dart' as _i14;
+import 'asset/asset.dart' as _i13;
+import 'asset/asset_filter.dart' as _i12;
+import 'asset/assets.dart' as _i3;
+import 'instruction_1.dart' as _i21;
+import 'junction/junction.dart' as _i18;
+import 'junction/network_id.dart' as _i19;
+import 'junctions/junctions.dart' as _i10;
+import 'location/location.dart' as _i6;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'xcm_1.dart' as _i7;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.Assets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.Assets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.Assets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.Location? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.Assets assets,
+    required _i6.Location beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.Assets assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    required _i5.Weight requireWeightAtMost,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      requireWeightAtMost: requireWeightAtMost,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.AssetFilter give,
+    required _i3.Assets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.AssetFilter assets,
+    required _i6.Location reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.AssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.Asset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i7.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i7.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.Assets assets,
+    required _i6.Location ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.Assets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.Assets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.Location? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i15.Tuple2<int, _i16.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i17.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i18.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i19.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.Asset asset,
+    required _i6.Location unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.Asset asset,
+    required _i6.Location target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.Asset asset,
+    required _i6.Location owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.Asset asset,
+    required _i6.Location locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.Location value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.Location? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<Location>
+  final _i6.Location? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    required this.requireWeightAtMost,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      requireWeightAtMost: _i5.Weight.codec.decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Weight
+  final _i5.Weight requireWeightAtMost;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'requireWeightAtMost': requireWeightAtMost.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + _i5.Weight.codec.sizeHint(requireWeightAtMost);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      requireWeightAtMost,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.requireWeightAtMost == requireWeightAtMost &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        requireWeightAtMost,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.AssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter give;
+
+  /// Assets
+  final _i3.Assets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(give);
+    size = size + const _i3.AssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i20.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.AssetFilter.codec.decode(input),
+      reserve: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.AssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.Asset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      ticket: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input));
+  }
+
+  /// Option<Location>
+  final _i6.Location? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i15.Tuple2<int, _i16.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+          _i1.U32Codec.codec,
+          _i16.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i17.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i17.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i17.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i17.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i20.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i20.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i20.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i18.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i18.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i18.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i19.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i19.NetworkId network;
+
+  /// InteriorLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i19.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      unlocker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      target: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.Asset.codec.decode(input),
+      owner: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.Asset.codec.decode(input),
+      locker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.Location.codec.decode(input));
+  }
+
+  /// Location
+  final _i6.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<Location>
+  final _i6.Location? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/instruction_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/instruction_2.dart
@@ -1,0 +1,3473 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i21;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../tuples.dart' as _i16;
+import '../../xcm/double_encoded/double_encoded_2.dart' as _i9;
+import '../../xcm/v3/maybe_error_code.dart' as _i18;
+import '../../xcm/v3/origin_kind.dart' as _i8;
+import '../../xcm/v3/traits/error.dart' as _i17;
+import '../../xcm/v3/weight_limit.dart' as _i14;
+import 'asset/asset.dart' as _i13;
+import 'asset/asset_filter.dart' as _i12;
+import 'asset/assets.dart' as _i3;
+import 'instruction_1.dart' as _i22;
+import 'instruction_2.dart' as _i23;
+import 'junction/junction.dart' as _i19;
+import 'junction/network_id.dart' as _i20;
+import 'junctions/junctions.dart' as _i10;
+import 'location/location.dart' as _i6;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'xcm_1.dart' as _i7;
+import 'xcm_2.dart' as _i15;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.Assets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.Assets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.Assets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.Location? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.Assets assets,
+    required _i6.Location beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.Assets assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    required _i5.Weight requireWeightAtMost,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      requireWeightAtMost: requireWeightAtMost,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.AssetFilter give,
+    required _i3.Assets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.AssetFilter assets,
+    required _i6.Location reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.AssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.Asset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i15.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i15.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.Assets assets,
+    required _i6.Location ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.Assets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.Assets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.Location? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i16.Tuple2<int, _i17.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i18.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i19.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i20.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.Asset asset,
+    required _i6.Location unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.Asset asset,
+    required _i6.Location target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.Asset asset,
+    required _i6.Location owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.Asset asset,
+    required _i6.Location locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.Location value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.Location? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<Location>
+  final _i6.Location? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    required this.requireWeightAtMost,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      requireWeightAtMost: _i5.Weight.codec.decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Weight
+  final _i5.Weight requireWeightAtMost;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'requireWeightAtMost': requireWeightAtMost.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + _i5.Weight.codec.sizeHint(requireWeightAtMost);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      requireWeightAtMost,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.requireWeightAtMost == requireWeightAtMost &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        requireWeightAtMost,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.AssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter give;
+
+  /// Assets
+  final _i3.Assets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(give);
+    size = size + const _i3.AssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i21.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.AssetFilter.codec.decode(input),
+      reserve: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.AssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.Asset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() =>
+      {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      ticket: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input));
+  }
+
+  /// Option<Location>
+  final _i6.Location? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i16.Tuple2<int, _i17.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+          _i1.U32Codec.codec,
+          _i17.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i18.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i18.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i18.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i21.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i21.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i21.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i19.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i19.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i19.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i20.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i20.NetworkId network;
+
+  /// InteriorLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i20.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i20.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      unlocker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      target: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.Asset.codec.decode(input),
+      owner: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.Asset.codec.decode(input),
+      locker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.Location.codec.decode(input));
+  }
+
+  /// Location
+  final _i6.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<Location>
+  final _i6.Location? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junction/junction.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junction/junction.dart
@@ -1,0 +1,732 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import '../../../xcm/v3/junction/body_id.dart' as _i4;
+import '../../../xcm/v3/junction/body_part.dart' as _i5;
+import 'network_id.dart' as _i3;
+
+abstract class Junction {
+  const Junction();
+
+  factory Junction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionCodec codec = $JunctionCodec();
+
+  static const $Junction values = $Junction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junction {
+  const $Junction();
+
+  Parachain parachain(BigInt value0) {
+    return Parachain(value0);
+  }
+
+  AccountId32 accountId32({
+    _i3.NetworkId? network,
+    required List<int> id,
+  }) {
+    return AccountId32(
+      network: network,
+      id: id,
+    );
+  }
+
+  AccountIndex64 accountIndex64({
+    _i3.NetworkId? network,
+    required BigInt index,
+  }) {
+    return AccountIndex64(
+      network: network,
+      index: index,
+    );
+  }
+
+  AccountKey20 accountKey20({
+    _i3.NetworkId? network,
+    required List<int> key,
+  }) {
+    return AccountKey20(
+      network: network,
+      key: key,
+    );
+  }
+
+  PalletInstance palletInstance(int value0) {
+    return PalletInstance(value0);
+  }
+
+  GeneralIndex generalIndex(BigInt value0) {
+    return GeneralIndex(value0);
+  }
+
+  GeneralKey generalKey({
+    required int length,
+    required List<int> data,
+  }) {
+    return GeneralKey(
+      length: length,
+      data: data,
+    );
+  }
+
+  OnlyChild onlyChild() {
+    return OnlyChild();
+  }
+
+  Plurality plurality({
+    required _i4.BodyId id,
+    required _i5.BodyPart part,
+  }) {
+    return Plurality(
+      id: id,
+      part: part,
+    );
+  }
+
+  GlobalConsensus globalConsensus(_i3.NetworkId value0) {
+    return GlobalConsensus(value0);
+  }
+}
+
+class $JunctionCodec with _i1.Codec<Junction> {
+  const $JunctionCodec();
+
+  @override
+  Junction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Parachain._decode(input);
+      case 1:
+        return AccountId32._decode(input);
+      case 2:
+        return AccountIndex64._decode(input);
+      case 3:
+        return AccountKey20._decode(input);
+      case 4:
+        return PalletInstance._decode(input);
+      case 5:
+        return GeneralIndex._decode(input);
+      case 6:
+        return GeneralKey._decode(input);
+      case 7:
+        return const OnlyChild();
+      case 8:
+        return Plurality._decode(input);
+      case 9:
+        return GlobalConsensus._decode(input);
+      default:
+        throw Exception('Junction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Parachain:
+        (value as Parachain).encodeTo(output);
+        break;
+      case AccountId32:
+        (value as AccountId32).encodeTo(output);
+        break;
+      case AccountIndex64:
+        (value as AccountIndex64).encodeTo(output);
+        break;
+      case AccountKey20:
+        (value as AccountKey20).encodeTo(output);
+        break;
+      case PalletInstance:
+        (value as PalletInstance).encodeTo(output);
+        break;
+      case GeneralIndex:
+        (value as GeneralIndex).encodeTo(output);
+        break;
+      case GeneralKey:
+        (value as GeneralKey).encodeTo(output);
+        break;
+      case OnlyChild:
+        (value as OnlyChild).encodeTo(output);
+        break;
+      case Plurality:
+        (value as Plurality).encodeTo(output);
+        break;
+      case GlobalConsensus:
+        (value as GlobalConsensus).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junction value) {
+    switch (value.runtimeType) {
+      case Parachain:
+        return (value as Parachain)._sizeHint();
+      case AccountId32:
+        return (value as AccountId32)._sizeHint();
+      case AccountIndex64:
+        return (value as AccountIndex64)._sizeHint();
+      case AccountKey20:
+        return (value as AccountKey20)._sizeHint();
+      case PalletInstance:
+        return (value as PalletInstance)._sizeHint();
+      case GeneralIndex:
+        return (value as GeneralIndex)._sizeHint();
+      case GeneralKey:
+        return (value as GeneralKey)._sizeHint();
+      case OnlyChild:
+        return 1;
+      case Plurality:
+        return (value as Plurality)._sizeHint();
+      case GlobalConsensus:
+        return (value as GlobalConsensus)._sizeHint();
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Parachain extends Junction {
+  const Parachain(this.value0);
+
+  factory Parachain._decode(_i1.Input input) {
+    return Parachain(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Parachain': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Parachain && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AccountId32 extends Junction {
+  const AccountId32({
+    this.network,
+    required this.id,
+  });
+
+  factory AccountId32._decode(_i1.Input input) {
+    return AccountId32(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      id: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 32]
+  final List<int> id;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountId32': {
+          'network': network?.toJson(),
+          'id': id.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(id);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      id,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountId32 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.id,
+            id,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        id,
+      );
+}
+
+class AccountIndex64 extends Junction {
+  const AccountIndex64({
+    this.network,
+    required this.index,
+  });
+
+  factory AccountIndex64._decode(_i1.Input input) {
+    return AccountIndex64(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// u64
+  final BigInt index;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountIndex64': {
+          'network': network?.toJson(),
+          'index': index,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountIndex64 && other.network == network && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        index,
+      );
+}
+
+class AccountKey20 extends Junction {
+  const AccountKey20({
+    this.network,
+    required this.key,
+  });
+
+  factory AccountKey20._decode(_i1.Input input) {
+    return AccountKey20(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      key: const _i1.U8ArrayCodec(20).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 20]
+  final List<int> key;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountKey20': {
+          'network': network?.toJson(),
+          'key': key.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(20).sizeHint(key);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(20).encodeTo(
+      key,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountKey20 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.key,
+            key,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        key,
+      );
+}
+
+class PalletInstance extends Junction {
+  const PalletInstance(this.value0);
+
+  factory PalletInstance._decode(_i1.Input input) {
+    return PalletInstance(_i1.U8Codec.codec.decode(input));
+  }
+
+  /// u8
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'PalletInstance': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInstance && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralIndex extends Junction {
+  const GeneralIndex(this.value0);
+
+  factory GeneralIndex._decode(_i1.Input input) {
+    return GeneralIndex(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'GeneralIndex': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralIndex && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralKey extends Junction {
+  const GeneralKey({
+    required this.length,
+    required this.data,
+  });
+
+  factory GeneralKey._decode(_i1.Input input) {
+    return GeneralKey(
+      length: _i1.U8Codec.codec.decode(input),
+      data: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u8
+  final int length;
+
+  /// [u8; 32]
+  final List<int> data;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'GeneralKey': {
+          'length': length,
+          'data': data.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(length);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(data);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      length,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      data,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralKey &&
+          other.length == length &&
+          _i6.listsEqual(
+            other.data,
+            data,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        length,
+        data,
+      );
+}
+
+class OnlyChild extends Junction {
+  const OnlyChild();
+
+  @override
+  Map<String, dynamic> toJson() => {'OnlyChild': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is OnlyChild;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Plurality extends Junction {
+  const Plurality({
+    required this.id,
+    required this.part,
+  });
+
+  factory Plurality._decode(_i1.Input input) {
+    return Plurality(
+      id: _i4.BodyId.codec.decode(input),
+      part: _i5.BodyPart.codec.decode(input),
+    );
+  }
+
+  /// BodyId
+  final _i4.BodyId id;
+
+  /// BodyPart
+  final _i5.BodyPart part;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'Plurality': {
+          'id': id.toJson(),
+          'part': part.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.BodyId.codec.sizeHint(id);
+    size = size + _i5.BodyPart.codec.sizeHint(part);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i4.BodyId.codec.encodeTo(
+      id,
+      output,
+    );
+    _i5.BodyPart.codec.encodeTo(
+      part,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Plurality && other.id == id && other.part == part;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        part,
+      );
+}
+
+class GlobalConsensus extends Junction {
+  const GlobalConsensus(this.value0);
+
+  factory GlobalConsensus._decode(_i1.Input input) {
+    return GlobalConsensus(_i3.NetworkId.codec.decode(input));
+  }
+
+  /// NetworkId
+  final _i3.NetworkId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'GlobalConsensus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.NetworkId.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i3.NetworkId.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GlobalConsensus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junction/network_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junction/network_id.dart
@@ -1,0 +1,511 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class NetworkId {
+  const NetworkId();
+
+  factory NetworkId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $NetworkIdCodec codec = $NetworkIdCodec();
+
+  static const $NetworkId values = $NetworkId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $NetworkId {
+  const $NetworkId();
+
+  ByGenesis byGenesis(List<int> value0) {
+    return ByGenesis(value0);
+  }
+
+  ByFork byFork({
+    required BigInt blockNumber,
+    required List<int> blockHash,
+  }) {
+    return ByFork(
+      blockNumber: blockNumber,
+      blockHash: blockHash,
+    );
+  }
+
+  Polkadot polkadot() {
+    return Polkadot();
+  }
+
+  Kusama kusama() {
+    return Kusama();
+  }
+
+  Westend westend() {
+    return Westend();
+  }
+
+  Rococo rococo() {
+    return Rococo();
+  }
+
+  Wococo wococo() {
+    return Wococo();
+  }
+
+  Ethereum ethereum({required BigInt chainId}) {
+    return Ethereum(chainId: chainId);
+  }
+
+  BitcoinCore bitcoinCore() {
+    return BitcoinCore();
+  }
+
+  BitcoinCash bitcoinCash() {
+    return BitcoinCash();
+  }
+
+  PolkadotBulletin polkadotBulletin() {
+    return PolkadotBulletin();
+  }
+}
+
+class $NetworkIdCodec with _i1.Codec<NetworkId> {
+  const $NetworkIdCodec();
+
+  @override
+  NetworkId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return ByGenesis._decode(input);
+      case 1:
+        return ByFork._decode(input);
+      case 2:
+        return const Polkadot();
+      case 3:
+        return const Kusama();
+      case 4:
+        return const Westend();
+      case 5:
+        return const Rococo();
+      case 6:
+        return const Wococo();
+      case 7:
+        return Ethereum._decode(input);
+      case 8:
+        return const BitcoinCore();
+      case 9:
+        return const BitcoinCash();
+      case 10:
+        return const PolkadotBulletin();
+      default:
+        throw Exception('NetworkId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    NetworkId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        (value as ByGenesis).encodeTo(output);
+        break;
+      case ByFork:
+        (value as ByFork).encodeTo(output);
+        break;
+      case Polkadot:
+        (value as Polkadot).encodeTo(output);
+        break;
+      case Kusama:
+        (value as Kusama).encodeTo(output);
+        break;
+      case Westend:
+        (value as Westend).encodeTo(output);
+        break;
+      case Rococo:
+        (value as Rococo).encodeTo(output);
+        break;
+      case Wococo:
+        (value as Wococo).encodeTo(output);
+        break;
+      case Ethereum:
+        (value as Ethereum).encodeTo(output);
+        break;
+      case BitcoinCore:
+        (value as BitcoinCore).encodeTo(output);
+        break;
+      case BitcoinCash:
+        (value as BitcoinCash).encodeTo(output);
+        break;
+      case PolkadotBulletin:
+        (value as PolkadotBulletin).encodeTo(output);
+        break;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(NetworkId value) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        return (value as ByGenesis)._sizeHint();
+      case ByFork:
+        return (value as ByFork)._sizeHint();
+      case Polkadot:
+        return 1;
+      case Kusama:
+        return 1;
+      case Westend:
+        return 1;
+      case Rococo:
+        return 1;
+      case Wococo:
+        return 1;
+      case Ethereum:
+        return (value as Ethereum)._sizeHint();
+      case BitcoinCore:
+        return 1;
+      case BitcoinCash:
+        return 1;
+      case PolkadotBulletin:
+        return 1;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class ByGenesis extends NetworkId {
+  const ByGenesis(this.value0);
+
+  factory ByGenesis._decode(_i1.Input input) {
+    return ByGenesis(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'ByGenesis': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByGenesis &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ByFork extends NetworkId {
+  const ByFork({
+    required this.blockNumber,
+    required this.blockHash,
+  });
+
+  factory ByFork._decode(_i1.Input input) {
+    return ByFork(
+      blockNumber: _i1.U64Codec.codec.decode(input),
+      blockHash: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u64
+  final BigInt blockNumber;
+
+  /// [u8; 32]
+  final List<int> blockHash;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ByFork': {
+          'blockNumber': blockNumber,
+          'blockHash': blockHash.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U64Codec.codec.sizeHint(blockNumber);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(blockHash);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.U64Codec.codec.encodeTo(
+      blockNumber,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      blockHash,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByFork &&
+          other.blockNumber == blockNumber &&
+          _i3.listsEqual(
+            other.blockHash,
+            blockHash,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        blockNumber,
+        blockHash,
+      );
+}
+
+class Polkadot extends NetworkId {
+  const Polkadot();
+
+  @override
+  Map<String, dynamic> toJson() => {'Polkadot': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Polkadot;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Kusama extends NetworkId {
+  const Kusama();
+
+  @override
+  Map<String, dynamic> toJson() => {'Kusama': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Kusama;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Westend extends NetworkId {
+  const Westend();
+
+  @override
+  Map<String, dynamic> toJson() => {'Westend': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Westend;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Rococo extends NetworkId {
+  const Rococo();
+
+  @override
+  Map<String, dynamic> toJson() => {'Rococo': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Rococo;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Wococo extends NetworkId {
+  const Wococo();
+
+  @override
+  Map<String, dynamic> toJson() => {'Wococo': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Wococo;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Ethereum extends NetworkId {
+  const Ethereum({required this.chainId});
+
+  factory Ethereum._decode(_i1.Input input) {
+    return Ethereum(chainId: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt chainId;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'Ethereum': {'chainId': chainId}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(chainId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      chainId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Ethereum && other.chainId == chainId;
+
+  @override
+  int get hashCode => chainId.hashCode;
+}
+
+class BitcoinCore extends NetworkId {
+  const BitcoinCore();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCore': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCore;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BitcoinCash extends NetworkId {
+  const BitcoinCash();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCash': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCash;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class PolkadotBulletin extends NetworkId {
+  const PolkadotBulletin();
+
+  @override
+  Map<String, dynamic> toJson() => {'PolkadotBulletin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is PolkadotBulletin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junctions/junctions.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/junctions/junctions.dart
@@ -1,0 +1,634 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i4;
+
+import '../junction/junction.dart' as _i3;
+
+abstract class Junctions {
+  const Junctions();
+
+  factory Junctions.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionsCodec codec = $JunctionsCodec();
+
+  static const $Junctions values = $Junctions();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junctions {
+  const $Junctions();
+
+  Here here() {
+    return Here();
+  }
+
+  X1 x1(List<_i3.Junction> value0) {
+    return X1(value0);
+  }
+
+  X2 x2(List<_i3.Junction> value0) {
+    return X2(value0);
+  }
+
+  X3 x3(List<_i3.Junction> value0) {
+    return X3(value0);
+  }
+
+  X4 x4(List<_i3.Junction> value0) {
+    return X4(value0);
+  }
+
+  X5 x5(List<_i3.Junction> value0) {
+    return X5(value0);
+  }
+
+  X6 x6(List<_i3.Junction> value0) {
+    return X6(value0);
+  }
+
+  X7 x7(List<_i3.Junction> value0) {
+    return X7(value0);
+  }
+
+  X8 x8(List<_i3.Junction> value0) {
+    return X8(value0);
+  }
+}
+
+class $JunctionsCodec with _i1.Codec<Junctions> {
+  const $JunctionsCodec();
+
+  @override
+  Junctions decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Here();
+      case 1:
+        return X1._decode(input);
+      case 2:
+        return X2._decode(input);
+      case 3:
+        return X3._decode(input);
+      case 4:
+        return X4._decode(input);
+      case 5:
+        return X5._decode(input);
+      case 6:
+        return X6._decode(input);
+      case 7:
+        return X7._decode(input);
+      case 8:
+        return X8._decode(input);
+      default:
+        throw Exception('Junctions: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junctions value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Here:
+        (value as Here).encodeTo(output);
+        break;
+      case X1:
+        (value as X1).encodeTo(output);
+        break;
+      case X2:
+        (value as X2).encodeTo(output);
+        break;
+      case X3:
+        (value as X3).encodeTo(output);
+        break;
+      case X4:
+        (value as X4).encodeTo(output);
+        break;
+      case X5:
+        (value as X5).encodeTo(output);
+        break;
+      case X6:
+        (value as X6).encodeTo(output);
+        break;
+      case X7:
+        (value as X7).encodeTo(output);
+        break;
+      case X8:
+        (value as X8).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junctions value) {
+    switch (value.runtimeType) {
+      case Here:
+        return 1;
+      case X1:
+        return (value as X1)._sizeHint();
+      case X2:
+        return (value as X2)._sizeHint();
+      case X3:
+        return (value as X3)._sizeHint();
+      case X4:
+        return (value as X4)._sizeHint();
+      case X5:
+        return (value as X5)._sizeHint();
+      case X6:
+        return (value as X6)._sizeHint();
+      case X7:
+        return (value as X7)._sizeHint();
+      case X8:
+        return (value as X8)._sizeHint();
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Here extends Junctions {
+  const Here();
+
+  @override
+  Map<String, dynamic> toJson() => {'Here': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Here;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class X1 extends Junctions {
+  const X1(this.value0);
+
+  factory X1._decode(_i1.Input input) {
+    return X1(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      1,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 1]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X1': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          1,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      1,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X1 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X2 extends Junctions {
+  const X2(this.value0);
+
+  factory X2._decode(_i1.Input input) {
+    return X2(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      2,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 2]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X2': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          2,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      2,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X2 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X3 extends Junctions {
+  const X3(this.value0);
+
+  factory X3._decode(_i1.Input input) {
+    return X3(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      3,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 3]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X3': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          3,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      3,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X3 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X4 extends Junctions {
+  const X4(this.value0);
+
+  factory X4._decode(_i1.Input input) {
+    return X4(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      4,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 4]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X4': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          4,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      4,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X4 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X5 extends Junctions {
+  const X5(this.value0);
+
+  factory X5._decode(_i1.Input input) {
+    return X5(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      5,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 5]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X5': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          5,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      5,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X5 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X6 extends Junctions {
+  const X6(this.value0);
+
+  factory X6._decode(_i1.Input input) {
+    return X6(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      6,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 6]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X6': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          6,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      6,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X6 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X7 extends Junctions {
+  const X7(this.value0);
+
+  factory X7._decode(_i1.Input input) {
+    return X7(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      7,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 7]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X7': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          7,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      7,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X7 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X8 extends Junctions {
+  const X8(this.value0);
+
+  factory X8._decode(_i1.Input input) {
+    return X8(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      8,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 8]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X8': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          8,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      8,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X8 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/location/location.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/location/location.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i3;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../junctions/junctions.dart' as _i2;
+
+class Location {
+  const Location({
+    required this.parents,
+    required this.interior,
+  });
+
+  factory Location.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u8
+  final int parents;
+
+  /// Junctions
+  final _i2.Junctions interior;
+
+  static const $LocationCodec codec = $LocationCodec();
+
+  _i3.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'parents': parents,
+        'interior': interior.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Location && other.parents == parents && other.interior == interior;
+
+  @override
+  int get hashCode => Object.hash(
+        parents,
+        interior,
+      );
+}
+
+class $LocationCodec with _i1.Codec<Location> {
+  const $LocationCodec();
+
+  @override
+  void encodeTo(
+    Location obj,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      obj.parents,
+      output,
+    );
+    _i2.Junctions.codec.encodeTo(
+      obj.interior,
+      output,
+    );
+  }
+
+  @override
+  Location decode(_i1.Input input) {
+    return Location(
+      parents: _i1.U8Codec.codec.decode(input),
+      interior: _i2.Junctions.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Location obj) {
+    int size = 0;
+    size = size + _i1.U8Codec.codec.sizeHint(obj.parents);
+    size = size + _i2.Junctions.codec.sizeHint(obj.interior);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/pallet_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/pallet_info.dart
@@ -1,0 +1,142 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+class PalletInfo {
+  const PalletInfo({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.major,
+    required this.minor,
+    required this.patch,
+  });
+
+  factory PalletInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> name;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt major;
+
+  /// u32
+  final BigInt minor;
+
+  /// u32
+  final BigInt patch;
+
+  static const $PalletInfoCodec codec = $PalletInfoCodec();
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'name': name,
+        'moduleName': moduleName,
+        'major': major,
+        'minor': minor,
+        'patch': patch,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInfo &&
+          other.index == index &&
+          _i3.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i3.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.major == major &&
+          other.minor == minor &&
+          other.patch == patch;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        major,
+        minor,
+        patch,
+      );
+}
+
+class $PalletInfoCodec with _i1.Codec<PalletInfo> {
+  const $PalletInfoCodec();
+
+  @override
+  void encodeTo(
+    PalletInfo obj,
+    _i1.Output output,
+  ) {
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.major,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.minor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.patch,
+      output,
+    );
+  }
+
+  @override
+  PalletInfo decode(_i1.Input input) {
+    return PalletInfo(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      major: _i1.CompactBigIntCodec.codec.decode(input),
+      minor: _i1.CompactBigIntCodec.codec.decode(input),
+      patch: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(PalletInfo obj) {
+    int size = 0;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.major);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.minor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.patch);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/query_response_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/query_response_info.dart
@@ -1,0 +1,99 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i3;
+import 'location/location.dart' as _i2;
+
+class QueryResponseInfo {
+  const QueryResponseInfo({
+    required this.destination,
+    required this.queryId,
+    required this.maxWeight,
+  });
+
+  factory QueryResponseInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// Location
+  final _i2.Location destination;
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i3.Weight maxWeight;
+
+  static const $QueryResponseInfoCodec codec = $QueryResponseInfoCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'destination': destination.toJson(),
+        'queryId': queryId,
+        'maxWeight': maxWeight.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponseInfo &&
+          other.destination == destination &&
+          other.queryId == queryId &&
+          other.maxWeight == maxWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        destination,
+        queryId,
+        maxWeight,
+      );
+}
+
+class $QueryResponseInfoCodec with _i1.Codec<QueryResponseInfo> {
+  const $QueryResponseInfoCodec();
+
+  @override
+  void encodeTo(
+    QueryResponseInfo obj,
+    _i1.Output output,
+  ) {
+    _i2.Location.codec.encodeTo(
+      obj.destination,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.queryId,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      obj.maxWeight,
+      output,
+    );
+  }
+
+  @override
+  QueryResponseInfo decode(_i1.Input input) {
+    return QueryResponseInfo(
+      destination: _i2.Location.codec.decode(input),
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxWeight: _i3.Weight.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(QueryResponseInfo obj) {
+    int size = 0;
+    size = size + _i2.Location.codec.sizeHint(obj.destination);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.queryId);
+    size = size + _i3.Weight.codec.sizeHint(obj.maxWeight);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/response.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/response.dart
@@ -1,0 +1,392 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i9;
+
+import '../../tuples.dart' as _i4;
+import '../../xcm/v3/maybe_error_code.dart' as _i7;
+import '../../xcm/v3/traits/error.dart' as _i5;
+import 'asset/asset.dart' as _i8;
+import 'asset/assets.dart' as _i3;
+import 'pallet_info.dart' as _i6;
+
+abstract class Response {
+  const Response();
+
+  factory Response.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $ResponseCodec codec = $ResponseCodec();
+
+  static const $Response values = $Response();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Response {
+  const $Response();
+
+  Null null_() {
+    return Null();
+  }
+
+  Assets assets(_i3.Assets value0) {
+    return Assets(value0);
+  }
+
+  ExecutionResult executionResult(_i4.Tuple2<int, _i5.Error>? value0) {
+    return ExecutionResult(value0);
+  }
+
+  Version version(int value0) {
+    return Version(value0);
+  }
+
+  PalletsInfo palletsInfo(List<_i6.PalletInfo> value0) {
+    return PalletsInfo(value0);
+  }
+
+  DispatchResult dispatchResult(_i7.MaybeErrorCode value0) {
+    return DispatchResult(value0);
+  }
+}
+
+class $ResponseCodec with _i1.Codec<Response> {
+  const $ResponseCodec();
+
+  @override
+  Response decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Null();
+      case 1:
+        return Assets._decode(input);
+      case 2:
+        return ExecutionResult._decode(input);
+      case 3:
+        return Version._decode(input);
+      case 4:
+        return PalletsInfo._decode(input);
+      case 5:
+        return DispatchResult._decode(input);
+      default:
+        throw Exception('Response: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Response value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Null:
+        (value as Null).encodeTo(output);
+        break;
+      case Assets:
+        (value as Assets).encodeTo(output);
+        break;
+      case ExecutionResult:
+        (value as ExecutionResult).encodeTo(output);
+        break;
+      case Version:
+        (value as Version).encodeTo(output);
+        break;
+      case PalletsInfo:
+        (value as PalletsInfo).encodeTo(output);
+        break;
+      case DispatchResult:
+        (value as DispatchResult).encodeTo(output);
+        break;
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Response value) {
+    switch (value.runtimeType) {
+      case Null:
+        return 1;
+      case Assets:
+        return (value as Assets)._sizeHint();
+      case ExecutionResult:
+        return (value as ExecutionResult)._sizeHint();
+      case Version:
+        return (value as Version)._sizeHint();
+      case PalletsInfo:
+        return (value as PalletsInfo)._sizeHint();
+      case DispatchResult:
+        return (value as DispatchResult)._sizeHint();
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Null extends Response {
+  const Null();
+
+  @override
+  Map<String, dynamic> toJson() => {'Null': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Null;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Assets extends Response {
+  const Assets(this.value0);
+
+  factory Assets._decode(_i1.Input input) {
+    return Assets(const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Assets': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Assets &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExecutionResult extends Response {
+  const ExecutionResult(this.value0);
+
+  factory ExecutionResult._decode(_i1.Input input) {
+    return ExecutionResult(const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i4.Tuple2<int, _i5.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExecutionResult': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+          _i1.U32Codec.codec,
+          _i5.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExecutionResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Version extends Response {
+  const Version(this.value0);
+
+  factory Version._decode(_i1.Input input) {
+    return Version(_i1.U32Codec.codec.decode(input));
+  }
+
+  /// super::Version
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'Version': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U32Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.U32Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Version && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class PalletsInfo extends Response {
+  const PalletsInfo(this.value0);
+
+  factory PalletsInfo._decode(_i1.Input input) {
+    return PalletsInfo(const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).decode(input));
+  }
+
+  /// BoundedVec<PalletInfo, MaxPalletsInfo>
+  final List<_i6.PalletInfo> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'PalletsInfo': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletsInfo &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DispatchResult extends Response {
+  const DispatchResult(this.value0);
+
+  factory DispatchResult._decode(_i1.Input input) {
+    return DispatchResult(_i7.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i7.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DispatchResult': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i7.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i7.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DispatchResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/xcm_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/xcm_1.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_1.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/xcm_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v4/xcm_2.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_2.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset.dart
@@ -1,0 +1,85 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../location/location.dart' as _i5;
+import 'asset_id.dart' as _i2;
+import 'fungibility.dart' as _i3;
+
+class Asset {
+  const Asset({
+    required this.id,
+    required this.fun,
+  });
+
+  factory Asset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// AssetId
+  final _i2.AssetId id;
+
+  /// Fungibility
+  final _i3.Fungibility fun;
+
+  static const $AssetCodec codec = $AssetCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson() => {
+        'id': id.toJson(),
+        'fun': fun.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Asset && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class $AssetCodec with _i1.Codec<Asset> {
+  const $AssetCodec();
+
+  @override
+  void encodeTo(
+    Asset obj,
+    _i1.Output output,
+  ) {
+    _i5.Location.codec.encodeTo(
+      obj.id,
+      output,
+    );
+    _i3.Fungibility.codec.encodeTo(
+      obj.fun,
+      output,
+    );
+  }
+
+  @override
+  Asset decode(_i1.Input input) {
+    return Asset(
+      id: _i5.Location.codec.decode(input),
+      fun: _i3.Fungibility.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Asset obj) {
+    int size = 0;
+    size = size + const _i2.AssetIdCodec().sizeHint(obj.id);
+    size = size + _i3.Fungibility.codec.sizeHint(obj.fun);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_filter.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_filter.dart
@@ -1,0 +1,180 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import 'asset.dart' as _i5;
+import 'assets.dart' as _i3;
+import 'wild_asset.dart' as _i4;
+
+abstract class AssetFilter {
+  const AssetFilter();
+
+  factory AssetFilter.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetFilterCodec codec = $AssetFilterCodec();
+
+  static const $AssetFilter values = $AssetFilter();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetFilter {
+  const $AssetFilter();
+
+  Definite definite(_i3.Assets value0) {
+    return Definite(value0);
+  }
+
+  Wild wild(_i4.WildAsset value0) {
+    return Wild(value0);
+  }
+}
+
+class $AssetFilterCodec with _i1.Codec<AssetFilter> {
+  const $AssetFilterCodec();
+
+  @override
+  AssetFilter decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Definite._decode(input);
+      case 1:
+        return Wild._decode(input);
+      default:
+        throw Exception('AssetFilter: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetFilter value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Definite:
+        (value as Definite).encodeTo(output);
+        break;
+      case Wild:
+        (value as Wild).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetFilter value) {
+    switch (value.runtimeType) {
+      case Definite:
+        return (value as Definite)._sizeHint();
+      case Wild:
+        return (value as Wild)._sizeHint();
+      default:
+        throw Exception('AssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Definite extends AssetFilter {
+  const Definite(this.value0);
+
+  factory Definite._decode(_i1.Input input) {
+    return Definite(const _i1.SequenceCodec<_i5.Asset>(_i5.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Definite': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i5.Asset>(_i5.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Definite &&
+          _i6.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Wild extends AssetFilter {
+  const Wild(this.value0);
+
+  factory Wild._decode(_i1.Input input) {
+    return Wild(_i4.WildAsset.codec.decode(input));
+  }
+
+  /// WildAsset
+  final _i4.WildAsset value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Wild': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.WildAsset.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i4.WildAsset.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Wild && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_id.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import '../location/location.dart' as _i1;
+
+typedef AssetId = _i1.Location;
+
+class AssetIdCodec with _i2.Codec<AssetId> {
+  const AssetIdCodec();
+
+  @override
+  AssetId decode(_i2.Input input) {
+    return _i1.Location.codec.decode(input);
+  }
+
+  @override
+  void encodeTo(
+    AssetId value,
+    _i2.Output output,
+  ) {
+    _i1.Location.codec.encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(AssetId value) {
+    return _i1.Location.codec.sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_instance.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_instance.dart
@@ -1,0 +1,377 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class AssetInstance {
+  const AssetInstance();
+
+  factory AssetInstance.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetInstanceCodec codec = $AssetInstanceCodec();
+
+  static const $AssetInstance values = $AssetInstance();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetInstance {
+  const $AssetInstance();
+
+  Undefined undefined() {
+    return Undefined();
+  }
+
+  Index index(BigInt value0) {
+    return Index(value0);
+  }
+
+  Array4 array4(List<int> value0) {
+    return Array4(value0);
+  }
+
+  Array8 array8(List<int> value0) {
+    return Array8(value0);
+  }
+
+  Array16 array16(List<int> value0) {
+    return Array16(value0);
+  }
+
+  Array32 array32(List<int> value0) {
+    return Array32(value0);
+  }
+}
+
+class $AssetInstanceCodec with _i1.Codec<AssetInstance> {
+  const $AssetInstanceCodec();
+
+  @override
+  AssetInstance decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Undefined();
+      case 1:
+        return Index._decode(input);
+      case 2:
+        return Array4._decode(input);
+      case 3:
+        return Array8._decode(input);
+      case 4:
+        return Array16._decode(input);
+      case 5:
+        return Array32._decode(input);
+      default:
+        throw Exception('AssetInstance: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetInstance value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Undefined:
+        (value as Undefined).encodeTo(output);
+        break;
+      case Index:
+        (value as Index).encodeTo(output);
+        break;
+      case Array4:
+        (value as Array4).encodeTo(output);
+        break;
+      case Array8:
+        (value as Array8).encodeTo(output);
+        break;
+      case Array16:
+        (value as Array16).encodeTo(output);
+        break;
+      case Array32:
+        (value as Array32).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetInstance value) {
+    switch (value.runtimeType) {
+      case Undefined:
+        return 1;
+      case Index:
+        return (value as Index)._sizeHint();
+      case Array4:
+        return (value as Array4)._sizeHint();
+      case Array8:
+        return (value as Array8)._sizeHint();
+      case Array16:
+        return (value as Array16)._sizeHint();
+      case Array32:
+        return (value as Array32)._sizeHint();
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Undefined extends AssetInstance {
+  const Undefined();
+
+  @override
+  Map<String, dynamic> toJson() => {'Undefined': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Undefined;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Index extends AssetInstance {
+  const Index(this.value0);
+
+  factory Index._decode(_i1.Input input) {
+    return Index(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Index': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Index && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array4 extends AssetInstance {
+  const Array4(this.value0);
+
+  factory Array4._decode(_i1.Input input) {
+    return Array4(const _i1.U8ArrayCodec(4).decode(input));
+  }
+
+  /// [u8; 4]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array4': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(4).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.U8ArrayCodec(4).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array4 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array8 extends AssetInstance {
+  const Array8(this.value0);
+
+  factory Array8._decode(_i1.Input input) {
+    return Array8(const _i1.U8ArrayCodec(8).decode(input));
+  }
+
+  /// [u8; 8]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array8': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(8).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.U8ArrayCodec(8).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array8 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array16 extends AssetInstance {
+  const Array16(this.value0);
+
+  factory Array16._decode(_i1.Input input) {
+    return Array16(const _i1.U8ArrayCodec(16).decode(input));
+  }
+
+  /// [u8; 16]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array16': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(16).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.U8ArrayCodec(16).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array16 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array32 extends AssetInstance {
+  const Array32(this.value0);
+
+  factory Array32._decode(_i1.Input input) {
+    return Array32(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array32': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array32 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_transfer_filter.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/asset_transfer_filter.dart
@@ -1,0 +1,225 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_filter.dart' as _i3;
+
+abstract class AssetTransferFilter {
+  const AssetTransferFilter();
+
+  factory AssetTransferFilter.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetTransferFilterCodec codec = $AssetTransferFilterCodec();
+
+  static const $AssetTransferFilter values = $AssetTransferFilter();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson();
+}
+
+class $AssetTransferFilter {
+  const $AssetTransferFilter();
+
+  Teleport teleport(_i3.AssetFilter value0) {
+    return Teleport(value0);
+  }
+
+  ReserveDeposit reserveDeposit(_i3.AssetFilter value0) {
+    return ReserveDeposit(value0);
+  }
+
+  ReserveWithdraw reserveWithdraw(_i3.AssetFilter value0) {
+    return ReserveWithdraw(value0);
+  }
+}
+
+class $AssetTransferFilterCodec with _i1.Codec<AssetTransferFilter> {
+  const $AssetTransferFilterCodec();
+
+  @override
+  AssetTransferFilter decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Teleport._decode(input);
+      case 1:
+        return ReserveDeposit._decode(input);
+      case 2:
+        return ReserveWithdraw._decode(input);
+      default:
+        throw Exception('AssetTransferFilter: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetTransferFilter value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Teleport:
+        (value as Teleport).encodeTo(output);
+        break;
+      case ReserveDeposit:
+        (value as ReserveDeposit).encodeTo(output);
+        break;
+      case ReserveWithdraw:
+        (value as ReserveWithdraw).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetTransferFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetTransferFilter value) {
+    switch (value.runtimeType) {
+      case Teleport:
+        return (value as Teleport)._sizeHint();
+      case ReserveDeposit:
+        return (value as ReserveDeposit)._sizeHint();
+      case ReserveWithdraw:
+        return (value as ReserveWithdraw)._sizeHint();
+      default:
+        throw Exception('AssetTransferFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Teleport extends AssetTransferFilter {
+  const Teleport(this.value0);
+
+  factory Teleport._decode(_i1.Input input) {
+    return Teleport(_i3.AssetFilter.codec.decode(input));
+  }
+
+  /// AssetFilter
+  final _i3.AssetFilter value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Teleport': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetFilter.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i3.AssetFilter.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Teleport && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveDeposit extends AssetTransferFilter {
+  const ReserveDeposit(this.value0);
+
+  factory ReserveDeposit._decode(_i1.Input input) {
+    return ReserveDeposit(_i3.AssetFilter.codec.decode(input));
+  }
+
+  /// AssetFilter
+  final _i3.AssetFilter value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReserveDeposit': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetFilter.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.AssetFilter.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveDeposit && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveWithdraw extends AssetTransferFilter {
+  const ReserveWithdraw(this.value0);
+
+  factory ReserveWithdraw._decode(_i1.Input input) {
+    return ReserveWithdraw(_i3.AssetFilter.codec.decode(input));
+  }
+
+  /// AssetFilter
+  final _i3.AssetFilter value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReserveWithdraw': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetFilter.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i3.AssetFilter.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveWithdraw && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/assets.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/assets.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'asset.dart' as _i1;
+
+typedef Assets = List<_i1.Asset>;
+
+class AssetsCodec with _i2.Codec<Assets> {
+  const AssetsCodec();
+
+  @override
+  Assets decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Assets value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Assets value) {
+    return const _i2.SequenceCodec<_i1.Asset>(_i1.Asset.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/fungibility.dart
@@ -1,0 +1,172 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_instance.dart' as _i3;
+
+abstract class Fungibility {
+  const Fungibility();
+
+  factory Fungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $FungibilityCodec codec = $FungibilityCodec();
+
+  static const $Fungibility values = $Fungibility();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Fungibility {
+  const $Fungibility();
+
+  Fungible fungible(BigInt value0) {
+    return Fungible(value0);
+  }
+
+  NonFungible nonFungible(_i3.AssetInstance value0) {
+    return NonFungible(value0);
+  }
+}
+
+class $FungibilityCodec with _i1.Codec<Fungibility> {
+  const $FungibilityCodec();
+
+  @override
+  Fungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Fungible._decode(input);
+      case 1:
+        return NonFungible._decode(input);
+      default:
+        throw Exception('Fungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Fungibility value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Fungible:
+        (value as Fungible).encodeTo(output);
+        break;
+      case NonFungible:
+        (value as NonFungible).encodeTo(output);
+        break;
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Fungibility value) {
+    switch (value.runtimeType) {
+      case Fungible:
+        return (value as Fungible)._sizeHint();
+      case NonFungible:
+        return (value as NonFungible)._sizeHint();
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Fungible extends Fungibility {
+  const Fungible(this.value0);
+
+  factory Fungible._decode(_i1.Input input) {
+    return Fungible(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Fungible': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Fungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class NonFungible extends Fungibility {
+  const NonFungible(this.value0);
+
+  factory NonFungible._decode(_i1.Input input) {
+    return NonFungible(_i3.AssetInstance.codec.decode(input));
+  }
+
+  /// AssetInstance
+  final _i3.AssetInstance value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'NonFungible': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetInstance.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.AssetInstance.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NonFungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/wild_asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/wild_asset.dart
@@ -1,0 +1,328 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../location/location.dart' as _i5;
+import 'asset_id.dart' as _i3;
+import 'wild_fungibility.dart' as _i4;
+
+abstract class WildAsset {
+  const WildAsset();
+
+  factory WildAsset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $WildAssetCodec codec = $WildAssetCodec();
+
+  static const $WildAsset values = $WildAsset();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $WildAsset {
+  const $WildAsset();
+
+  All all() {
+    return All();
+  }
+
+  AllOf allOf({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+  }) {
+    return AllOf(
+      id: id,
+      fun: fun,
+    );
+  }
+
+  AllCounted allCounted(BigInt value0) {
+    return AllCounted(value0);
+  }
+
+  AllOfCounted allOfCounted({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+    required BigInt count,
+  }) {
+    return AllOfCounted(
+      id: id,
+      fun: fun,
+      count: count,
+    );
+  }
+}
+
+class $WildAssetCodec with _i1.Codec<WildAsset> {
+  const $WildAssetCodec();
+
+  @override
+  WildAsset decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const All();
+      case 1:
+        return AllOf._decode(input);
+      case 2:
+        return AllCounted._decode(input);
+      case 3:
+        return AllOfCounted._decode(input);
+      default:
+        throw Exception('WildAsset: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildAsset value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case All:
+        (value as All).encodeTo(output);
+        break;
+      case AllOf:
+        (value as AllOf).encodeTo(output);
+        break;
+      case AllCounted:
+        (value as AllCounted).encodeTo(output);
+        break;
+      case AllOfCounted:
+        (value as AllOfCounted).encodeTo(output);
+        break;
+      default:
+        throw Exception('WildAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(WildAsset value) {
+    switch (value.runtimeType) {
+      case All:
+        return 1;
+      case AllOf:
+        return (value as AllOf)._sizeHint();
+      case AllCounted:
+        return (value as AllCounted)._sizeHint();
+      case AllOfCounted:
+        return (value as AllOfCounted)._sizeHint();
+      default:
+        throw Exception('WildAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class All extends WildAsset {
+  const All();
+
+  @override
+  Map<String, dynamic> toJson() => {'All': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is All;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AllOf extends WildAsset {
+  const AllOf({
+    required this.id,
+    required this.fun,
+  });
+
+  factory AllOf._decode(_i1.Input input) {
+    return AllOf(
+      id: _i5.Location.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOf': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetIdCodec().sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOf && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class AllCounted extends WildAsset {
+  const AllCounted(this.value0);
+
+  factory AllCounted._decode(_i1.Input input) {
+    return AllCounted(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'AllCounted': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllCounted && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AllOfCounted extends WildAsset {
+  const AllOfCounted({
+    required this.id,
+    required this.fun,
+    required this.count,
+  });
+
+  factory AllOfCounted._decode(_i1.Input input) {
+    return AllOfCounted(
+      id: _i5.Location.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+      count: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  /// u32
+  final BigInt count;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOfCounted': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+          'count': count,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetIdCodec().sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(count);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      count,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOfCounted && other.id == id && other.fun == fun && other.count == count;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+        count,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/wild_fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/asset/wild_fungibility.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+enum WildFungibility {
+  fungible('Fungible', 0),
+  nonFungible('NonFungible', 1);
+
+  const WildFungibility(
+    this.variantName,
+    this.codecIndex,
+  );
+
+  factory WildFungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  final String variantName;
+
+  final int codecIndex;
+
+  static const $WildFungibilityCodec codec = $WildFungibilityCodec();
+
+  String toJson() => variantName;
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+}
+
+class $WildFungibilityCodec with _i1.Codec<WildFungibility> {
+  const $WildFungibilityCodec();
+
+  @override
+  WildFungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WildFungibility.fungible;
+      case 1:
+        return WildFungibility.nonFungible;
+      default:
+        throw Exception('WildFungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildFungibility value,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      value.codecIndex,
+      output,
+    );
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/hint.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/hint.dart
@@ -1,0 +1,121 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'location/location.dart' as _i3;
+
+abstract class Hint {
+  const Hint();
+
+  factory Hint.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $HintCodec codec = $HintCodec();
+
+  static const $Hint values = $Hint();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, Map<String, dynamic>>> toJson();
+}
+
+class $Hint {
+  const $Hint();
+
+  AssetClaimer assetClaimer({required _i3.Location location}) {
+    return AssetClaimer(location: location);
+  }
+}
+
+class $HintCodec with _i1.Codec<Hint> {
+  const $HintCodec();
+
+  @override
+  Hint decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return AssetClaimer._decode(input);
+      default:
+        throw Exception('Hint: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Hint value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case AssetClaimer:
+        (value as AssetClaimer).encodeTo(output);
+        break;
+      default:
+        throw Exception('Hint: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Hint value) {
+    switch (value.runtimeType) {
+      case AssetClaimer:
+        return (value as AssetClaimer)._sizeHint();
+      default:
+        throw Exception('Hint: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class AssetClaimer extends Hint {
+  const AssetClaimer({required this.location});
+
+  factory AssetClaimer._decode(_i1.Input input) {
+    return AssetClaimer(location: _i3.Location.codec.decode(input));
+  }
+
+  /// Location
+  final _i3.Location location;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'AssetClaimer': {'location': location.toJson()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Location.codec.sizeHint(location);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i3.Location.codec.encodeTo(
+      location,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AssetClaimer && other.location == location;
+
+  @override
+  int get hashCode => location.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/instruction_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/instruction_1.dart
@@ -1,0 +1,3806 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i22;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../tuples_1.dart' as _i15;
+import '../../xcm/double_encoded/double_encoded_1.dart' as _i9;
+import '../../xcm/v3/maybe_error_code.dart' as _i17;
+import '../../xcm/v3/origin_kind.dart' as _i8;
+import '../../xcm/v3/weight_limit.dart' as _i14;
+import '../../xcm/v5/traits/error.dart' as _i16;
+import 'asset/asset.dart' as _i13;
+import 'asset/asset_filter.dart' as _i12;
+import 'asset/asset_transfer_filter.dart' as _i20;
+import 'asset/assets.dart' as _i3;
+import 'hint.dart' as _i21;
+import 'instruction_1.dart' as _i23;
+import 'junction/junction.dart' as _i18;
+import 'junction/network_id.dart' as _i19;
+import 'junctions/junctions.dart' as _i10;
+import 'location/location.dart' as _i6;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'xcm_1.dart' as _i7;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.Assets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.Assets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.Assets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.Location? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.Assets assets,
+    required _i6.Location beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.Assets assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    _i5.Weight? fallbackMaxWeight,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      fallbackMaxWeight: fallbackMaxWeight,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.AssetFilter give,
+    required _i3.Assets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.AssetFilter assets,
+    required _i6.Location reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.AssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.Asset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i7.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i7.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.Assets assets,
+    required _i6.Location ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.Assets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.Assets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.Location? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i15.Tuple2<int, _i16.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i17.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i18.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i19.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.Asset asset,
+    required _i6.Location unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.Asset asset,
+    required _i6.Location target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.Asset asset,
+    required _i6.Location owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.Asset asset,
+    required _i6.Location locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.Location value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.Location? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+
+  PayFees payFees({required _i13.Asset asset}) {
+    return PayFees(asset: asset);
+  }
+
+  InitiateTransfer initiateTransfer({
+    required _i6.Location destination,
+    _i20.AssetTransferFilter? remoteFees,
+    required bool preserveOrigin,
+    required List<_i20.AssetTransferFilter> assets,
+    required _i7.Xcm remoteXcm,
+  }) {
+    return InitiateTransfer(
+      destination: destination,
+      remoteFees: remoteFees,
+      preserveOrigin: preserveOrigin,
+      assets: assets,
+      remoteXcm: remoteXcm,
+    );
+  }
+
+  ExecuteWithOrigin executeWithOrigin({
+    _i10.Junctions? descendantOrigin,
+    required _i7.Xcm xcm,
+  }) {
+    return ExecuteWithOrigin(
+      descendantOrigin: descendantOrigin,
+      xcm: xcm,
+    );
+  }
+
+  SetHints setHints({required List<_i21.Hint> hints}) {
+    return SetHints(hints: hints);
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      case 48:
+        return PayFees._decode(input);
+      case 49:
+        return InitiateTransfer._decode(input);
+      case 50:
+        return ExecuteWithOrigin._decode(input);
+      case 51:
+        return SetHints._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      case PayFees:
+        (value as PayFees).encodeTo(output);
+        break;
+      case InitiateTransfer:
+        (value as InitiateTransfer).encodeTo(output);
+        break;
+      case ExecuteWithOrigin:
+        (value as ExecuteWithOrigin).encodeTo(output);
+        break;
+      case SetHints:
+        (value as SetHints).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      case PayFees:
+        return (value as PayFees)._sizeHint();
+      case InitiateTransfer:
+        return (value as InitiateTransfer)._sizeHint();
+      case ExecuteWithOrigin:
+        return (value as ExecuteWithOrigin)._sizeHint();
+      case SetHints:
+        return (value as SetHints)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<Location>
+  final _i6.Location? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i22.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i22.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    this.fallbackMaxWeight,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      fallbackMaxWeight: const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Option<Weight>
+  final _i5.Weight? fallbackMaxWeight;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'fallbackMaxWeight': fallbackMaxWeight?.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).sizeHint(fallbackMaxWeight);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).encodeTo(
+      fallbackMaxWeight,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.fallbackMaxWeight == fallbackMaxWeight &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        fallbackMaxWeight,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.AssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter give;
+
+  /// Assets
+  final _i3.Assets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(give);
+    size = size + const _i3.AssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i22.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.AssetFilter.codec.decode(input),
+      reserve: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.AssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.Asset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      ticket: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i22.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input));
+  }
+
+  /// Option<Location>
+  final _i6.Location? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i15.Tuple2<int, _i16.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+          _i1.U32Codec.codec,
+          _i16.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i17.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i17.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i17.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i17.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i22.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i22.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i22.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i18.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i18.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i18.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i19.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i19.NetworkId network;
+
+  /// InteriorLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i19.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      unlocker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      target: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.Asset.codec.decode(input),
+      owner: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.Asset.codec.decode(input),
+      locker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i22.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.Location.codec.decode(input));
+  }
+
+  /// Location
+  final _i6.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<Location>
+  final _i6.Location? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}
+
+class PayFees extends Instruction {
+  const PayFees({required this.asset});
+
+  factory PayFees._decode(_i1.Input input) {
+    return PayFees(asset: _i13.Asset.codec.decode(input));
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  @override
+  Map<String, Map<String, Map<String, Map<String, dynamic>>>> toJson() => {
+        'PayFees': {'asset': asset.toJson()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      48,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PayFees && other.asset == asset;
+
+  @override
+  int get hashCode => asset.hashCode;
+}
+
+class InitiateTransfer extends Instruction {
+  const InitiateTransfer({
+    required this.destination,
+    this.remoteFees,
+    required this.preserveOrigin,
+    required this.assets,
+    required this.remoteXcm,
+  });
+
+  factory InitiateTransfer._decode(_i1.Input input) {
+    return InitiateTransfer(
+      destination: _i6.Location.codec.decode(input),
+      remoteFees: const _i1.OptionCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).decode(input),
+      preserveOrigin: _i1.BoolCodec.codec.decode(input),
+      assets: const _i1.SequenceCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).decode(input),
+      remoteXcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Location
+  final _i6.Location destination;
+
+  /// Option<AssetTransferFilter>
+  final _i20.AssetTransferFilter? remoteFees;
+
+  /// bool
+  final bool preserveOrigin;
+
+  /// BoundedVec<AssetTransferFilter, MaxAssetTransferFilters>
+  final List<_i20.AssetTransferFilter> assets;
+
+  /// Xcm<()>
+  final _i7.Xcm remoteXcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTransfer': {
+          'destination': destination.toJson(),
+          'remoteFees': remoteFees?.toJson(),
+          'preserveOrigin': preserveOrigin,
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'remoteXcm': remoteXcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(destination);
+    size = size + const _i1.OptionCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).sizeHint(remoteFees);
+    size = size + _i1.BoolCodec.codec.sizeHint(preserveOrigin);
+    size = size + const _i1.SequenceCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).sizeHint(assets);
+    size = size + const _i7.XcmCodec().sizeHint(remoteXcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      49,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.OptionCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).encodeTo(
+      remoteFees,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      preserveOrigin,
+      output,
+    );
+    const _i1.SequenceCodec<_i20.AssetTransferFilter>(_i20.AssetTransferFilter.codec).encodeTo(
+      assets,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      remoteXcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTransfer &&
+          other.destination == destination &&
+          other.remoteFees == remoteFees &&
+          other.preserveOrigin == preserveOrigin &&
+          _i22.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          _i22.listsEqual(
+            other.remoteXcm,
+            remoteXcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        destination,
+        remoteFees,
+        preserveOrigin,
+        assets,
+        remoteXcm,
+      );
+}
+
+class ExecuteWithOrigin extends Instruction {
+  const ExecuteWithOrigin({
+    this.descendantOrigin,
+    required this.xcm,
+  });
+
+  factory ExecuteWithOrigin._decode(_i1.Input input) {
+    return ExecuteWithOrigin(
+      descendantOrigin: const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).decode(input),
+      xcm: const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Option<InteriorLocation>
+  final _i10.Junctions? descendantOrigin;
+
+  /// Xcm<Call>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExecuteWithOrigin': {
+          'descendantOrigin': descendantOrigin?.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).sizeHint(descendantOrigin);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      50,
+      output,
+    );
+    const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).encodeTo(
+      descendantOrigin,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExecuteWithOrigin &&
+          other.descendantOrigin == descendantOrigin &&
+          _i22.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        descendantOrigin,
+        xcm,
+      );
+}
+
+class SetHints extends Instruction {
+  const SetHints({required this.hints});
+
+  factory SetHints._decode(_i1.Input input) {
+    return SetHints(hints: const _i1.SequenceCodec<_i21.Hint>(_i21.Hint.codec).decode(input));
+  }
+
+  /// BoundedVec<Hint, HintNumVariants>
+  final List<_i21.Hint> hints;
+
+  @override
+  Map<String, Map<String, List<Map<String, Map<String, Map<String, dynamic>>>>>> toJson() => {
+        'SetHints': {'hints': hints.map((value) => value.toJson()).toList()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.SequenceCodec<_i21.Hint>(_i21.Hint.codec).sizeHint(hints);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      51,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Hint>(_i21.Hint.codec).encodeTo(
+      hints,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetHints &&
+          _i22.listsEqual(
+            other.hints,
+            hints,
+          );
+
+  @override
+  int get hashCode => hints.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/instruction_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/instruction_2.dart
@@ -1,0 +1,3809 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i23;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../tuples_1.dart' as _i16;
+import '../../xcm/double_encoded/double_encoded_2.dart' as _i9;
+import '../../xcm/v3/maybe_error_code.dart' as _i18;
+import '../../xcm/v3/origin_kind.dart' as _i8;
+import '../../xcm/v3/weight_limit.dart' as _i14;
+import '../../xcm/v5/traits/error.dart' as _i17;
+import 'asset/asset.dart' as _i13;
+import 'asset/asset_filter.dart' as _i12;
+import 'asset/asset_transfer_filter.dart' as _i21;
+import 'asset/assets.dart' as _i3;
+import 'hint.dart' as _i22;
+import 'instruction_1.dart' as _i24;
+import 'instruction_2.dart' as _i25;
+import 'junction/junction.dart' as _i19;
+import 'junction/network_id.dart' as _i20;
+import 'junctions/junctions.dart' as _i10;
+import 'location/location.dart' as _i6;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'xcm_1.dart' as _i7;
+import 'xcm_2.dart' as _i15;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.Assets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.Assets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.Assets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.Location? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.Assets assets,
+    required _i6.Location beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.Assets assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    _i5.Weight? fallbackMaxWeight,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      fallbackMaxWeight: fallbackMaxWeight,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.AssetFilter give,
+    required _i3.Assets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.AssetFilter assets,
+    required _i6.Location reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.AssetFilter assets,
+    required _i6.Location dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.AssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.Asset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i15.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i15.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.Assets assets,
+    required _i6.Location ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.Assets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.Assets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.Location? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i16.Tuple2<int, _i17.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i18.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i19.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i20.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.Asset asset,
+    required _i6.Location unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.Asset asset,
+    required _i6.Location target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.Asset asset,
+    required _i6.Location owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.Asset asset,
+    required _i6.Location locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.Location value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.Location? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+
+  PayFees payFees({required _i13.Asset asset}) {
+    return PayFees(asset: asset);
+  }
+
+  InitiateTransfer initiateTransfer({
+    required _i6.Location destination,
+    _i21.AssetTransferFilter? remoteFees,
+    required bool preserveOrigin,
+    required List<_i21.AssetTransferFilter> assets,
+    required _i7.Xcm remoteXcm,
+  }) {
+    return InitiateTransfer(
+      destination: destination,
+      remoteFees: remoteFees,
+      preserveOrigin: preserveOrigin,
+      assets: assets,
+      remoteXcm: remoteXcm,
+    );
+  }
+
+  ExecuteWithOrigin executeWithOrigin({
+    _i10.Junctions? descendantOrigin,
+    required _i15.Xcm xcm,
+  }) {
+    return ExecuteWithOrigin(
+      descendantOrigin: descendantOrigin,
+      xcm: xcm,
+    );
+  }
+
+  SetHints setHints({required List<_i22.Hint> hints}) {
+    return SetHints(hints: hints);
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      case 48:
+        return PayFees._decode(input);
+      case 49:
+        return InitiateTransfer._decode(input);
+      case 50:
+        return ExecuteWithOrigin._decode(input);
+      case 51:
+        return SetHints._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      case PayFees:
+        (value as PayFees).encodeTo(output);
+        break;
+      case InitiateTransfer:
+        (value as InitiateTransfer).encodeTo(output);
+        break;
+      case ExecuteWithOrigin:
+        (value as ExecuteWithOrigin).encodeTo(output);
+        break;
+      case SetHints:
+        (value as SetHints).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      case PayFees:
+        return (value as PayFees)._sizeHint();
+      case InitiateTransfer:
+        return (value as InitiateTransfer)._sizeHint();
+      case ExecuteWithOrigin:
+        return (value as ExecuteWithOrigin)._sizeHint();
+      case SetHints:
+        return (value as SetHints)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<Location>
+  final _i6.Location? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i23.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i23.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    this.fallbackMaxWeight,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      fallbackMaxWeight: const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Option<Weight>
+  final _i5.Weight? fallbackMaxWeight;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'fallbackMaxWeight': fallbackMaxWeight?.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).sizeHint(fallbackMaxWeight);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    const _i1.OptionCodec<_i5.Weight>(_i5.Weight.codec).encodeTo(
+      fallbackMaxWeight,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.fallbackMaxWeight == fallbackMaxWeight &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        fallbackMaxWeight,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      beneficiary: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.AssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter give;
+
+  /// Assets
+  final _i3.Assets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(give);
+    size = size + const _i3.AssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i23.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.AssetFilter.codec.decode(input),
+      reserve: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.AssetFilter.codec.decode(input),
+      dest: _i6.Location.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  /// Location
+  final _i6.Location dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.AssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// AssetFilter
+  final _i12.AssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.AssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.AssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.Asset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() =>
+      {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input),
+      ticket: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Assets
+  final _i3.Assets assets;
+
+  /// Location
+  final _i6.Location ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(assets);
+    size = size + _i6.Location.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i23.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.Asset>(_i13.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input));
+  }
+
+  /// Option<Location>
+  final _i6.Location? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i16.Tuple2<int, _i17.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+          _i1.U32Codec.codec,
+          _i17.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i18.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i18.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i18.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i23.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i23.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i23.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i19.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i19.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i19.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i20.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i20.NetworkId network;
+
+  /// InteriorLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i20.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i20.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      unlocker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.Asset.codec.decode(input),
+      target: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.Asset.codec.decode(input),
+      owner: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.Asset.codec.decode(input),
+      locker: _i6.Location.codec.decode(input),
+    );
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  /// Location
+  final _i6.Location locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    size = size + _i6.Location.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i23.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.Location.codec.decode(input));
+  }
+
+  /// Location
+  final _i6.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<Location>
+  final _i6.Location? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.Location>(_i6.Location.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}
+
+class PayFees extends Instruction {
+  const PayFees({required this.asset});
+
+  factory PayFees._decode(_i1.Input input) {
+    return PayFees(asset: _i13.Asset.codec.decode(input));
+  }
+
+  /// Asset
+  final _i13.Asset asset;
+
+  @override
+  Map<String, Map<String, Map<String, Map<String, dynamic>>>> toJson() => {
+        'PayFees': {'asset': asset.toJson()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.Asset.codec.sizeHint(asset);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      48,
+      output,
+    );
+    _i13.Asset.codec.encodeTo(
+      asset,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PayFees && other.asset == asset;
+
+  @override
+  int get hashCode => asset.hashCode;
+}
+
+class InitiateTransfer extends Instruction {
+  const InitiateTransfer({
+    required this.destination,
+    this.remoteFees,
+    required this.preserveOrigin,
+    required this.assets,
+    required this.remoteXcm,
+  });
+
+  factory InitiateTransfer._decode(_i1.Input input) {
+    return InitiateTransfer(
+      destination: _i6.Location.codec.decode(input),
+      remoteFees: const _i1.OptionCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).decode(input),
+      preserveOrigin: _i1.BoolCodec.codec.decode(input),
+      assets: const _i1.SequenceCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).decode(input),
+      remoteXcm: const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Location
+  final _i6.Location destination;
+
+  /// Option<AssetTransferFilter>
+  final _i21.AssetTransferFilter? remoteFees;
+
+  /// bool
+  final bool preserveOrigin;
+
+  /// BoundedVec<AssetTransferFilter, MaxAssetTransferFilters>
+  final List<_i21.AssetTransferFilter> assets;
+
+  /// Xcm<()>
+  final _i7.Xcm remoteXcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTransfer': {
+          'destination': destination.toJson(),
+          'remoteFees': remoteFees?.toJson(),
+          'preserveOrigin': preserveOrigin,
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'remoteXcm': remoteXcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.Location.codec.sizeHint(destination);
+    size = size + const _i1.OptionCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).sizeHint(remoteFees);
+    size = size + _i1.BoolCodec.codec.sizeHint(preserveOrigin);
+    size = size + const _i1.SequenceCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).sizeHint(assets);
+    size = size + const _i7.XcmCodec().sizeHint(remoteXcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      49,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.OptionCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).encodeTo(
+      remoteFees,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      preserveOrigin,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.AssetTransferFilter>(_i21.AssetTransferFilter.codec).encodeTo(
+      assets,
+      output,
+    );
+    const _i1.SequenceCodec<_i24.Instruction>(_i24.Instruction.codec).encodeTo(
+      remoteXcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTransfer &&
+          other.destination == destination &&
+          other.remoteFees == remoteFees &&
+          other.preserveOrigin == preserveOrigin &&
+          _i23.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          _i23.listsEqual(
+            other.remoteXcm,
+            remoteXcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        destination,
+        remoteFees,
+        preserveOrigin,
+        assets,
+        remoteXcm,
+      );
+}
+
+class ExecuteWithOrigin extends Instruction {
+  const ExecuteWithOrigin({
+    this.descendantOrigin,
+    required this.xcm,
+  });
+
+  factory ExecuteWithOrigin._decode(_i1.Input input) {
+    return ExecuteWithOrigin(
+      descendantOrigin: const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).decode(input),
+      xcm: const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).decode(input),
+    );
+  }
+
+  /// Option<InteriorLocation>
+  final _i10.Junctions? descendantOrigin;
+
+  /// Xcm<Call>
+  final _i15.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExecuteWithOrigin': {
+          'descendantOrigin': descendantOrigin?.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).sizeHint(descendantOrigin);
+    size = size + const _i15.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      50,
+      output,
+    );
+    const _i1.OptionCodec<_i10.Junctions>(_i10.Junctions.codec).encodeTo(
+      descendantOrigin,
+      output,
+    );
+    const _i1.SequenceCodec<_i25.Instruction>(_i25.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExecuteWithOrigin &&
+          other.descendantOrigin == descendantOrigin &&
+          _i23.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        descendantOrigin,
+        xcm,
+      );
+}
+
+class SetHints extends Instruction {
+  const SetHints({required this.hints});
+
+  factory SetHints._decode(_i1.Input input) {
+    return SetHints(hints: const _i1.SequenceCodec<_i22.Hint>(_i22.Hint.codec).decode(input));
+  }
+
+  /// BoundedVec<Hint, HintNumVariants>
+  final List<_i22.Hint> hints;
+
+  @override
+  Map<String, Map<String, List<Map<String, Map<String, Map<String, dynamic>>>>>> toJson() => {
+        'SetHints': {'hints': hints.map((value) => value.toJson()).toList()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.SequenceCodec<_i22.Hint>(_i22.Hint.codec).sizeHint(hints);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      51,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Hint>(_i22.Hint.codec).encodeTo(
+      hints,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetHints &&
+          _i23.listsEqual(
+            other.hints,
+            hints,
+          );
+
+  @override
+  int get hashCode => hints.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junction/junction.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junction/junction.dart
@@ -1,0 +1,732 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import '../../../xcm/v3/junction/body_id.dart' as _i4;
+import '../../../xcm/v3/junction/body_part.dart' as _i5;
+import 'network_id.dart' as _i3;
+
+abstract class Junction {
+  const Junction();
+
+  factory Junction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionCodec codec = $JunctionCodec();
+
+  static const $Junction values = $Junction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junction {
+  const $Junction();
+
+  Parachain parachain(BigInt value0) {
+    return Parachain(value0);
+  }
+
+  AccountId32 accountId32({
+    _i3.NetworkId? network,
+    required List<int> id,
+  }) {
+    return AccountId32(
+      network: network,
+      id: id,
+    );
+  }
+
+  AccountIndex64 accountIndex64({
+    _i3.NetworkId? network,
+    required BigInt index,
+  }) {
+    return AccountIndex64(
+      network: network,
+      index: index,
+    );
+  }
+
+  AccountKey20 accountKey20({
+    _i3.NetworkId? network,
+    required List<int> key,
+  }) {
+    return AccountKey20(
+      network: network,
+      key: key,
+    );
+  }
+
+  PalletInstance palletInstance(int value0) {
+    return PalletInstance(value0);
+  }
+
+  GeneralIndex generalIndex(BigInt value0) {
+    return GeneralIndex(value0);
+  }
+
+  GeneralKey generalKey({
+    required int length,
+    required List<int> data,
+  }) {
+    return GeneralKey(
+      length: length,
+      data: data,
+    );
+  }
+
+  OnlyChild onlyChild() {
+    return OnlyChild();
+  }
+
+  Plurality plurality({
+    required _i4.BodyId id,
+    required _i5.BodyPart part,
+  }) {
+    return Plurality(
+      id: id,
+      part: part,
+    );
+  }
+
+  GlobalConsensus globalConsensus(_i3.NetworkId value0) {
+    return GlobalConsensus(value0);
+  }
+}
+
+class $JunctionCodec with _i1.Codec<Junction> {
+  const $JunctionCodec();
+
+  @override
+  Junction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Parachain._decode(input);
+      case 1:
+        return AccountId32._decode(input);
+      case 2:
+        return AccountIndex64._decode(input);
+      case 3:
+        return AccountKey20._decode(input);
+      case 4:
+        return PalletInstance._decode(input);
+      case 5:
+        return GeneralIndex._decode(input);
+      case 6:
+        return GeneralKey._decode(input);
+      case 7:
+        return const OnlyChild();
+      case 8:
+        return Plurality._decode(input);
+      case 9:
+        return GlobalConsensus._decode(input);
+      default:
+        throw Exception('Junction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Parachain:
+        (value as Parachain).encodeTo(output);
+        break;
+      case AccountId32:
+        (value as AccountId32).encodeTo(output);
+        break;
+      case AccountIndex64:
+        (value as AccountIndex64).encodeTo(output);
+        break;
+      case AccountKey20:
+        (value as AccountKey20).encodeTo(output);
+        break;
+      case PalletInstance:
+        (value as PalletInstance).encodeTo(output);
+        break;
+      case GeneralIndex:
+        (value as GeneralIndex).encodeTo(output);
+        break;
+      case GeneralKey:
+        (value as GeneralKey).encodeTo(output);
+        break;
+      case OnlyChild:
+        (value as OnlyChild).encodeTo(output);
+        break;
+      case Plurality:
+        (value as Plurality).encodeTo(output);
+        break;
+      case GlobalConsensus:
+        (value as GlobalConsensus).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junction value) {
+    switch (value.runtimeType) {
+      case Parachain:
+        return (value as Parachain)._sizeHint();
+      case AccountId32:
+        return (value as AccountId32)._sizeHint();
+      case AccountIndex64:
+        return (value as AccountIndex64)._sizeHint();
+      case AccountKey20:
+        return (value as AccountKey20)._sizeHint();
+      case PalletInstance:
+        return (value as PalletInstance)._sizeHint();
+      case GeneralIndex:
+        return (value as GeneralIndex)._sizeHint();
+      case GeneralKey:
+        return (value as GeneralKey)._sizeHint();
+      case OnlyChild:
+        return 1;
+      case Plurality:
+        return (value as Plurality)._sizeHint();
+      case GlobalConsensus:
+        return (value as GlobalConsensus)._sizeHint();
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Parachain extends Junction {
+  const Parachain(this.value0);
+
+  factory Parachain._decode(_i1.Input input) {
+    return Parachain(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Parachain': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Parachain && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AccountId32 extends Junction {
+  const AccountId32({
+    this.network,
+    required this.id,
+  });
+
+  factory AccountId32._decode(_i1.Input input) {
+    return AccountId32(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      id: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 32]
+  final List<int> id;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountId32': {
+          'network': network?.toJson(),
+          'id': id.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(id);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      id,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountId32 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.id,
+            id,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        id,
+      );
+}
+
+class AccountIndex64 extends Junction {
+  const AccountIndex64({
+    this.network,
+    required this.index,
+  });
+
+  factory AccountIndex64._decode(_i1.Input input) {
+    return AccountIndex64(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// u64
+  final BigInt index;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountIndex64': {
+          'network': network?.toJson(),
+          'index': index,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountIndex64 && other.network == network && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        index,
+      );
+}
+
+class AccountKey20 extends Junction {
+  const AccountKey20({
+    this.network,
+    required this.key,
+  });
+
+  factory AccountKey20._decode(_i1.Input input) {
+    return AccountKey20(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      key: const _i1.U8ArrayCodec(20).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 20]
+  final List<int> key;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountKey20': {
+          'network': network?.toJson(),
+          'key': key.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(20).sizeHint(key);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(20).encodeTo(
+      key,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountKey20 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.key,
+            key,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        key,
+      );
+}
+
+class PalletInstance extends Junction {
+  const PalletInstance(this.value0);
+
+  factory PalletInstance._decode(_i1.Input input) {
+    return PalletInstance(_i1.U8Codec.codec.decode(input));
+  }
+
+  /// u8
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'PalletInstance': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInstance && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralIndex extends Junction {
+  const GeneralIndex(this.value0);
+
+  factory GeneralIndex._decode(_i1.Input input) {
+    return GeneralIndex(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'GeneralIndex': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralIndex && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralKey extends Junction {
+  const GeneralKey({
+    required this.length,
+    required this.data,
+  });
+
+  factory GeneralKey._decode(_i1.Input input) {
+    return GeneralKey(
+      length: _i1.U8Codec.codec.decode(input),
+      data: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u8
+  final int length;
+
+  /// [u8; 32]
+  final List<int> data;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'GeneralKey': {
+          'length': length,
+          'data': data.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(length);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(data);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      length,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      data,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralKey &&
+          other.length == length &&
+          _i6.listsEqual(
+            other.data,
+            data,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        length,
+        data,
+      );
+}
+
+class OnlyChild extends Junction {
+  const OnlyChild();
+
+  @override
+  Map<String, dynamic> toJson() => {'OnlyChild': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is OnlyChild;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Plurality extends Junction {
+  const Plurality({
+    required this.id,
+    required this.part,
+  });
+
+  factory Plurality._decode(_i1.Input input) {
+    return Plurality(
+      id: _i4.BodyId.codec.decode(input),
+      part: _i5.BodyPart.codec.decode(input),
+    );
+  }
+
+  /// BodyId
+  final _i4.BodyId id;
+
+  /// BodyPart
+  final _i5.BodyPart part;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'Plurality': {
+          'id': id.toJson(),
+          'part': part.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.BodyId.codec.sizeHint(id);
+    size = size + _i5.BodyPart.codec.sizeHint(part);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i4.BodyId.codec.encodeTo(
+      id,
+      output,
+    );
+    _i5.BodyPart.codec.encodeTo(
+      part,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Plurality && other.id == id && other.part == part;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        part,
+      );
+}
+
+class GlobalConsensus extends Junction {
+  const GlobalConsensus(this.value0);
+
+  factory GlobalConsensus._decode(_i1.Input input) {
+    return GlobalConsensus(_i3.NetworkId.codec.decode(input));
+  }
+
+  /// NetworkId
+  final _i3.NetworkId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'GlobalConsensus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.NetworkId.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i3.NetworkId.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GlobalConsensus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junction/network_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junction/network_id.dart
@@ -1,0 +1,418 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class NetworkId {
+  const NetworkId();
+
+  factory NetworkId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $NetworkIdCodec codec = $NetworkIdCodec();
+
+  static const $NetworkId values = $NetworkId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $NetworkId {
+  const $NetworkId();
+
+  ByGenesis byGenesis(List<int> value0) {
+    return ByGenesis(value0);
+  }
+
+  ByFork byFork({
+    required BigInt blockNumber,
+    required List<int> blockHash,
+  }) {
+    return ByFork(
+      blockNumber: blockNumber,
+      blockHash: blockHash,
+    );
+  }
+
+  Polkadot polkadot() {
+    return Polkadot();
+  }
+
+  Kusama kusama() {
+    return Kusama();
+  }
+
+  Ethereum ethereum({required BigInt chainId}) {
+    return Ethereum(chainId: chainId);
+  }
+
+  BitcoinCore bitcoinCore() {
+    return BitcoinCore();
+  }
+
+  BitcoinCash bitcoinCash() {
+    return BitcoinCash();
+  }
+
+  PolkadotBulletin polkadotBulletin() {
+    return PolkadotBulletin();
+  }
+}
+
+class $NetworkIdCodec with _i1.Codec<NetworkId> {
+  const $NetworkIdCodec();
+
+  @override
+  NetworkId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return ByGenesis._decode(input);
+      case 1:
+        return ByFork._decode(input);
+      case 2:
+        return const Polkadot();
+      case 3:
+        return const Kusama();
+      case 7:
+        return Ethereum._decode(input);
+      case 8:
+        return const BitcoinCore();
+      case 9:
+        return const BitcoinCash();
+      case 10:
+        return const PolkadotBulletin();
+      default:
+        throw Exception('NetworkId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    NetworkId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        (value as ByGenesis).encodeTo(output);
+        break;
+      case ByFork:
+        (value as ByFork).encodeTo(output);
+        break;
+      case Polkadot:
+        (value as Polkadot).encodeTo(output);
+        break;
+      case Kusama:
+        (value as Kusama).encodeTo(output);
+        break;
+      case Ethereum:
+        (value as Ethereum).encodeTo(output);
+        break;
+      case BitcoinCore:
+        (value as BitcoinCore).encodeTo(output);
+        break;
+      case BitcoinCash:
+        (value as BitcoinCash).encodeTo(output);
+        break;
+      case PolkadotBulletin:
+        (value as PolkadotBulletin).encodeTo(output);
+        break;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(NetworkId value) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        return (value as ByGenesis)._sizeHint();
+      case ByFork:
+        return (value as ByFork)._sizeHint();
+      case Polkadot:
+        return 1;
+      case Kusama:
+        return 1;
+      case Ethereum:
+        return (value as Ethereum)._sizeHint();
+      case BitcoinCore:
+        return 1;
+      case BitcoinCash:
+        return 1;
+      case PolkadotBulletin:
+        return 1;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class ByGenesis extends NetworkId {
+  const ByGenesis(this.value0);
+
+  factory ByGenesis._decode(_i1.Input input) {
+    return ByGenesis(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'ByGenesis': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByGenesis &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ByFork extends NetworkId {
+  const ByFork({
+    required this.blockNumber,
+    required this.blockHash,
+  });
+
+  factory ByFork._decode(_i1.Input input) {
+    return ByFork(
+      blockNumber: _i1.U64Codec.codec.decode(input),
+      blockHash: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u64
+  final BigInt blockNumber;
+
+  /// [u8; 32]
+  final List<int> blockHash;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ByFork': {
+          'blockNumber': blockNumber,
+          'blockHash': blockHash.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U64Codec.codec.sizeHint(blockNumber);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(blockHash);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.U64Codec.codec.encodeTo(
+      blockNumber,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      blockHash,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByFork &&
+          other.blockNumber == blockNumber &&
+          _i3.listsEqual(
+            other.blockHash,
+            blockHash,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        blockNumber,
+        blockHash,
+      );
+}
+
+class Polkadot extends NetworkId {
+  const Polkadot();
+
+  @override
+  Map<String, dynamic> toJson() => {'Polkadot': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Polkadot;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Kusama extends NetworkId {
+  const Kusama();
+
+  @override
+  Map<String, dynamic> toJson() => {'Kusama': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Kusama;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Ethereum extends NetworkId {
+  const Ethereum({required this.chainId});
+
+  factory Ethereum._decode(_i1.Input input) {
+    return Ethereum(chainId: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt chainId;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'Ethereum': {'chainId': chainId}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(chainId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      chainId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Ethereum && other.chainId == chainId;
+
+  @override
+  int get hashCode => chainId.hashCode;
+}
+
+class BitcoinCore extends NetworkId {
+  const BitcoinCore();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCore': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCore;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BitcoinCash extends NetworkId {
+  const BitcoinCash();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCash': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCash;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class PolkadotBulletin extends NetworkId {
+  const PolkadotBulletin();
+
+  @override
+  Map<String, dynamic> toJson() => {'PolkadotBulletin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is PolkadotBulletin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junctions/junctions.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/junctions/junctions.dart
@@ -1,0 +1,634 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i4;
+
+import '../junction/junction.dart' as _i3;
+
+abstract class Junctions {
+  const Junctions();
+
+  factory Junctions.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionsCodec codec = $JunctionsCodec();
+
+  static const $Junctions values = $Junctions();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junctions {
+  const $Junctions();
+
+  Here here() {
+    return Here();
+  }
+
+  X1 x1(List<_i3.Junction> value0) {
+    return X1(value0);
+  }
+
+  X2 x2(List<_i3.Junction> value0) {
+    return X2(value0);
+  }
+
+  X3 x3(List<_i3.Junction> value0) {
+    return X3(value0);
+  }
+
+  X4 x4(List<_i3.Junction> value0) {
+    return X4(value0);
+  }
+
+  X5 x5(List<_i3.Junction> value0) {
+    return X5(value0);
+  }
+
+  X6 x6(List<_i3.Junction> value0) {
+    return X6(value0);
+  }
+
+  X7 x7(List<_i3.Junction> value0) {
+    return X7(value0);
+  }
+
+  X8 x8(List<_i3.Junction> value0) {
+    return X8(value0);
+  }
+}
+
+class $JunctionsCodec with _i1.Codec<Junctions> {
+  const $JunctionsCodec();
+
+  @override
+  Junctions decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Here();
+      case 1:
+        return X1._decode(input);
+      case 2:
+        return X2._decode(input);
+      case 3:
+        return X3._decode(input);
+      case 4:
+        return X4._decode(input);
+      case 5:
+        return X5._decode(input);
+      case 6:
+        return X6._decode(input);
+      case 7:
+        return X7._decode(input);
+      case 8:
+        return X8._decode(input);
+      default:
+        throw Exception('Junctions: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junctions value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Here:
+        (value as Here).encodeTo(output);
+        break;
+      case X1:
+        (value as X1).encodeTo(output);
+        break;
+      case X2:
+        (value as X2).encodeTo(output);
+        break;
+      case X3:
+        (value as X3).encodeTo(output);
+        break;
+      case X4:
+        (value as X4).encodeTo(output);
+        break;
+      case X5:
+        (value as X5).encodeTo(output);
+        break;
+      case X6:
+        (value as X6).encodeTo(output);
+        break;
+      case X7:
+        (value as X7).encodeTo(output);
+        break;
+      case X8:
+        (value as X8).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junctions value) {
+    switch (value.runtimeType) {
+      case Here:
+        return 1;
+      case X1:
+        return (value as X1)._sizeHint();
+      case X2:
+        return (value as X2)._sizeHint();
+      case X3:
+        return (value as X3)._sizeHint();
+      case X4:
+        return (value as X4)._sizeHint();
+      case X5:
+        return (value as X5)._sizeHint();
+      case X6:
+        return (value as X6)._sizeHint();
+      case X7:
+        return (value as X7)._sizeHint();
+      case X8:
+        return (value as X8)._sizeHint();
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Here extends Junctions {
+  const Here();
+
+  @override
+  Map<String, dynamic> toJson() => {'Here': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Here;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class X1 extends Junctions {
+  const X1(this.value0);
+
+  factory X1._decode(_i1.Input input) {
+    return X1(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      1,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 1]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X1': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          1,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      1,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X1 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X2 extends Junctions {
+  const X2(this.value0);
+
+  factory X2._decode(_i1.Input input) {
+    return X2(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      2,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 2]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X2': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          2,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      2,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X2 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X3 extends Junctions {
+  const X3(this.value0);
+
+  factory X3._decode(_i1.Input input) {
+    return X3(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      3,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 3]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X3': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          3,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      3,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X3 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X4 extends Junctions {
+  const X4(this.value0);
+
+  factory X4._decode(_i1.Input input) {
+    return X4(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      4,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 4]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X4': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          4,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      4,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X4 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X5 extends Junctions {
+  const X5(this.value0);
+
+  factory X5._decode(_i1.Input input) {
+    return X5(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      5,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 5]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X5': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          5,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      5,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X5 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X6 extends Junctions {
+  const X6(this.value0);
+
+  factory X6._decode(_i1.Input input) {
+    return X6(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      6,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 6]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X6': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          6,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      6,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X6 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X7 extends Junctions {
+  const X7(this.value0);
+
+  factory X7._decode(_i1.Input input) {
+    return X7(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      7,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 7]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X7': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          7,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      7,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X7 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X8 extends Junctions {
+  const X8(this.value0);
+
+  factory X8._decode(_i1.Input input) {
+    return X8(const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      8,
+    ).decode(input));
+  }
+
+  /// Arc<[Junction; 8]>
+  final List<_i3.Junction> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'X8': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.ArrayCodec<_i3.Junction>(
+          _i3.Junction.codec,
+          8,
+        ).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    const _i1.ArrayCodec<_i3.Junction>(
+      _i3.Junction.codec,
+      8,
+    ).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X8 &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/location/location.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/location/location.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i3;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../junctions/junctions.dart' as _i2;
+
+class Location {
+  const Location({
+    required this.parents,
+    required this.interior,
+  });
+
+  factory Location.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u8
+  final int parents;
+
+  /// Junctions
+  final _i2.Junctions interior;
+
+  static const $LocationCodec codec = $LocationCodec();
+
+  _i3.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'parents': parents,
+        'interior': interior.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Location && other.parents == parents && other.interior == interior;
+
+  @override
+  int get hashCode => Object.hash(
+        parents,
+        interior,
+      );
+}
+
+class $LocationCodec with _i1.Codec<Location> {
+  const $LocationCodec();
+
+  @override
+  void encodeTo(
+    Location obj,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      obj.parents,
+      output,
+    );
+    _i2.Junctions.codec.encodeTo(
+      obj.interior,
+      output,
+    );
+  }
+
+  @override
+  Location decode(_i1.Input input) {
+    return Location(
+      parents: _i1.U8Codec.codec.decode(input),
+      interior: _i2.Junctions.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Location obj) {
+    int size = 0;
+    size = size + _i1.U8Codec.codec.sizeHint(obj.parents);
+    size = size + _i2.Junctions.codec.sizeHint(obj.interior);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/pallet_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/pallet_info.dart
@@ -1,0 +1,142 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+class PalletInfo {
+  const PalletInfo({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.major,
+    required this.minor,
+    required this.patch,
+  });
+
+  factory PalletInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> name;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt major;
+
+  /// u32
+  final BigInt minor;
+
+  /// u32
+  final BigInt patch;
+
+  static const $PalletInfoCodec codec = $PalletInfoCodec();
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'name': name,
+        'moduleName': moduleName,
+        'major': major,
+        'minor': minor,
+        'patch': patch,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInfo &&
+          other.index == index &&
+          _i3.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i3.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.major == major &&
+          other.minor == minor &&
+          other.patch == patch;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        major,
+        minor,
+        patch,
+      );
+}
+
+class $PalletInfoCodec with _i1.Codec<PalletInfo> {
+  const $PalletInfoCodec();
+
+  @override
+  void encodeTo(
+    PalletInfo obj,
+    _i1.Output output,
+  ) {
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.major,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.minor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.patch,
+      output,
+    );
+  }
+
+  @override
+  PalletInfo decode(_i1.Input input) {
+    return PalletInfo(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      major: _i1.CompactBigIntCodec.codec.decode(input),
+      minor: _i1.CompactBigIntCodec.codec.decode(input),
+      patch: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(PalletInfo obj) {
+    int size = 0;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.major);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.minor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.patch);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/query_response_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/query_response_info.dart
@@ -1,0 +1,99 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i3;
+import 'location/location.dart' as _i2;
+
+class QueryResponseInfo {
+  const QueryResponseInfo({
+    required this.destination,
+    required this.queryId,
+    required this.maxWeight,
+  });
+
+  factory QueryResponseInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// Location
+  final _i2.Location destination;
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i3.Weight maxWeight;
+
+  static const $QueryResponseInfoCodec codec = $QueryResponseInfoCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'destination': destination.toJson(),
+        'queryId': queryId,
+        'maxWeight': maxWeight.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponseInfo &&
+          other.destination == destination &&
+          other.queryId == queryId &&
+          other.maxWeight == maxWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        destination,
+        queryId,
+        maxWeight,
+      );
+}
+
+class $QueryResponseInfoCodec with _i1.Codec<QueryResponseInfo> {
+  const $QueryResponseInfoCodec();
+
+  @override
+  void encodeTo(
+    QueryResponseInfo obj,
+    _i1.Output output,
+  ) {
+    _i2.Location.codec.encodeTo(
+      obj.destination,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.queryId,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      obj.maxWeight,
+      output,
+    );
+  }
+
+  @override
+  QueryResponseInfo decode(_i1.Input input) {
+    return QueryResponseInfo(
+      destination: _i2.Location.codec.decode(input),
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxWeight: _i3.Weight.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(QueryResponseInfo obj) {
+    int size = 0;
+    size = size + _i2.Location.codec.sizeHint(obj.destination);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.queryId);
+    size = size + _i3.Weight.codec.sizeHint(obj.maxWeight);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/response.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/response.dart
@@ -1,0 +1,392 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i9;
+
+import '../../tuples_1.dart' as _i4;
+import '../../xcm/v3/maybe_error_code.dart' as _i7;
+import '../../xcm/v5/traits/error.dart' as _i5;
+import 'asset/asset.dart' as _i8;
+import 'asset/assets.dart' as _i3;
+import 'pallet_info.dart' as _i6;
+
+abstract class Response {
+  const Response();
+
+  factory Response.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $ResponseCodec codec = $ResponseCodec();
+
+  static const $Response values = $Response();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Response {
+  const $Response();
+
+  Null null_() {
+    return Null();
+  }
+
+  Assets assets(_i3.Assets value0) {
+    return Assets(value0);
+  }
+
+  ExecutionResult executionResult(_i4.Tuple2<int, _i5.Error>? value0) {
+    return ExecutionResult(value0);
+  }
+
+  Version version(int value0) {
+    return Version(value0);
+  }
+
+  PalletsInfo palletsInfo(List<_i6.PalletInfo> value0) {
+    return PalletsInfo(value0);
+  }
+
+  DispatchResult dispatchResult(_i7.MaybeErrorCode value0) {
+    return DispatchResult(value0);
+  }
+}
+
+class $ResponseCodec with _i1.Codec<Response> {
+  const $ResponseCodec();
+
+  @override
+  Response decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Null();
+      case 1:
+        return Assets._decode(input);
+      case 2:
+        return ExecutionResult._decode(input);
+      case 3:
+        return Version._decode(input);
+      case 4:
+        return PalletsInfo._decode(input);
+      case 5:
+        return DispatchResult._decode(input);
+      default:
+        throw Exception('Response: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Response value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Null:
+        (value as Null).encodeTo(output);
+        break;
+      case Assets:
+        (value as Assets).encodeTo(output);
+        break;
+      case ExecutionResult:
+        (value as ExecutionResult).encodeTo(output);
+        break;
+      case Version:
+        (value as Version).encodeTo(output);
+        break;
+      case PalletsInfo:
+        (value as PalletsInfo).encodeTo(output);
+        break;
+      case DispatchResult:
+        (value as DispatchResult).encodeTo(output);
+        break;
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Response value) {
+    switch (value.runtimeType) {
+      case Null:
+        return 1;
+      case Assets:
+        return (value as Assets)._sizeHint();
+      case ExecutionResult:
+        return (value as ExecutionResult)._sizeHint();
+      case Version:
+        return (value as Version)._sizeHint();
+      case PalletsInfo:
+        return (value as PalletsInfo)._sizeHint();
+      case DispatchResult:
+        return (value as DispatchResult)._sizeHint();
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Null extends Response {
+  const Null();
+
+  @override
+  Map<String, dynamic> toJson() => {'Null': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Null;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Assets extends Response {
+  const Assets(this.value0);
+
+  factory Assets._decode(_i1.Input input) {
+    return Assets(const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).decode(input));
+  }
+
+  /// Assets
+  final _i3.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Assets': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Assets &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExecutionResult extends Response {
+  const ExecutionResult(this.value0);
+
+  factory ExecutionResult._decode(_i1.Input input) {
+    return ExecutionResult(const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i4.Tuple2<int, _i5.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExecutionResult': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+          _i1.U32Codec.codec,
+          _i5.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExecutionResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Version extends Response {
+  const Version(this.value0);
+
+  factory Version._decode(_i1.Input input) {
+    return Version(_i1.U32Codec.codec.decode(input));
+  }
+
+  /// super::Version
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'Version': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U32Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.U32Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Version && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class PalletsInfo extends Response {
+  const PalletsInfo(this.value0);
+
+  factory PalletsInfo._decode(_i1.Input input) {
+    return PalletsInfo(const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).decode(input));
+  }
+
+  /// BoundedVec<PalletInfo, MaxPalletsInfo>
+  final List<_i6.PalletInfo> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'PalletsInfo': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletsInfo &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DispatchResult extends Response {
+  const DispatchResult(this.value0);
+
+  factory DispatchResult._decode(_i1.Input input) {
+    return DispatchResult(_i7.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i7.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DispatchResult': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i7.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i7.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DispatchResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/traits/instruction_error.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/traits/instruction_error.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i3;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../../xcm/v5/traits/error.dart' as _i2;
+
+class InstructionError {
+  const InstructionError({
+    required this.index,
+    required this.error,
+  });
+
+  factory InstructionError.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// InstructionIndex
+  final int index;
+
+  /// Error
+  final _i2.Error error;
+
+  static const $InstructionErrorCodec codec = $InstructionErrorCodec();
+
+  _i3.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'error': error.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InstructionError && other.index == index && other.error == error;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        error,
+      );
+}
+
+class $InstructionErrorCodec with _i1.Codec<InstructionError> {
+  const $InstructionErrorCodec();
+
+  @override
+  void encodeTo(
+    InstructionError obj,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      obj.index,
+      output,
+    );
+    _i2.Error.codec.encodeTo(
+      obj.error,
+      output,
+    );
+  }
+
+  @override
+  InstructionError decode(_i1.Input input) {
+    return InstructionError(
+      index: _i1.U8Codec.codec.decode(input),
+      error: _i2.Error.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(InstructionError obj) {
+    int size = 0;
+    size = size + _i1.U8Codec.codec.sizeHint(obj.index);
+    size = size + _i2.Error.codec.sizeHint(obj.error);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/traits/outcome.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/traits/outcome.dart
@@ -1,0 +1,256 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../../sp_weights/weight_v2/weight.dart' as _i3;
+import 'instruction_error.dart' as _i4;
+
+abstract class Outcome {
+  const Outcome();
+
+  factory Outcome.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $OutcomeCodec codec = $OutcomeCodec();
+
+  static const $Outcome values = $Outcome();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson();
+}
+
+class $Outcome {
+  const $Outcome();
+
+  Complete complete({required _i3.Weight used}) {
+    return Complete(used: used);
+  }
+
+  Incomplete incomplete({
+    required _i3.Weight used,
+    required _i4.InstructionError error,
+  }) {
+    return Incomplete(
+      used: used,
+      error: error,
+    );
+  }
+
+  Error error(_i4.InstructionError value0) {
+    return Error(value0);
+  }
+}
+
+class $OutcomeCodec with _i1.Codec<Outcome> {
+  const $OutcomeCodec();
+
+  @override
+  Outcome decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Complete._decode(input);
+      case 1:
+        return Incomplete._decode(input);
+      case 2:
+        return Error._decode(input);
+      default:
+        throw Exception('Outcome: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Outcome value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Complete:
+        (value as Complete).encodeTo(output);
+        break;
+      case Incomplete:
+        (value as Incomplete).encodeTo(output);
+        break;
+      case Error:
+        (value as Error).encodeTo(output);
+        break;
+      default:
+        throw Exception('Outcome: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Outcome value) {
+    switch (value.runtimeType) {
+      case Complete:
+        return (value as Complete)._sizeHint();
+      case Incomplete:
+        return (value as Incomplete)._sizeHint();
+      case Error:
+        return (value as Error)._sizeHint();
+      default:
+        throw Exception('Outcome: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Complete extends Outcome {
+  const Complete({required this.used});
+
+  factory Complete._decode(_i1.Input input) {
+    return Complete(used: _i3.Weight.codec.decode(input));
+  }
+
+  /// Weight
+  final _i3.Weight used;
+
+  @override
+  Map<String, Map<String, Map<String, BigInt>>> toJson() => {
+        'Complete': {'used': used.toJson()}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Weight.codec.sizeHint(used);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      used,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Complete && other.used == used;
+
+  @override
+  int get hashCode => used.hashCode;
+}
+
+class Incomplete extends Outcome {
+  const Incomplete({
+    required this.used,
+    required this.error,
+  });
+
+  factory Incomplete._decode(_i1.Input input) {
+    return Incomplete(
+      used: _i3.Weight.codec.decode(input),
+      error: _i4.InstructionError.codec.decode(input),
+    );
+  }
+
+  /// Weight
+  final _i3.Weight used;
+
+  /// InstructionError
+  final _i4.InstructionError error;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'Incomplete': {
+          'used': used.toJson(),
+          'error': error.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Weight.codec.sizeHint(used);
+    size = size + _i4.InstructionError.codec.sizeHint(error);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      used,
+      output,
+    );
+    _i4.InstructionError.codec.encodeTo(
+      error,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Incomplete && other.used == used && other.error == error;
+
+  @override
+  int get hashCode => Object.hash(
+        used,
+        error,
+      );
+}
+
+class Error extends Outcome {
+  const Error(this.value0);
+
+  factory Error._decode(_i1.Input input) {
+    return Error(_i4.InstructionError.codec.decode(input));
+  }
+
+  /// InstructionError
+  final _i4.InstructionError value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Error': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.InstructionError.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i4.InstructionError.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Error && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/xcm_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/xcm_1.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_1.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/xcm_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/staging_xcm/v5/xcm_2.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_2.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples.dart
@@ -47,3 +47,59 @@ class Tuple2Codec<T0, T1> with _i1.Codec<Tuple2<T0, T1>> {
     return size;
   }
 }
+
+class Tuple3<T0, T1, T2> {
+  const Tuple3(
+    this.value0,
+    this.value1,
+    this.value2,
+  );
+
+  final T0 value0;
+
+  final T1 value1;
+
+  final T2 value2;
+}
+
+class Tuple3Codec<T0, T1, T2> with _i1.Codec<Tuple3<T0, T1, T2>> {
+  const Tuple3Codec(
+    this.codec0,
+    this.codec1,
+    this.codec2,
+  );
+
+  final _i1.Codec<T0> codec0;
+
+  final _i1.Codec<T1> codec1;
+
+  final _i1.Codec<T2> codec2;
+
+  @override
+  void encodeTo(
+    Tuple3<T0, T1, T2> tuple,
+    _i1.Output output,
+  ) {
+    codec0.encodeTo(tuple.value0, output);
+    codec1.encodeTo(tuple.value1, output);
+    codec2.encodeTo(tuple.value2, output);
+  }
+
+  @override
+  Tuple3<T0, T1, T2> decode(_i1.Input input) {
+    return Tuple3(
+      codec0.decode(input),
+      codec1.decode(input),
+      codec2.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Tuple3<T0, T1, T2> tuple) {
+    int size = 0;
+    size += codec0.sizeHint(tuple.value0);
+    size += codec1.sizeHint(tuple.value1);
+    size += codec2.sizeHint(tuple.value2);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples_2.dart
@@ -1,16 +1,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:polkadart/scale_codec.dart' as _i1;
 
-class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> {
-  const Tuple8(
+class Tuple3<T0, T1, T2> {
+  const Tuple3(
     this.value0,
     this.value1,
     this.value2,
-    this.value3,
-    this.value4,
-    this.value5,
-    this.value6,
-    this.value7,
   );
 
   final T0 value0;
@@ -18,28 +13,13 @@ class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> {
   final T1 value1;
 
   final T2 value2;
-
-  final T3 value3;
-
-  final T4 value4;
-
-  final T5 value5;
-
-  final T6 value6;
-
-  final T7 value7;
 }
 
-class Tuple8Codec<T0, T1, T2, T3, T4, T5, T6, T7> with _i1.Codec<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> {
-  const Tuple8Codec(
+class Tuple3Codec<T0, T1, T2> with _i1.Codec<Tuple3<T0, T1, T2>> {
+  const Tuple3Codec(
     this.codec0,
     this.codec1,
     this.codec2,
-    this.codec3,
-    this.codec4,
-    this.codec5,
-    this.codec6,
-    this.codec7,
   );
 
   final _i1.Codec<T0> codec0;
@@ -48,56 +28,31 @@ class Tuple8Codec<T0, T1, T2, T3, T4, T5, T6, T7> with _i1.Codec<Tuple8<T0, T1, 
 
   final _i1.Codec<T2> codec2;
 
-  final _i1.Codec<T3> codec3;
-
-  final _i1.Codec<T4> codec4;
-
-  final _i1.Codec<T5> codec5;
-
-  final _i1.Codec<T6> codec6;
-
-  final _i1.Codec<T7> codec7;
-
   @override
   void encodeTo(
-    Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> tuple,
+    Tuple3<T0, T1, T2> tuple,
     _i1.Output output,
   ) {
     codec0.encodeTo(tuple.value0, output);
     codec1.encodeTo(tuple.value1, output);
     codec2.encodeTo(tuple.value2, output);
-    codec3.encodeTo(tuple.value3, output);
-    codec4.encodeTo(tuple.value4, output);
-    codec5.encodeTo(tuple.value5, output);
-    codec6.encodeTo(tuple.value6, output);
-    codec7.encodeTo(tuple.value7, output);
   }
 
   @override
-  Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> decode(_i1.Input input) {
-    return Tuple8(
+  Tuple3<T0, T1, T2> decode(_i1.Input input) {
+    return Tuple3(
       codec0.decode(input),
       codec1.decode(input),
       codec2.decode(input),
-      codec3.decode(input),
-      codec4.decode(input),
-      codec5.decode(input),
-      codec6.decode(input),
-      codec7.decode(input),
     );
   }
 
   @override
-  int sizeHint(Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> tuple) {
+  int sizeHint(Tuple3<T0, T1, T2> tuple) {
     int size = 0;
     size += codec0.sizeHint(tuple.value0);
     size += codec1.sizeHint(tuple.value1);
     size += codec2.sizeHint(tuple.value2);
-    size += codec3.sizeHint(tuple.value3);
-    size += codec4.sizeHint(tuple.value4);
-    size += codec5.sizeHint(tuple.value5);
-    size += codec6.sizeHint(tuple.value6);
-    size += codec7.sizeHint(tuple.value7);
     return size;
   }
 }

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples_3.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/tuples_3.dart
@@ -1,0 +1,112 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
+  const Tuple9(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+    this.value4,
+    this.value5,
+    this.value6,
+    this.value7,
+    this.value8,
+  );
+
+  final T0 value0;
+
+  final T1 value1;
+
+  final T2 value2;
+
+  final T3 value3;
+
+  final T4 value4;
+
+  final T5 value5;
+
+  final T6 value6;
+
+  final T7 value7;
+
+  final T8 value8;
+}
+
+class Tuple9Codec<T0, T1, T2, T3, T4, T5, T6, T7, T8> with _i1.Codec<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> {
+  const Tuple9Codec(
+    this.codec0,
+    this.codec1,
+    this.codec2,
+    this.codec3,
+    this.codec4,
+    this.codec5,
+    this.codec6,
+    this.codec7,
+    this.codec8,
+  );
+
+  final _i1.Codec<T0> codec0;
+
+  final _i1.Codec<T1> codec1;
+
+  final _i1.Codec<T2> codec2;
+
+  final _i1.Codec<T3> codec3;
+
+  final _i1.Codec<T4> codec4;
+
+  final _i1.Codec<T5> codec5;
+
+  final _i1.Codec<T6> codec6;
+
+  final _i1.Codec<T7> codec7;
+
+  final _i1.Codec<T8> codec8;
+
+  @override
+  void encodeTo(
+    Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> tuple,
+    _i1.Output output,
+  ) {
+    codec0.encodeTo(tuple.value0, output);
+    codec1.encodeTo(tuple.value1, output);
+    codec2.encodeTo(tuple.value2, output);
+    codec3.encodeTo(tuple.value3, output);
+    codec4.encodeTo(tuple.value4, output);
+    codec5.encodeTo(tuple.value5, output);
+    codec6.encodeTo(tuple.value6, output);
+    codec7.encodeTo(tuple.value7, output);
+    codec8.encodeTo(tuple.value8, output);
+  }
+
+  @override
+  Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> decode(_i1.Input input) {
+    return Tuple9(
+      codec0.decode(input),
+      codec1.decode(input),
+      codec2.decode(input),
+      codec3.decode(input),
+      codec4.decode(input),
+      codec5.decode(input),
+      codec6.decode(input),
+      codec7.decode(input),
+      codec8.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> tuple) {
+    int size = 0;
+    size += codec0.sizeHint(tuple.value0);
+    size += codec1.sizeHint(tuple.value1);
+    size += codec2.sizeHint(tuple.value2);
+    size += codec3.sizeHint(tuple.value3);
+    size += codec4.sizeHint(tuple.value4);
+    size += codec5.sizeHint(tuple.value5);
+    size += codec6.sizeHint(tuple.value6);
+    size += codec7.sizeHint(tuple.value7);
+    size += codec8.sizeHint(tuple.value8);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/double_encoded/double_encoded_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/double_encoded/double_encoded_1.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+class DoubleEncoded {
+  const DoubleEncoded({required this.encoded});
+
+  factory DoubleEncoded.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// Vec<u8>
+  final List<int> encoded;
+
+  static const $DoubleEncodedCodec codec = $DoubleEncodedCodec();
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, List<int>> toJson() => {'encoded': encoded};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DoubleEncoded &&
+          _i3.listsEqual(
+            other.encoded,
+            encoded,
+          );
+
+  @override
+  int get hashCode => encoded.hashCode;
+}
+
+class $DoubleEncodedCodec with _i1.Codec<DoubleEncoded> {
+  const $DoubleEncodedCodec();
+
+  @override
+  void encodeTo(
+    DoubleEncoded obj,
+    _i1.Output output,
+  ) {
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.encoded,
+      output,
+    );
+  }
+
+  @override
+  DoubleEncoded decode(_i1.Input input) {
+    return DoubleEncoded(encoded: _i1.U8SequenceCodec.codec.decode(input));
+  }
+
+  @override
+  int sizeHint(DoubleEncoded obj) {
+    int size = 0;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.encoded);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/double_encoded/double_encoded_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/double_encoded/double_encoded_2.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+class DoubleEncoded {
+  const DoubleEncoded({required this.encoded});
+
+  factory DoubleEncoded.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// Vec<u8>
+  final List<int> encoded;
+
+  static const $DoubleEncodedCodec codec = $DoubleEncodedCodec();
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, List<int>> toJson() => {'encoded': encoded};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DoubleEncoded &&
+          _i3.listsEqual(
+            other.encoded,
+            encoded,
+          );
+
+  @override
+  int get hashCode => encoded.hashCode;
+}
+
+class $DoubleEncodedCodec with _i1.Codec<DoubleEncoded> {
+  const $DoubleEncodedCodec();
+
+  @override
+  void encodeTo(
+    DoubleEncoded obj,
+    _i1.Output output,
+  ) {
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.encoded,
+      output,
+    );
+  }
+
+  @override
+  DoubleEncoded decode(_i1.Input input) {
+    return DoubleEncoded(encoded: _i1.U8SequenceCodec.codec.decode(input));
+  }
+
+  @override
+  int sizeHint(DoubleEncoded obj) {
+    int size = 0;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.encoded);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/instruction_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/instruction_1.dart
@@ -1,0 +1,3470 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i20;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../staging_xcm/v3/multilocation/multi_location.dart' as _i6;
+import '../../tuples.dart' as _i15;
+import '../double_encoded/double_encoded_1.dart' as _i9;
+import 'instruction_1.dart' as _i21;
+import 'junction/junction.dart' as _i18;
+import 'junction/network_id.dart' as _i19;
+import 'junctions/junctions.dart' as _i10;
+import 'maybe_error_code.dart' as _i17;
+import 'multiasset/multi_asset.dart' as _i13;
+import 'multiasset/multi_asset_filter.dart' as _i12;
+import 'multiasset/multi_assets.dart' as _i3;
+import 'origin_kind.dart' as _i8;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'traits/error.dart' as _i16;
+import 'weight_limit.dart' as _i14;
+import 'xcm_1.dart' as _i7;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.MultiAssets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.MultiAssets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.MultiAssets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.MultiLocation? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    required _i5.Weight requireWeightAtMost,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      requireWeightAtMost: requireWeightAtMost,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.MultiAssetFilter give,
+    required _i3.MultiAssets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.MultiAssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.MultiAsset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i7.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i7.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.MultiAssets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.MultiAssets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.MultiLocation? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i15.Tuple2<int, _i16.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i17.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i18.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i19.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.MultiLocation value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.MultiLocation? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      beneficiary: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    required this.requireWeightAtMost,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      requireWeightAtMost: _i5.Weight.codec.decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Weight
+  final _i5.Weight requireWeightAtMost;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'requireWeightAtMost': requireWeightAtMost.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + _i5.Weight.codec.sizeHint(requireWeightAtMost);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      requireWeightAtMost,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.requireWeightAtMost == requireWeightAtMost &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        requireWeightAtMost,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorMultiLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      beneficiary: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.MultiAssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter give;
+
+  /// MultiAssets
+  final _i3.MultiAssets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(give);
+    size = size + const _i3.MultiAssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i20.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      reserve: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.MultiAsset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i7.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i7.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      ticket: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i20.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input));
+  }
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i15.Tuple2<int, _i16.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+          _i1.U32Codec.codec,
+          _i16.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i15.Tuple2<int, _i16.Error>>(_i15.Tuple2Codec<int, _i16.Error>(
+      _i1.U32Codec.codec,
+      _i16.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i17.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i17.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i17.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i17.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i20.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i20.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i20.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i18.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i18.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i18.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i19.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i19.NetworkId network;
+
+  /// InteriorMultiLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i19.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i21.Instruction>(_i21.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i20.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.MultiAsset.codec.decode(input),
+      unlocker: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.MultiAsset.codec.decode(input),
+      target: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.MultiAsset.codec.decode(input),
+      owner: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.MultiAsset.codec.decode(input),
+      locker: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i20.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.MultiLocation.codec.decode(input));
+  }
+
+  /// MultiLocation
+  final _i6.MultiLocation value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.MultiLocation.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/instruction_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/instruction_2.dart
@@ -1,0 +1,3473 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i21;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i5;
+import '../../staging_xcm/v3/multilocation/multi_location.dart' as _i6;
+import '../../tuples.dart' as _i16;
+import '../double_encoded/double_encoded_2.dart' as _i9;
+import 'instruction_1.dart' as _i22;
+import 'instruction_2.dart' as _i23;
+import 'junction/junction.dart' as _i19;
+import 'junction/network_id.dart' as _i20;
+import 'junctions/junctions.dart' as _i10;
+import 'maybe_error_code.dart' as _i18;
+import 'multiasset/multi_asset.dart' as _i13;
+import 'multiasset/multi_asset_filter.dart' as _i12;
+import 'multiasset/multi_assets.dart' as _i3;
+import 'origin_kind.dart' as _i8;
+import 'query_response_info.dart' as _i11;
+import 'response.dart' as _i4;
+import 'traits/error.dart' as _i17;
+import 'weight_limit.dart' as _i14;
+import 'xcm_1.dart' as _i7;
+import 'xcm_2.dart' as _i15;
+
+abstract class Instruction {
+  const Instruction();
+
+  factory Instruction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $InstructionCodec codec = $InstructionCodec();
+
+  static const $Instruction values = $Instruction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Instruction {
+  const $Instruction();
+
+  WithdrawAsset withdrawAsset(_i3.MultiAssets value0) {
+    return WithdrawAsset(value0);
+  }
+
+  ReserveAssetDeposited reserveAssetDeposited(_i3.MultiAssets value0) {
+    return ReserveAssetDeposited(value0);
+  }
+
+  ReceiveTeleportedAsset receiveTeleportedAsset(_i3.MultiAssets value0) {
+    return ReceiveTeleportedAsset(value0);
+  }
+
+  QueryResponse queryResponse({
+    required BigInt queryId,
+    required _i4.Response response,
+    required _i5.Weight maxWeight,
+    _i6.MultiLocation? querier,
+  }) {
+    return QueryResponse(
+      queryId: queryId,
+      response: response,
+      maxWeight: maxWeight,
+      querier: querier,
+    );
+  }
+
+  TransferAsset transferAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation beneficiary,
+  }) {
+    return TransferAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  TransferReserveAsset transferReserveAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return TransferReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  Transact transact({
+    required _i8.OriginKind originKind,
+    required _i5.Weight requireWeightAtMost,
+    required _i9.DoubleEncoded call,
+  }) {
+    return Transact(
+      originKind: originKind,
+      requireWeightAtMost: requireWeightAtMost,
+      call: call,
+    );
+  }
+
+  HrmpNewChannelOpenRequest hrmpNewChannelOpenRequest({
+    required BigInt sender,
+    required BigInt maxMessageSize,
+    required BigInt maxCapacity,
+  }) {
+    return HrmpNewChannelOpenRequest(
+      sender: sender,
+      maxMessageSize: maxMessageSize,
+      maxCapacity: maxCapacity,
+    );
+  }
+
+  HrmpChannelAccepted hrmpChannelAccepted({required BigInt recipient}) {
+    return HrmpChannelAccepted(recipient: recipient);
+  }
+
+  HrmpChannelClosing hrmpChannelClosing({
+    required BigInt initiator,
+    required BigInt sender,
+    required BigInt recipient,
+  }) {
+    return HrmpChannelClosing(
+      initiator: initiator,
+      sender: sender,
+      recipient: recipient,
+    );
+  }
+
+  ClearOrigin clearOrigin() {
+    return ClearOrigin();
+  }
+
+  DescendOrigin descendOrigin(_i10.Junctions value0) {
+    return DescendOrigin(value0);
+  }
+
+  ReportError reportError(_i11.QueryResponseInfo value0) {
+    return ReportError(value0);
+  }
+
+  DepositAsset depositAsset({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation beneficiary,
+  }) {
+    return DepositAsset(
+      assets: assets,
+      beneficiary: beneficiary,
+    );
+  }
+
+  DepositReserveAsset depositReserveAsset({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return DepositReserveAsset(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ExchangeAsset exchangeAsset({
+    required _i12.MultiAssetFilter give,
+    required _i3.MultiAssets want,
+    required bool maximal,
+  }) {
+    return ExchangeAsset(
+      give: give,
+      want: want,
+      maximal: maximal,
+    );
+  }
+
+  InitiateReserveWithdraw initiateReserveWithdraw({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation reserve,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateReserveWithdraw(
+      assets: assets,
+      reserve: reserve,
+      xcm: xcm,
+    );
+  }
+
+  InitiateTeleport initiateTeleport({
+    required _i12.MultiAssetFilter assets,
+    required _i6.MultiLocation dest,
+    required _i7.Xcm xcm,
+  }) {
+    return InitiateTeleport(
+      assets: assets,
+      dest: dest,
+      xcm: xcm,
+    );
+  }
+
+  ReportHolding reportHolding({
+    required _i11.QueryResponseInfo responseInfo,
+    required _i12.MultiAssetFilter assets,
+  }) {
+    return ReportHolding(
+      responseInfo: responseInfo,
+      assets: assets,
+    );
+  }
+
+  BuyExecution buyExecution({
+    required _i13.MultiAsset fees,
+    required _i14.WeightLimit weightLimit,
+  }) {
+    return BuyExecution(
+      fees: fees,
+      weightLimit: weightLimit,
+    );
+  }
+
+  RefundSurplus refundSurplus() {
+    return RefundSurplus();
+  }
+
+  SetErrorHandler setErrorHandler(_i15.Xcm value0) {
+    return SetErrorHandler(value0);
+  }
+
+  SetAppendix setAppendix(_i15.Xcm value0) {
+    return SetAppendix(value0);
+  }
+
+  ClearError clearError() {
+    return ClearError();
+  }
+
+  ClaimAsset claimAsset({
+    required _i3.MultiAssets assets,
+    required _i6.MultiLocation ticket,
+  }) {
+    return ClaimAsset(
+      assets: assets,
+      ticket: ticket,
+    );
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  SubscribeVersion subscribeVersion({
+    required BigInt queryId,
+    required _i5.Weight maxResponseWeight,
+  }) {
+    return SubscribeVersion(
+      queryId: queryId,
+      maxResponseWeight: maxResponseWeight,
+    );
+  }
+
+  UnsubscribeVersion unsubscribeVersion() {
+    return UnsubscribeVersion();
+  }
+
+  BurnAsset burnAsset(_i3.MultiAssets value0) {
+    return BurnAsset(value0);
+  }
+
+  ExpectAsset expectAsset(_i3.MultiAssets value0) {
+    return ExpectAsset(value0);
+  }
+
+  ExpectOrigin expectOrigin(_i6.MultiLocation? value0) {
+    return ExpectOrigin(value0);
+  }
+
+  ExpectError expectError(_i16.Tuple2<int, _i17.Error>? value0) {
+    return ExpectError(value0);
+  }
+
+  ExpectTransactStatus expectTransactStatus(_i18.MaybeErrorCode value0) {
+    return ExpectTransactStatus(value0);
+  }
+
+  QueryPallet queryPallet({
+    required List<int> moduleName,
+    required _i11.QueryResponseInfo responseInfo,
+  }) {
+    return QueryPallet(
+      moduleName: moduleName,
+      responseInfo: responseInfo,
+    );
+  }
+
+  ExpectPallet expectPallet({
+    required BigInt index,
+    required List<int> name,
+    required List<int> moduleName,
+    required BigInt crateMajor,
+    required BigInt minCrateMinor,
+  }) {
+    return ExpectPallet(
+      index: index,
+      name: name,
+      moduleName: moduleName,
+      crateMajor: crateMajor,
+      minCrateMinor: minCrateMinor,
+    );
+  }
+
+  ReportTransactStatus reportTransactStatus(_i11.QueryResponseInfo value0) {
+    return ReportTransactStatus(value0);
+  }
+
+  ClearTransactStatus clearTransactStatus() {
+    return ClearTransactStatus();
+  }
+
+  UniversalOrigin universalOrigin(_i19.Junction value0) {
+    return UniversalOrigin(value0);
+  }
+
+  ExportMessage exportMessage({
+    required _i20.NetworkId network,
+    required _i10.Junctions destination,
+    required _i7.Xcm xcm,
+  }) {
+    return ExportMessage(
+      network: network,
+      destination: destination,
+      xcm: xcm,
+    );
+  }
+
+  LockAsset lockAsset({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation unlocker,
+  }) {
+    return LockAsset(
+      asset: asset,
+      unlocker: unlocker,
+    );
+  }
+
+  UnlockAsset unlockAsset({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation target,
+  }) {
+    return UnlockAsset(
+      asset: asset,
+      target: target,
+    );
+  }
+
+  NoteUnlockable noteUnlockable({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation owner,
+  }) {
+    return NoteUnlockable(
+      asset: asset,
+      owner: owner,
+    );
+  }
+
+  RequestUnlock requestUnlock({
+    required _i13.MultiAsset asset,
+    required _i6.MultiLocation locker,
+  }) {
+    return RequestUnlock(
+      asset: asset,
+      locker: locker,
+    );
+  }
+
+  SetFeesMode setFeesMode({required bool jitWithdraw}) {
+    return SetFeesMode(jitWithdraw: jitWithdraw);
+  }
+
+  SetTopic setTopic(List<int> value0) {
+    return SetTopic(value0);
+  }
+
+  ClearTopic clearTopic() {
+    return ClearTopic();
+  }
+
+  AliasOrigin aliasOrigin(_i6.MultiLocation value0) {
+    return AliasOrigin(value0);
+  }
+
+  UnpaidExecution unpaidExecution({
+    required _i14.WeightLimit weightLimit,
+    _i6.MultiLocation? checkOrigin,
+  }) {
+    return UnpaidExecution(
+      weightLimit: weightLimit,
+      checkOrigin: checkOrigin,
+    );
+  }
+}
+
+class $InstructionCodec with _i1.Codec<Instruction> {
+  const $InstructionCodec();
+
+  @override
+  Instruction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WithdrawAsset._decode(input);
+      case 1:
+        return ReserveAssetDeposited._decode(input);
+      case 2:
+        return ReceiveTeleportedAsset._decode(input);
+      case 3:
+        return QueryResponse._decode(input);
+      case 4:
+        return TransferAsset._decode(input);
+      case 5:
+        return TransferReserveAsset._decode(input);
+      case 6:
+        return Transact._decode(input);
+      case 7:
+        return HrmpNewChannelOpenRequest._decode(input);
+      case 8:
+        return HrmpChannelAccepted._decode(input);
+      case 9:
+        return HrmpChannelClosing._decode(input);
+      case 10:
+        return const ClearOrigin();
+      case 11:
+        return DescendOrigin._decode(input);
+      case 12:
+        return ReportError._decode(input);
+      case 13:
+        return DepositAsset._decode(input);
+      case 14:
+        return DepositReserveAsset._decode(input);
+      case 15:
+        return ExchangeAsset._decode(input);
+      case 16:
+        return InitiateReserveWithdraw._decode(input);
+      case 17:
+        return InitiateTeleport._decode(input);
+      case 18:
+        return ReportHolding._decode(input);
+      case 19:
+        return BuyExecution._decode(input);
+      case 20:
+        return const RefundSurplus();
+      case 21:
+        return SetErrorHandler._decode(input);
+      case 22:
+        return SetAppendix._decode(input);
+      case 23:
+        return const ClearError();
+      case 24:
+        return ClaimAsset._decode(input);
+      case 25:
+        return Trap._decode(input);
+      case 26:
+        return SubscribeVersion._decode(input);
+      case 27:
+        return const UnsubscribeVersion();
+      case 28:
+        return BurnAsset._decode(input);
+      case 29:
+        return ExpectAsset._decode(input);
+      case 30:
+        return ExpectOrigin._decode(input);
+      case 31:
+        return ExpectError._decode(input);
+      case 32:
+        return ExpectTransactStatus._decode(input);
+      case 33:
+        return QueryPallet._decode(input);
+      case 34:
+        return ExpectPallet._decode(input);
+      case 35:
+        return ReportTransactStatus._decode(input);
+      case 36:
+        return const ClearTransactStatus();
+      case 37:
+        return UniversalOrigin._decode(input);
+      case 38:
+        return ExportMessage._decode(input);
+      case 39:
+        return LockAsset._decode(input);
+      case 40:
+        return UnlockAsset._decode(input);
+      case 41:
+        return NoteUnlockable._decode(input);
+      case 42:
+        return RequestUnlock._decode(input);
+      case 43:
+        return SetFeesMode._decode(input);
+      case 44:
+        return SetTopic._decode(input);
+      case 45:
+        return const ClearTopic();
+      case 46:
+        return AliasOrigin._decode(input);
+      case 47:
+        return UnpaidExecution._decode(input);
+      default:
+        throw Exception('Instruction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Instruction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        (value as WithdrawAsset).encodeTo(output);
+        break;
+      case ReserveAssetDeposited:
+        (value as ReserveAssetDeposited).encodeTo(output);
+        break;
+      case ReceiveTeleportedAsset:
+        (value as ReceiveTeleportedAsset).encodeTo(output);
+        break;
+      case QueryResponse:
+        (value as QueryResponse).encodeTo(output);
+        break;
+      case TransferAsset:
+        (value as TransferAsset).encodeTo(output);
+        break;
+      case TransferReserveAsset:
+        (value as TransferReserveAsset).encodeTo(output);
+        break;
+      case Transact:
+        (value as Transact).encodeTo(output);
+        break;
+      case HrmpNewChannelOpenRequest:
+        (value as HrmpNewChannelOpenRequest).encodeTo(output);
+        break;
+      case HrmpChannelAccepted:
+        (value as HrmpChannelAccepted).encodeTo(output);
+        break;
+      case HrmpChannelClosing:
+        (value as HrmpChannelClosing).encodeTo(output);
+        break;
+      case ClearOrigin:
+        (value as ClearOrigin).encodeTo(output);
+        break;
+      case DescendOrigin:
+        (value as DescendOrigin).encodeTo(output);
+        break;
+      case ReportError:
+        (value as ReportError).encodeTo(output);
+        break;
+      case DepositAsset:
+        (value as DepositAsset).encodeTo(output);
+        break;
+      case DepositReserveAsset:
+        (value as DepositReserveAsset).encodeTo(output);
+        break;
+      case ExchangeAsset:
+        (value as ExchangeAsset).encodeTo(output);
+        break;
+      case InitiateReserveWithdraw:
+        (value as InitiateReserveWithdraw).encodeTo(output);
+        break;
+      case InitiateTeleport:
+        (value as InitiateTeleport).encodeTo(output);
+        break;
+      case ReportHolding:
+        (value as ReportHolding).encodeTo(output);
+        break;
+      case BuyExecution:
+        (value as BuyExecution).encodeTo(output);
+        break;
+      case RefundSurplus:
+        (value as RefundSurplus).encodeTo(output);
+        break;
+      case SetErrorHandler:
+        (value as SetErrorHandler).encodeTo(output);
+        break;
+      case SetAppendix:
+        (value as SetAppendix).encodeTo(output);
+        break;
+      case ClearError:
+        (value as ClearError).encodeTo(output);
+        break;
+      case ClaimAsset:
+        (value as ClaimAsset).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case SubscribeVersion:
+        (value as SubscribeVersion).encodeTo(output);
+        break;
+      case UnsubscribeVersion:
+        (value as UnsubscribeVersion).encodeTo(output);
+        break;
+      case BurnAsset:
+        (value as BurnAsset).encodeTo(output);
+        break;
+      case ExpectAsset:
+        (value as ExpectAsset).encodeTo(output);
+        break;
+      case ExpectOrigin:
+        (value as ExpectOrigin).encodeTo(output);
+        break;
+      case ExpectError:
+        (value as ExpectError).encodeTo(output);
+        break;
+      case ExpectTransactStatus:
+        (value as ExpectTransactStatus).encodeTo(output);
+        break;
+      case QueryPallet:
+        (value as QueryPallet).encodeTo(output);
+        break;
+      case ExpectPallet:
+        (value as ExpectPallet).encodeTo(output);
+        break;
+      case ReportTransactStatus:
+        (value as ReportTransactStatus).encodeTo(output);
+        break;
+      case ClearTransactStatus:
+        (value as ClearTransactStatus).encodeTo(output);
+        break;
+      case UniversalOrigin:
+        (value as UniversalOrigin).encodeTo(output);
+        break;
+      case ExportMessage:
+        (value as ExportMessage).encodeTo(output);
+        break;
+      case LockAsset:
+        (value as LockAsset).encodeTo(output);
+        break;
+      case UnlockAsset:
+        (value as UnlockAsset).encodeTo(output);
+        break;
+      case NoteUnlockable:
+        (value as NoteUnlockable).encodeTo(output);
+        break;
+      case RequestUnlock:
+        (value as RequestUnlock).encodeTo(output);
+        break;
+      case SetFeesMode:
+        (value as SetFeesMode).encodeTo(output);
+        break;
+      case SetTopic:
+        (value as SetTopic).encodeTo(output);
+        break;
+      case ClearTopic:
+        (value as ClearTopic).encodeTo(output);
+        break;
+      case AliasOrigin:
+        (value as AliasOrigin).encodeTo(output);
+        break;
+      case UnpaidExecution:
+        (value as UnpaidExecution).encodeTo(output);
+        break;
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Instruction value) {
+    switch (value.runtimeType) {
+      case WithdrawAsset:
+        return (value as WithdrawAsset)._sizeHint();
+      case ReserveAssetDeposited:
+        return (value as ReserveAssetDeposited)._sizeHint();
+      case ReceiveTeleportedAsset:
+        return (value as ReceiveTeleportedAsset)._sizeHint();
+      case QueryResponse:
+        return (value as QueryResponse)._sizeHint();
+      case TransferAsset:
+        return (value as TransferAsset)._sizeHint();
+      case TransferReserveAsset:
+        return (value as TransferReserveAsset)._sizeHint();
+      case Transact:
+        return (value as Transact)._sizeHint();
+      case HrmpNewChannelOpenRequest:
+        return (value as HrmpNewChannelOpenRequest)._sizeHint();
+      case HrmpChannelAccepted:
+        return (value as HrmpChannelAccepted)._sizeHint();
+      case HrmpChannelClosing:
+        return (value as HrmpChannelClosing)._sizeHint();
+      case ClearOrigin:
+        return 1;
+      case DescendOrigin:
+        return (value as DescendOrigin)._sizeHint();
+      case ReportError:
+        return (value as ReportError)._sizeHint();
+      case DepositAsset:
+        return (value as DepositAsset)._sizeHint();
+      case DepositReserveAsset:
+        return (value as DepositReserveAsset)._sizeHint();
+      case ExchangeAsset:
+        return (value as ExchangeAsset)._sizeHint();
+      case InitiateReserveWithdraw:
+        return (value as InitiateReserveWithdraw)._sizeHint();
+      case InitiateTeleport:
+        return (value as InitiateTeleport)._sizeHint();
+      case ReportHolding:
+        return (value as ReportHolding)._sizeHint();
+      case BuyExecution:
+        return (value as BuyExecution)._sizeHint();
+      case RefundSurplus:
+        return 1;
+      case SetErrorHandler:
+        return (value as SetErrorHandler)._sizeHint();
+      case SetAppendix:
+        return (value as SetAppendix)._sizeHint();
+      case ClearError:
+        return 1;
+      case ClaimAsset:
+        return (value as ClaimAsset)._sizeHint();
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case SubscribeVersion:
+        return (value as SubscribeVersion)._sizeHint();
+      case UnsubscribeVersion:
+        return 1;
+      case BurnAsset:
+        return (value as BurnAsset)._sizeHint();
+      case ExpectAsset:
+        return (value as ExpectAsset)._sizeHint();
+      case ExpectOrigin:
+        return (value as ExpectOrigin)._sizeHint();
+      case ExpectError:
+        return (value as ExpectError)._sizeHint();
+      case ExpectTransactStatus:
+        return (value as ExpectTransactStatus)._sizeHint();
+      case QueryPallet:
+        return (value as QueryPallet)._sizeHint();
+      case ExpectPallet:
+        return (value as ExpectPallet)._sizeHint();
+      case ReportTransactStatus:
+        return (value as ReportTransactStatus)._sizeHint();
+      case ClearTransactStatus:
+        return 1;
+      case UniversalOrigin:
+        return (value as UniversalOrigin)._sizeHint();
+      case ExportMessage:
+        return (value as ExportMessage)._sizeHint();
+      case LockAsset:
+        return (value as LockAsset)._sizeHint();
+      case UnlockAsset:
+        return (value as UnlockAsset)._sizeHint();
+      case NoteUnlockable:
+        return (value as NoteUnlockable)._sizeHint();
+      case RequestUnlock:
+        return (value as RequestUnlock)._sizeHint();
+      case SetFeesMode:
+        return (value as SetFeesMode)._sizeHint();
+      case SetTopic:
+        return (value as SetTopic)._sizeHint();
+      case ClearTopic:
+        return 1;
+      case AliasOrigin:
+        return (value as AliasOrigin)._sizeHint();
+      case UnpaidExecution:
+        return (value as UnpaidExecution)._sizeHint();
+      default:
+        throw Exception('Instruction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class WithdrawAsset extends Instruction {
+  const WithdrawAsset(this.value0);
+
+  factory WithdrawAsset._decode(_i1.Input input) {
+    return WithdrawAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'WithdrawAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WithdrawAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReserveAssetDeposited extends Instruction {
+  const ReserveAssetDeposited(this.value0);
+
+  factory ReserveAssetDeposited._decode(_i1.Input input) {
+    return ReserveAssetDeposited(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReserveAssetDeposited': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReserveAssetDeposited &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReceiveTeleportedAsset extends Instruction {
+  const ReceiveTeleportedAsset(this.value0);
+
+  factory ReceiveTeleportedAsset._decode(_i1.Input input) {
+    return ReceiveTeleportedAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ReceiveTeleportedAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReceiveTeleportedAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryResponse extends Instruction {
+  const QueryResponse({
+    required this.queryId,
+    required this.response,
+    required this.maxWeight,
+    this.querier,
+  });
+
+  factory QueryResponse._decode(_i1.Input input) {
+    return QueryResponse(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      response: _i4.Response.codec.decode(input),
+      maxWeight: _i5.Weight.codec.decode(input),
+      querier: const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Response
+  final _i4.Response response;
+
+  /// Weight
+  final _i5.Weight maxWeight;
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? querier;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryResponse': {
+          'queryId': queryId,
+          'response': response.toJson(),
+          'maxWeight': maxWeight.toJson(),
+          'querier': querier?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i4.Response.codec.sizeHint(response);
+    size = size + _i5.Weight.codec.sizeHint(maxWeight);
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(querier);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      response,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxWeight,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      querier,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponse &&
+          other.queryId == queryId &&
+          other.response == response &&
+          other.maxWeight == maxWeight &&
+          other.querier == querier;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        response,
+        maxWeight,
+        querier,
+      );
+}
+
+class TransferAsset extends Instruction {
+  const TransferAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory TransferAsset._decode(_i1.Input input) {
+    return TransferAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      beneficiary: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation beneficiary;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class TransferReserveAsset extends Instruction {
+  const TransferReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory TransferReserveAsset._decode(_i1.Input input) {
+    return TransferReserveAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'TransferReserveAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TransferReserveAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class Transact extends Instruction {
+  const Transact({
+    required this.originKind,
+    required this.requireWeightAtMost,
+    required this.call,
+  });
+
+  factory Transact._decode(_i1.Input input) {
+    return Transact(
+      originKind: _i8.OriginKind.codec.decode(input),
+      requireWeightAtMost: _i5.Weight.codec.decode(input),
+      call: _i9.DoubleEncoded.codec.decode(input),
+    );
+  }
+
+  /// OriginKind
+  final _i8.OriginKind originKind;
+
+  /// Weight
+  final _i5.Weight requireWeightAtMost;
+
+  /// DoubleEncoded<Call>
+  final _i9.DoubleEncoded call;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'Transact': {
+          'originKind': originKind.toJson(),
+          'requireWeightAtMost': requireWeightAtMost.toJson(),
+          'call': call.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i8.OriginKind.codec.sizeHint(originKind);
+    size = size + _i5.Weight.codec.sizeHint(requireWeightAtMost);
+    size = size + _i9.DoubleEncoded.codec.sizeHint(call);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i8.OriginKind.codec.encodeTo(
+      originKind,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      requireWeightAtMost,
+      output,
+    );
+    _i9.DoubleEncoded.codec.encodeTo(
+      call,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Transact &&
+          other.originKind == originKind &&
+          other.requireWeightAtMost == requireWeightAtMost &&
+          other.call == call;
+
+  @override
+  int get hashCode => Object.hash(
+        originKind,
+        requireWeightAtMost,
+        call,
+      );
+}
+
+class HrmpNewChannelOpenRequest extends Instruction {
+  const HrmpNewChannelOpenRequest({
+    required this.sender,
+    required this.maxMessageSize,
+    required this.maxCapacity,
+  });
+
+  factory HrmpNewChannelOpenRequest._decode(_i1.Input input) {
+    return HrmpNewChannelOpenRequest(
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      maxMessageSize: _i1.CompactBigIntCodec.codec.decode(input),
+      maxCapacity: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt maxMessageSize;
+
+  /// u32
+  final BigInt maxCapacity;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpNewChannelOpenRequest': {
+          'sender': sender,
+          'maxMessageSize': maxMessageSize,
+          'maxCapacity': maxCapacity,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxMessageSize);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(maxCapacity);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxMessageSize,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      maxCapacity,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpNewChannelOpenRequest &&
+          other.sender == sender &&
+          other.maxMessageSize == maxMessageSize &&
+          other.maxCapacity == maxCapacity;
+
+  @override
+  int get hashCode => Object.hash(
+        sender,
+        maxMessageSize,
+        maxCapacity,
+      );
+}
+
+class HrmpChannelAccepted extends Instruction {
+  const HrmpChannelAccepted({required this.recipient});
+
+  factory HrmpChannelAccepted._decode(_i1.Input input) {
+    return HrmpChannelAccepted(recipient: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelAccepted': {'recipient': recipient}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelAccepted && other.recipient == recipient;
+
+  @override
+  int get hashCode => recipient.hashCode;
+}
+
+class HrmpChannelClosing extends Instruction {
+  const HrmpChannelClosing({
+    required this.initiator,
+    required this.sender,
+    required this.recipient,
+  });
+
+  factory HrmpChannelClosing._decode(_i1.Input input) {
+    return HrmpChannelClosing(
+      initiator: _i1.CompactBigIntCodec.codec.decode(input),
+      sender: _i1.CompactBigIntCodec.codec.decode(input),
+      recipient: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt initiator;
+
+  /// u32
+  final BigInt sender;
+
+  /// u32
+  final BigInt recipient;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'HrmpChannelClosing': {
+          'initiator': initiator,
+          'sender': sender,
+          'recipient': recipient,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(initiator);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(sender);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(recipient);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      initiator,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      sender,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      recipient,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is HrmpChannelClosing &&
+          other.initiator == initiator &&
+          other.sender == sender &&
+          other.recipient == recipient;
+
+  @override
+  int get hashCode => Object.hash(
+        initiator,
+        sender,
+        recipient,
+      );
+}
+
+class ClearOrigin extends Instruction {
+  const ClearOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DescendOrigin extends Instruction {
+  const DescendOrigin(this.value0);
+
+  factory DescendOrigin._decode(_i1.Input input) {
+    return DescendOrigin(_i10.Junctions.codec.decode(input));
+  }
+
+  /// InteriorMultiLocation
+  final _i10.Junctions value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DescendOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i10.Junctions.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DescendOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ReportError extends Instruction {
+  const ReportError(this.value0);
+
+  factory ReportError._decode(_i1.Input input) {
+    return ReportError(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportError': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DepositAsset extends Instruction {
+  const DepositAsset({
+    required this.assets,
+    required this.beneficiary,
+  });
+
+  factory DepositAsset._decode(_i1.Input input) {
+    return DepositAsset(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      beneficiary: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation beneficiary;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'DepositAsset': {
+          'assets': assets.toJson(),
+          'beneficiary': beneficiary.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(beneficiary);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      beneficiary,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositAsset && other.assets == assets && other.beneficiary == beneficiary;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        beneficiary,
+      );
+}
+
+class DepositReserveAsset extends Instruction {
+  const DepositReserveAsset({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory DepositReserveAsset._decode(_i1.Input input) {
+    return DepositReserveAsset(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'DepositReserveAsset': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DepositReserveAsset &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ExchangeAsset extends Instruction {
+  const ExchangeAsset({
+    required this.give,
+    required this.want,
+    required this.maximal,
+  });
+
+  factory ExchangeAsset._decode(_i1.Input input) {
+    return ExchangeAsset(
+      give: _i12.MultiAssetFilter.codec.decode(input),
+      want: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      maximal: _i1.BoolCodec.codec.decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter give;
+
+  /// MultiAssets
+  final _i3.MultiAssets want;
+
+  /// bool
+  final bool maximal;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExchangeAsset': {
+          'give': give.toJson(),
+          'want': want.map((value) => value.toJson()).toList(),
+          'maximal': maximal,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(give);
+    size = size + const _i3.MultiAssetsCodec().sizeHint(want);
+    size = size + _i1.BoolCodec.codec.sizeHint(maximal);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      give,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      want,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      maximal,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExchangeAsset &&
+          other.give == give &&
+          _i21.listsEqual(
+            other.want,
+            want,
+          ) &&
+          other.maximal == maximal;
+
+  @override
+  int get hashCode => Object.hash(
+        give,
+        want,
+        maximal,
+      );
+}
+
+class InitiateReserveWithdraw extends Instruction {
+  const InitiateReserveWithdraw({
+    required this.assets,
+    required this.reserve,
+    required this.xcm,
+  });
+
+  factory InitiateReserveWithdraw._decode(_i1.Input input) {
+    return InitiateReserveWithdraw(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      reserve: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation reserve;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateReserveWithdraw': {
+          'assets': assets.toJson(),
+          'reserve': reserve.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(reserve);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      reserve,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateReserveWithdraw &&
+          other.assets == assets &&
+          other.reserve == reserve &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        reserve,
+        xcm,
+      );
+}
+
+class InitiateTeleport extends Instruction {
+  const InitiateTeleport({
+    required this.assets,
+    required this.dest,
+    required this.xcm,
+  });
+
+  factory InitiateTeleport._decode(_i1.Input input) {
+    return InitiateTeleport(
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+      dest: _i6.MultiLocation.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation dest;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'InitiateTeleport': {
+          'assets': assets.toJson(),
+          'dest': dest.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(dest);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      dest,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is InitiateTeleport &&
+          other.assets == assets &&
+          other.dest == dest &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        dest,
+        xcm,
+      );
+}
+
+class ReportHolding extends Instruction {
+  const ReportHolding({
+    required this.responseInfo,
+    required this.assets,
+  });
+
+  factory ReportHolding._decode(_i1.Input input) {
+    return ReportHolding(
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+      assets: _i12.MultiAssetFilter.codec.decode(input),
+    );
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  /// MultiAssetFilter
+  final _i12.MultiAssetFilter assets;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'ReportHolding': {
+          'responseInfo': responseInfo.toJson(),
+          'assets': assets.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    size = size + _i12.MultiAssetFilter.codec.sizeHint(assets);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+    _i12.MultiAssetFilter.codec.encodeTo(
+      assets,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportHolding && other.responseInfo == responseInfo && other.assets == assets;
+
+  @override
+  int get hashCode => Object.hash(
+        responseInfo,
+        assets,
+      );
+}
+
+class BuyExecution extends Instruction {
+  const BuyExecution({
+    required this.fees,
+    required this.weightLimit,
+  });
+
+  factory BuyExecution._decode(_i1.Input input) {
+    return BuyExecution(
+      fees: _i13.MultiAsset.codec.decode(input),
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset fees;
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'BuyExecution': {
+          'fees': fees.toJson(),
+          'weightLimit': weightLimit.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(fees);
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      fees,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BuyExecution && other.fees == fees && other.weightLimit == weightLimit;
+
+  @override
+  int get hashCode => Object.hash(
+        fees,
+        weightLimit,
+      );
+}
+
+class RefundSurplus extends Instruction {
+  const RefundSurplus();
+
+  @override
+  Map<String, dynamic> toJson() => {'RefundSurplus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is RefundSurplus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class SetErrorHandler extends Instruction {
+  const SetErrorHandler(this.value0);
+
+  factory SetErrorHandler._decode(_i1.Input input) {
+    return SetErrorHandler(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() =>
+      {'SetErrorHandler': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetErrorHandler &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SetAppendix extends Instruction {
+  const SetAppendix(this.value0);
+
+  factory SetAppendix._decode(_i1.Input input) {
+    return SetAppendix(const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).decode(input));
+  }
+
+  /// Xcm<Call>
+  final _i15.Xcm value0;
+
+  @override
+  Map<String, List<dynamic>> toJson() => {'SetAppendix': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i15.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+    const _i1.SequenceCodec<_i23.Instruction>(_i23.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetAppendix &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearError extends Instruction {
+  const ClearError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ClaimAsset extends Instruction {
+  const ClaimAsset({
+    required this.assets,
+    required this.ticket,
+  });
+
+  factory ClaimAsset._decode(_i1.Input input) {
+    return ClaimAsset(
+      assets: const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input),
+      ticket: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets assets;
+
+  /// MultiLocation
+  final _i6.MultiLocation ticket;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ClaimAsset': {
+          'assets': assets.map((value) => value.toJson()).toList(),
+          'ticket': ticket.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(assets);
+    size = size + _i6.MultiLocation.codec.sizeHint(ticket);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      assets,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      ticket,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ClaimAsset &&
+          _i21.listsEqual(
+            other.assets,
+            assets,
+          ) &&
+          other.ticket == ticket;
+
+  @override
+  int get hashCode => Object.hash(
+        assets,
+        ticket,
+      );
+}
+
+class Trap extends Instruction {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class SubscribeVersion extends Instruction {
+  const SubscribeVersion({
+    required this.queryId,
+    required this.maxResponseWeight,
+  });
+
+  factory SubscribeVersion._decode(_i1.Input input) {
+    return SubscribeVersion(
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxResponseWeight: _i5.Weight.codec.decode(input),
+    );
+  }
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i5.Weight maxResponseWeight;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'SubscribeVersion': {
+          'queryId': queryId,
+          'maxResponseWeight': maxResponseWeight.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(queryId);
+    size = size + _i5.Weight.codec.sizeHint(maxResponseWeight);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      queryId,
+      output,
+    );
+    _i5.Weight.codec.encodeTo(
+      maxResponseWeight,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SubscribeVersion && other.queryId == queryId && other.maxResponseWeight == maxResponseWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        queryId,
+        maxResponseWeight,
+      );
+}
+
+class UnsubscribeVersion extends Instruction {
+  const UnsubscribeVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnsubscribeVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnsubscribeVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BurnAsset extends Instruction {
+  const BurnAsset(this.value0);
+
+  factory BurnAsset._decode(_i1.Input input) {
+    return BurnAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'BurnAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is BurnAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectAsset extends Instruction {
+  const ExpectAsset(this.value0);
+
+  factory ExpectAsset._decode(_i1.Input input) {
+    return ExpectAsset(const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'ExpectAsset': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+    const _i1.SequenceCodec<_i13.MultiAsset>(_i13.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectAsset &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectOrigin extends Instruction {
+  const ExpectOrigin(this.value0);
+
+  factory ExpectOrigin._decode(_i1.Input input) {
+    return ExpectOrigin(const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input));
+  }
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? value0;
+
+  @override
+  Map<String, Map<String, dynamic>?> toJson() => {'ExpectOrigin': value0?.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectError extends Instruction {
+  const ExpectError(this.value0);
+
+  factory ExpectError._decode(_i1.Input input) {
+    return ExpectError(const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i16.Tuple2<int, _i17.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExpectError': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+          _i1.U32Codec.codec,
+          _i17.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+    const _i1.OptionCodec<_i16.Tuple2<int, _i17.Error>>(_i16.Tuple2Codec<int, _i17.Error>(
+      _i1.U32Codec.codec,
+      _i17.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectError && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectTransactStatus extends Instruction {
+  const ExpectTransactStatus(this.value0);
+
+  factory ExpectTransactStatus._decode(_i1.Input input) {
+    return ExpectTransactStatus(_i18.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i18.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ExpectTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i18.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+    _i18.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class QueryPallet extends Instruction {
+  const QueryPallet({
+    required this.moduleName,
+    required this.responseInfo,
+  });
+
+  factory QueryPallet._decode(_i1.Input input) {
+    return QueryPallet(
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      responseInfo: _i11.QueryResponseInfo.codec.decode(input),
+    );
+  }
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo responseInfo;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'QueryPallet': {
+          'moduleName': moduleName,
+          'responseInfo': responseInfo.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(responseInfo);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      responseInfo,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryPallet &&
+          _i21.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.responseInfo == responseInfo;
+
+  @override
+  int get hashCode => Object.hash(
+        moduleName,
+        responseInfo,
+      );
+}
+
+class ExpectPallet extends Instruction {
+  const ExpectPallet({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.crateMajor,
+    required this.minCrateMinor,
+  });
+
+  factory ExpectPallet._decode(_i1.Input input) {
+    return ExpectPallet(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      crateMajor: _i1.CompactBigIntCodec.codec.decode(input),
+      minCrateMinor: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// Vec<u8>
+  final List<int> name;
+
+  /// Vec<u8>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt crateMajor;
+
+  /// u32
+  final BigInt minCrateMinor;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExpectPallet': {
+          'index': index,
+          'name': name,
+          'moduleName': moduleName,
+          'crateMajor': crateMajor,
+          'minCrateMinor': minCrateMinor,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(crateMajor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(minCrateMinor);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      crateMajor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      minCrateMinor,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExpectPallet &&
+          other.index == index &&
+          _i21.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i21.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.crateMajor == crateMajor &&
+          other.minCrateMinor == minCrateMinor;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        crateMajor,
+        minCrateMinor,
+      );
+}
+
+class ReportTransactStatus extends Instruction {
+  const ReportTransactStatus(this.value0);
+
+  factory ReportTransactStatus._decode(_i1.Input input) {
+    return ReportTransactStatus(_i11.QueryResponseInfo.codec.decode(input));
+  }
+
+  /// QueryResponseInfo
+  final _i11.QueryResponseInfo value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'ReportTransactStatus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i11.QueryResponseInfo.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+    _i11.QueryResponseInfo.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ReportTransactStatus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTransactStatus extends Instruction {
+  const ClearTransactStatus();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTransactStatus': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTransactStatus;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UniversalOrigin extends Instruction {
+  const UniversalOrigin(this.value0);
+
+  factory UniversalOrigin._decode(_i1.Input input) {
+    return UniversalOrigin(_i19.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i19.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'UniversalOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i19.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i19.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UniversalOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExportMessage extends Instruction {
+  const ExportMessage({
+    required this.network,
+    required this.destination,
+    required this.xcm,
+  });
+
+  factory ExportMessage._decode(_i1.Input input) {
+    return ExportMessage(
+      network: _i20.NetworkId.codec.decode(input),
+      destination: _i10.Junctions.codec.decode(input),
+      xcm: const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).decode(input),
+    );
+  }
+
+  /// NetworkId
+  final _i20.NetworkId network;
+
+  /// InteriorMultiLocation
+  final _i10.Junctions destination;
+
+  /// Xcm<()>
+  final _i7.Xcm xcm;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ExportMessage': {
+          'network': network.toJson(),
+          'destination': destination.toJson(),
+          'xcm': xcm.map((value) => value.toJson()).toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i20.NetworkId.codec.sizeHint(network);
+    size = size + _i10.Junctions.codec.sizeHint(destination);
+    size = size + const _i7.XcmCodec().sizeHint(xcm);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+    _i20.NetworkId.codec.encodeTo(
+      network,
+      output,
+    );
+    _i10.Junctions.codec.encodeTo(
+      destination,
+      output,
+    );
+    const _i1.SequenceCodec<_i22.Instruction>(_i22.Instruction.codec).encodeTo(
+      xcm,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExportMessage &&
+          other.network == network &&
+          other.destination == destination &&
+          _i21.listsEqual(
+            other.xcm,
+            xcm,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        destination,
+        xcm,
+      );
+}
+
+class LockAsset extends Instruction {
+  const LockAsset({
+    required this.asset,
+    required this.unlocker,
+  });
+
+  factory LockAsset._decode(_i1.Input input) {
+    return LockAsset(
+      asset: _i13.MultiAsset.codec.decode(input),
+      unlocker: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation unlocker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'LockAsset': {
+          'asset': asset.toJson(),
+          'unlocker': unlocker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(unlocker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      unlocker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is LockAsset && other.asset == asset && other.unlocker == unlocker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        unlocker,
+      );
+}
+
+class UnlockAsset extends Instruction {
+  const UnlockAsset({
+    required this.asset,
+    required this.target,
+  });
+
+  factory UnlockAsset._decode(_i1.Input input) {
+    return UnlockAsset(
+      asset: _i13.MultiAsset.codec.decode(input),
+      target: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation target;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'UnlockAsset': {
+          'asset': asset.toJson(),
+          'target': target.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(target);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      target,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnlockAsset && other.asset == asset && other.target == target;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        target,
+      );
+}
+
+class NoteUnlockable extends Instruction {
+  const NoteUnlockable({
+    required this.asset,
+    required this.owner,
+  });
+
+  factory NoteUnlockable._decode(_i1.Input input) {
+    return NoteUnlockable(
+      asset: _i13.MultiAsset.codec.decode(input),
+      owner: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation owner;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'NoteUnlockable': {
+          'asset': asset.toJson(),
+          'owner': owner.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(owner);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      41,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      owner,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NoteUnlockable && other.asset == asset && other.owner == owner;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        owner,
+      );
+}
+
+class RequestUnlock extends Instruction {
+  const RequestUnlock({
+    required this.asset,
+    required this.locker,
+  });
+
+  factory RequestUnlock._decode(_i1.Input input) {
+    return RequestUnlock(
+      asset: _i13.MultiAsset.codec.decode(input),
+      locker: _i6.MultiLocation.codec.decode(input),
+    );
+  }
+
+  /// MultiAsset
+  final _i13.MultiAsset asset;
+
+  /// MultiLocation
+  final _i6.MultiLocation locker;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'RequestUnlock': {
+          'asset': asset.toJson(),
+          'locker': locker.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i13.MultiAsset.codec.sizeHint(asset);
+    size = size + _i6.MultiLocation.codec.sizeHint(locker);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      42,
+      output,
+    );
+    _i13.MultiAsset.codec.encodeTo(
+      asset,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      locker,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is RequestUnlock && other.asset == asset && other.locker == locker;
+
+  @override
+  int get hashCode => Object.hash(
+        asset,
+        locker,
+      );
+}
+
+class SetFeesMode extends Instruction {
+  const SetFeesMode({required this.jitWithdraw});
+
+  factory SetFeesMode._decode(_i1.Input input) {
+    return SetFeesMode(jitWithdraw: _i1.BoolCodec.codec.decode(input));
+  }
+
+  /// bool
+  final bool jitWithdraw;
+
+  @override
+  Map<String, Map<String, bool>> toJson() => {
+        'SetFeesMode': {'jitWithdraw': jitWithdraw}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.BoolCodec.codec.sizeHint(jitWithdraw);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      43,
+      output,
+    );
+    _i1.BoolCodec.codec.encodeTo(
+      jitWithdraw,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetFeesMode && other.jitWithdraw == jitWithdraw;
+
+  @override
+  int get hashCode => jitWithdraw.hashCode;
+}
+
+class SetTopic extends Instruction {
+  const SetTopic(this.value0);
+
+  factory SetTopic._decode(_i1.Input input) {
+    return SetTopic(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'SetTopic': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      44,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is SetTopic &&
+          _i21.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ClearTopic extends Instruction {
+  const ClearTopic();
+
+  @override
+  Map<String, dynamic> toJson() => {'ClearTopic': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      45,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ClearTopic;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AliasOrigin extends Instruction {
+  const AliasOrigin(this.value0);
+
+  factory AliasOrigin._decode(_i1.Input input) {
+    return AliasOrigin(_i6.MultiLocation.codec.decode(input));
+  }
+
+  /// MultiLocation
+  final _i6.MultiLocation value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'AliasOrigin': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i6.MultiLocation.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      46,
+      output,
+    );
+    _i6.MultiLocation.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AliasOrigin && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class UnpaidExecution extends Instruction {
+  const UnpaidExecution({
+    required this.weightLimit,
+    this.checkOrigin,
+  });
+
+  factory UnpaidExecution._decode(_i1.Input input) {
+    return UnpaidExecution(
+      weightLimit: _i14.WeightLimit.codec.decode(input),
+      checkOrigin: const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).decode(input),
+    );
+  }
+
+  /// WeightLimit
+  final _i14.WeightLimit weightLimit;
+
+  /// Option<MultiLocation>
+  final _i6.MultiLocation? checkOrigin;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>?>> toJson() => {
+        'UnpaidExecution': {
+          'weightLimit': weightLimit.toJson(),
+          'checkOrigin': checkOrigin?.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i14.WeightLimit.codec.sizeHint(weightLimit);
+    size = size + const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).sizeHint(checkOrigin);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      47,
+      output,
+    );
+    _i14.WeightLimit.codec.encodeTo(
+      weightLimit,
+      output,
+    );
+    const _i1.OptionCodec<_i6.MultiLocation>(_i6.MultiLocation.codec).encodeTo(
+      checkOrigin,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is UnpaidExecution && other.weightLimit == weightLimit && other.checkOrigin == checkOrigin;
+
+  @override
+  int get hashCode => Object.hash(
+        weightLimit,
+        checkOrigin,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/body_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/body_id.dart
@@ -1,0 +1,423 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class BodyId {
+  const BodyId();
+
+  factory BodyId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $BodyIdCodec codec = $BodyIdCodec();
+
+  static const $BodyId values = $BodyId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $BodyId {
+  const $BodyId();
+
+  Unit unit() {
+    return Unit();
+  }
+
+  Moniker moniker(List<int> value0) {
+    return Moniker(value0);
+  }
+
+  Index index(BigInt value0) {
+    return Index(value0);
+  }
+
+  Executive executive() {
+    return Executive();
+  }
+
+  Technical technical() {
+    return Technical();
+  }
+
+  Legislative legislative() {
+    return Legislative();
+  }
+
+  Judicial judicial() {
+    return Judicial();
+  }
+
+  Defense defense() {
+    return Defense();
+  }
+
+  Administration administration() {
+    return Administration();
+  }
+
+  Treasury treasury() {
+    return Treasury();
+  }
+}
+
+class $BodyIdCodec with _i1.Codec<BodyId> {
+  const $BodyIdCodec();
+
+  @override
+  BodyId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Unit();
+      case 1:
+        return Moniker._decode(input);
+      case 2:
+        return Index._decode(input);
+      case 3:
+        return const Executive();
+      case 4:
+        return const Technical();
+      case 5:
+        return const Legislative();
+      case 6:
+        return const Judicial();
+      case 7:
+        return const Defense();
+      case 8:
+        return const Administration();
+      case 9:
+        return const Treasury();
+      default:
+        throw Exception('BodyId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    BodyId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Unit:
+        (value as Unit).encodeTo(output);
+        break;
+      case Moniker:
+        (value as Moniker).encodeTo(output);
+        break;
+      case Index:
+        (value as Index).encodeTo(output);
+        break;
+      case Executive:
+        (value as Executive).encodeTo(output);
+        break;
+      case Technical:
+        (value as Technical).encodeTo(output);
+        break;
+      case Legislative:
+        (value as Legislative).encodeTo(output);
+        break;
+      case Judicial:
+        (value as Judicial).encodeTo(output);
+        break;
+      case Defense:
+        (value as Defense).encodeTo(output);
+        break;
+      case Administration:
+        (value as Administration).encodeTo(output);
+        break;
+      case Treasury:
+        (value as Treasury).encodeTo(output);
+        break;
+      default:
+        throw Exception('BodyId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(BodyId value) {
+    switch (value.runtimeType) {
+      case Unit:
+        return 1;
+      case Moniker:
+        return (value as Moniker)._sizeHint();
+      case Index:
+        return (value as Index)._sizeHint();
+      case Executive:
+        return 1;
+      case Technical:
+        return 1;
+      case Legislative:
+        return 1;
+      case Judicial:
+        return 1;
+      case Defense:
+        return 1;
+      case Administration:
+        return 1;
+      case Treasury:
+        return 1;
+      default:
+        throw Exception('BodyId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Unit extends BodyId {
+  const Unit();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unit': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unit;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Moniker extends BodyId {
+  const Moniker(this.value0);
+
+  factory Moniker._decode(_i1.Input input) {
+    return Moniker(const _i1.U8ArrayCodec(4).decode(input));
+  }
+
+  /// [u8; 4]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Moniker': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(4).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.U8ArrayCodec(4).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Moniker &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Index extends BodyId {
+  const Index(this.value0);
+
+  factory Index._decode(_i1.Input input) {
+    return Index(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Index': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Index && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Executive extends BodyId {
+  const Executive();
+
+  @override
+  Map<String, dynamic> toJson() => {'Executive': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Executive;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Technical extends BodyId {
+  const Technical();
+
+  @override
+  Map<String, dynamic> toJson() => {'Technical': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Technical;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Legislative extends BodyId {
+  const Legislative();
+
+  @override
+  Map<String, dynamic> toJson() => {'Legislative': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Legislative;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Judicial extends BodyId {
+  const Judicial();
+
+  @override
+  Map<String, dynamic> toJson() => {'Judicial': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Judicial;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Defense extends BodyId {
+  const Defense();
+
+  @override
+  Map<String, dynamic> toJson() => {'Defense': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Defense;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Administration extends BodyId {
+  const Administration();
+
+  @override
+  Map<String, dynamic> toJson() => {'Administration': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Administration;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Treasury extends BodyId {
+  const Treasury();
+
+  @override
+  Map<String, dynamic> toJson() => {'Treasury': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Treasury;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/body_part.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/body_part.dart
@@ -1,0 +1,393 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+abstract class BodyPart {
+  const BodyPart();
+
+  factory BodyPart.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $BodyPartCodec codec = $BodyPartCodec();
+
+  static const $BodyPart values = $BodyPart();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $BodyPart {
+  const $BodyPart();
+
+  Voice voice() {
+    return Voice();
+  }
+
+  Members members({required BigInt count}) {
+    return Members(count: count);
+  }
+
+  Fraction fraction({
+    required BigInt nom,
+    required BigInt denom,
+  }) {
+    return Fraction(
+      nom: nom,
+      denom: denom,
+    );
+  }
+
+  AtLeastProportion atLeastProportion({
+    required BigInt nom,
+    required BigInt denom,
+  }) {
+    return AtLeastProportion(
+      nom: nom,
+      denom: denom,
+    );
+  }
+
+  MoreThanProportion moreThanProportion({
+    required BigInt nom,
+    required BigInt denom,
+  }) {
+    return MoreThanProportion(
+      nom: nom,
+      denom: denom,
+    );
+  }
+}
+
+class $BodyPartCodec with _i1.Codec<BodyPart> {
+  const $BodyPartCodec();
+
+  @override
+  BodyPart decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Voice();
+      case 1:
+        return Members._decode(input);
+      case 2:
+        return Fraction._decode(input);
+      case 3:
+        return AtLeastProportion._decode(input);
+      case 4:
+        return MoreThanProportion._decode(input);
+      default:
+        throw Exception('BodyPart: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    BodyPart value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Voice:
+        (value as Voice).encodeTo(output);
+        break;
+      case Members:
+        (value as Members).encodeTo(output);
+        break;
+      case Fraction:
+        (value as Fraction).encodeTo(output);
+        break;
+      case AtLeastProportion:
+        (value as AtLeastProportion).encodeTo(output);
+        break;
+      case MoreThanProportion:
+        (value as MoreThanProportion).encodeTo(output);
+        break;
+      default:
+        throw Exception('BodyPart: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(BodyPart value) {
+    switch (value.runtimeType) {
+      case Voice:
+        return 1;
+      case Members:
+        return (value as Members)._sizeHint();
+      case Fraction:
+        return (value as Fraction)._sizeHint();
+      case AtLeastProportion:
+        return (value as AtLeastProportion)._sizeHint();
+      case MoreThanProportion:
+        return (value as MoreThanProportion)._sizeHint();
+      default:
+        throw Exception('BodyPart: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Voice extends BodyPart {
+  const Voice();
+
+  @override
+  Map<String, dynamic> toJson() => {'Voice': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Voice;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Members extends BodyPart {
+  const Members({required this.count});
+
+  factory Members._decode(_i1.Input input) {
+    return Members(count: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt count;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'Members': {'count': count}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(count);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      count,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Members && other.count == count;
+
+  @override
+  int get hashCode => count.hashCode;
+}
+
+class Fraction extends BodyPart {
+  const Fraction({
+    required this.nom,
+    required this.denom,
+  });
+
+  factory Fraction._decode(_i1.Input input) {
+    return Fraction(
+      nom: _i1.CompactBigIntCodec.codec.decode(input),
+      denom: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt nom;
+
+  /// u32
+  final BigInt denom;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'Fraction': {
+          'nom': nom,
+          'denom': denom,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(nom);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(denom);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      nom,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      denom,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Fraction && other.nom == nom && other.denom == denom;
+
+  @override
+  int get hashCode => Object.hash(
+        nom,
+        denom,
+      );
+}
+
+class AtLeastProportion extends BodyPart {
+  const AtLeastProportion({
+    required this.nom,
+    required this.denom,
+  });
+
+  factory AtLeastProportion._decode(_i1.Input input) {
+    return AtLeastProportion(
+      nom: _i1.CompactBigIntCodec.codec.decode(input),
+      denom: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt nom;
+
+  /// u32
+  final BigInt denom;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'AtLeastProportion': {
+          'nom': nom,
+          'denom': denom,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(nom);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(denom);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      nom,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      denom,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AtLeastProportion && other.nom == nom && other.denom == denom;
+
+  @override
+  int get hashCode => Object.hash(
+        nom,
+        denom,
+      );
+}
+
+class MoreThanProportion extends BodyPart {
+  const MoreThanProportion({
+    required this.nom,
+    required this.denom,
+  });
+
+  factory MoreThanProportion._decode(_i1.Input input) {
+    return MoreThanProportion(
+      nom: _i1.CompactBigIntCodec.codec.decode(input),
+      denom: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// u32
+  final BigInt nom;
+
+  /// u32
+  final BigInt denom;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'MoreThanProportion': {
+          'nom': nom,
+          'denom': denom,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(nom);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(denom);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      nom,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      denom,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is MoreThanProportion && other.nom == nom && other.denom == denom;
+
+  @override
+  int get hashCode => Object.hash(
+        nom,
+        denom,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/junction.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/junction.dart
@@ -1,0 +1,732 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import 'body_id.dart' as _i4;
+import 'body_part.dart' as _i5;
+import 'network_id.dart' as _i3;
+
+abstract class Junction {
+  const Junction();
+
+  factory Junction.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionCodec codec = $JunctionCodec();
+
+  static const $Junction values = $Junction();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junction {
+  const $Junction();
+
+  Parachain parachain(BigInt value0) {
+    return Parachain(value0);
+  }
+
+  AccountId32 accountId32({
+    _i3.NetworkId? network,
+    required List<int> id,
+  }) {
+    return AccountId32(
+      network: network,
+      id: id,
+    );
+  }
+
+  AccountIndex64 accountIndex64({
+    _i3.NetworkId? network,
+    required BigInt index,
+  }) {
+    return AccountIndex64(
+      network: network,
+      index: index,
+    );
+  }
+
+  AccountKey20 accountKey20({
+    _i3.NetworkId? network,
+    required List<int> key,
+  }) {
+    return AccountKey20(
+      network: network,
+      key: key,
+    );
+  }
+
+  PalletInstance palletInstance(int value0) {
+    return PalletInstance(value0);
+  }
+
+  GeneralIndex generalIndex(BigInt value0) {
+    return GeneralIndex(value0);
+  }
+
+  GeneralKey generalKey({
+    required int length,
+    required List<int> data,
+  }) {
+    return GeneralKey(
+      length: length,
+      data: data,
+    );
+  }
+
+  OnlyChild onlyChild() {
+    return OnlyChild();
+  }
+
+  Plurality plurality({
+    required _i4.BodyId id,
+    required _i5.BodyPart part,
+  }) {
+    return Plurality(
+      id: id,
+      part: part,
+    );
+  }
+
+  GlobalConsensus globalConsensus(_i3.NetworkId value0) {
+    return GlobalConsensus(value0);
+  }
+}
+
+class $JunctionCodec with _i1.Codec<Junction> {
+  const $JunctionCodec();
+
+  @override
+  Junction decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Parachain._decode(input);
+      case 1:
+        return AccountId32._decode(input);
+      case 2:
+        return AccountIndex64._decode(input);
+      case 3:
+        return AccountKey20._decode(input);
+      case 4:
+        return PalletInstance._decode(input);
+      case 5:
+        return GeneralIndex._decode(input);
+      case 6:
+        return GeneralKey._decode(input);
+      case 7:
+        return const OnlyChild();
+      case 8:
+        return Plurality._decode(input);
+      case 9:
+        return GlobalConsensus._decode(input);
+      default:
+        throw Exception('Junction: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junction value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Parachain:
+        (value as Parachain).encodeTo(output);
+        break;
+      case AccountId32:
+        (value as AccountId32).encodeTo(output);
+        break;
+      case AccountIndex64:
+        (value as AccountIndex64).encodeTo(output);
+        break;
+      case AccountKey20:
+        (value as AccountKey20).encodeTo(output);
+        break;
+      case PalletInstance:
+        (value as PalletInstance).encodeTo(output);
+        break;
+      case GeneralIndex:
+        (value as GeneralIndex).encodeTo(output);
+        break;
+      case GeneralKey:
+        (value as GeneralKey).encodeTo(output);
+        break;
+      case OnlyChild:
+        (value as OnlyChild).encodeTo(output);
+        break;
+      case Plurality:
+        (value as Plurality).encodeTo(output);
+        break;
+      case GlobalConsensus:
+        (value as GlobalConsensus).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junction value) {
+    switch (value.runtimeType) {
+      case Parachain:
+        return (value as Parachain)._sizeHint();
+      case AccountId32:
+        return (value as AccountId32)._sizeHint();
+      case AccountIndex64:
+        return (value as AccountIndex64)._sizeHint();
+      case AccountKey20:
+        return (value as AccountKey20)._sizeHint();
+      case PalletInstance:
+        return (value as PalletInstance)._sizeHint();
+      case GeneralIndex:
+        return (value as GeneralIndex)._sizeHint();
+      case GeneralKey:
+        return (value as GeneralKey)._sizeHint();
+      case OnlyChild:
+        return 1;
+      case Plurality:
+        return (value as Plurality)._sizeHint();
+      case GlobalConsensus:
+        return (value as GlobalConsensus)._sizeHint();
+      default:
+        throw Exception('Junction: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Parachain extends Junction {
+  const Parachain(this.value0);
+
+  factory Parachain._decode(_i1.Input input) {
+    return Parachain(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Parachain': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Parachain && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AccountId32 extends Junction {
+  const AccountId32({
+    this.network,
+    required this.id,
+  });
+
+  factory AccountId32._decode(_i1.Input input) {
+    return AccountId32(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      id: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 32]
+  final List<int> id;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountId32': {
+          'network': network?.toJson(),
+          'id': id.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(id);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      id,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountId32 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.id,
+            id,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        id,
+      );
+}
+
+class AccountIndex64 extends Junction {
+  const AccountIndex64({
+    this.network,
+    required this.index,
+  });
+
+  factory AccountIndex64._decode(_i1.Input input) {
+    return AccountIndex64(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// u64
+  final BigInt index;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountIndex64': {
+          'network': network?.toJson(),
+          'index': index,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(index);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      index,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountIndex64 && other.network == network && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        index,
+      );
+}
+
+class AccountKey20 extends Junction {
+  const AccountKey20({
+    this.network,
+    required this.key,
+  });
+
+  factory AccountKey20._decode(_i1.Input input) {
+    return AccountKey20(
+      network: const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).decode(input),
+      key: const _i1.U8ArrayCodec(20).decode(input),
+    );
+  }
+
+  /// Option<NetworkId>
+  final _i3.NetworkId? network;
+
+  /// [u8; 20]
+  final List<int> key;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AccountKey20': {
+          'network': network?.toJson(),
+          'key': key.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).sizeHint(network);
+    size = size + const _i1.U8ArrayCodec(20).sizeHint(key);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.OptionCodec<_i3.NetworkId>(_i3.NetworkId.codec).encodeTo(
+      network,
+      output,
+    );
+    const _i1.U8ArrayCodec(20).encodeTo(
+      key,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AccountKey20 &&
+          other.network == network &&
+          _i6.listsEqual(
+            other.key,
+            key,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        network,
+        key,
+      );
+}
+
+class PalletInstance extends Junction {
+  const PalletInstance(this.value0);
+
+  factory PalletInstance._decode(_i1.Input input) {
+    return PalletInstance(_i1.U8Codec.codec.decode(input));
+  }
+
+  /// u8
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'PalletInstance': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInstance && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralIndex extends Junction {
+  const GeneralIndex(this.value0);
+
+  factory GeneralIndex._decode(_i1.Input input) {
+    return GeneralIndex(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'GeneralIndex': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralIndex && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class GeneralKey extends Junction {
+  const GeneralKey({
+    required this.length,
+    required this.data,
+  });
+
+  factory GeneralKey._decode(_i1.Input input) {
+    return GeneralKey(
+      length: _i1.U8Codec.codec.decode(input),
+      data: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u8
+  final int length;
+
+  /// [u8; 32]
+  final List<int> data;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'GeneralKey': {
+          'length': length,
+          'data': data.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8Codec.codec.sizeHint(length);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(data);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i1.U8Codec.codec.encodeTo(
+      length,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      data,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GeneralKey &&
+          other.length == length &&
+          _i6.listsEqual(
+            other.data,
+            data,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        length,
+        data,
+      );
+}
+
+class OnlyChild extends Junction {
+  const OnlyChild();
+
+  @override
+  Map<String, dynamic> toJson() => {'OnlyChild': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is OnlyChild;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Plurality extends Junction {
+  const Plurality({
+    required this.id,
+    required this.part,
+  });
+
+  factory Plurality._decode(_i1.Input input) {
+    return Plurality(
+      id: _i4.BodyId.codec.decode(input),
+      part: _i5.BodyPart.codec.decode(input),
+    );
+  }
+
+  /// BodyId
+  final _i4.BodyId id;
+
+  /// BodyPart
+  final _i5.BodyPart part;
+
+  @override
+  Map<String, Map<String, Map<String, dynamic>>> toJson() => {
+        'Plurality': {
+          'id': id.toJson(),
+          'part': part.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.BodyId.codec.sizeHint(id);
+    size = size + _i5.BodyPart.codec.sizeHint(part);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i4.BodyId.codec.encodeTo(
+      id,
+      output,
+    );
+    _i5.BodyPart.codec.encodeTo(
+      part,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Plurality && other.id == id && other.part == part;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        part,
+      );
+}
+
+class GlobalConsensus extends Junction {
+  const GlobalConsensus(this.value0);
+
+  factory GlobalConsensus._decode(_i1.Input input) {
+    return GlobalConsensus(_i3.NetworkId.codec.decode(input));
+  }
+
+  /// NetworkId
+  final _i3.NetworkId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'GlobalConsensus': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.NetworkId.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+    _i3.NetworkId.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is GlobalConsensus && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/network_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junction/network_id.dart
@@ -1,0 +1,511 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class NetworkId {
+  const NetworkId();
+
+  factory NetworkId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $NetworkIdCodec codec = $NetworkIdCodec();
+
+  static const $NetworkId values = $NetworkId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $NetworkId {
+  const $NetworkId();
+
+  ByGenesis byGenesis(List<int> value0) {
+    return ByGenesis(value0);
+  }
+
+  ByFork byFork({
+    required BigInt blockNumber,
+    required List<int> blockHash,
+  }) {
+    return ByFork(
+      blockNumber: blockNumber,
+      blockHash: blockHash,
+    );
+  }
+
+  Polkadot polkadot() {
+    return Polkadot();
+  }
+
+  Kusama kusama() {
+    return Kusama();
+  }
+
+  Westend westend() {
+    return Westend();
+  }
+
+  Rococo rococo() {
+    return Rococo();
+  }
+
+  Wococo wococo() {
+    return Wococo();
+  }
+
+  Ethereum ethereum({required BigInt chainId}) {
+    return Ethereum(chainId: chainId);
+  }
+
+  BitcoinCore bitcoinCore() {
+    return BitcoinCore();
+  }
+
+  BitcoinCash bitcoinCash() {
+    return BitcoinCash();
+  }
+
+  PolkadotBulletin polkadotBulletin() {
+    return PolkadotBulletin();
+  }
+}
+
+class $NetworkIdCodec with _i1.Codec<NetworkId> {
+  const $NetworkIdCodec();
+
+  @override
+  NetworkId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return ByGenesis._decode(input);
+      case 1:
+        return ByFork._decode(input);
+      case 2:
+        return const Polkadot();
+      case 3:
+        return const Kusama();
+      case 4:
+        return const Westend();
+      case 5:
+        return const Rococo();
+      case 6:
+        return const Wococo();
+      case 7:
+        return Ethereum._decode(input);
+      case 8:
+        return const BitcoinCore();
+      case 9:
+        return const BitcoinCash();
+      case 10:
+        return const PolkadotBulletin();
+      default:
+        throw Exception('NetworkId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    NetworkId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        (value as ByGenesis).encodeTo(output);
+        break;
+      case ByFork:
+        (value as ByFork).encodeTo(output);
+        break;
+      case Polkadot:
+        (value as Polkadot).encodeTo(output);
+        break;
+      case Kusama:
+        (value as Kusama).encodeTo(output);
+        break;
+      case Westend:
+        (value as Westend).encodeTo(output);
+        break;
+      case Rococo:
+        (value as Rococo).encodeTo(output);
+        break;
+      case Wococo:
+        (value as Wococo).encodeTo(output);
+        break;
+      case Ethereum:
+        (value as Ethereum).encodeTo(output);
+        break;
+      case BitcoinCore:
+        (value as BitcoinCore).encodeTo(output);
+        break;
+      case BitcoinCash:
+        (value as BitcoinCash).encodeTo(output);
+        break;
+      case PolkadotBulletin:
+        (value as PolkadotBulletin).encodeTo(output);
+        break;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(NetworkId value) {
+    switch (value.runtimeType) {
+      case ByGenesis:
+        return (value as ByGenesis)._sizeHint();
+      case ByFork:
+        return (value as ByFork)._sizeHint();
+      case Polkadot:
+        return 1;
+      case Kusama:
+        return 1;
+      case Westend:
+        return 1;
+      case Rococo:
+        return 1;
+      case Wococo:
+        return 1;
+      case Ethereum:
+        return (value as Ethereum)._sizeHint();
+      case BitcoinCore:
+        return 1;
+      case BitcoinCash:
+        return 1;
+      case PolkadotBulletin:
+        return 1;
+      default:
+        throw Exception('NetworkId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class ByGenesis extends NetworkId {
+  const ByGenesis(this.value0);
+
+  factory ByGenesis._decode(_i1.Input input) {
+    return ByGenesis(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'ByGenesis': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByGenesis &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ByFork extends NetworkId {
+  const ByFork({
+    required this.blockNumber,
+    required this.blockHash,
+  });
+
+  factory ByFork._decode(_i1.Input input) {
+    return ByFork(
+      blockNumber: _i1.U64Codec.codec.decode(input),
+      blockHash: const _i1.U8ArrayCodec(32).decode(input),
+    );
+  }
+
+  /// u64
+  final BigInt blockNumber;
+
+  /// [u8; 32]
+  final List<int> blockHash;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'ByFork': {
+          'blockNumber': blockNumber,
+          'blockHash': blockHash.toList(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U64Codec.codec.sizeHint(blockNumber);
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(blockHash);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.U64Codec.codec.encodeTo(
+      blockNumber,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      blockHash,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ByFork &&
+          other.blockNumber == blockNumber &&
+          _i3.listsEqual(
+            other.blockHash,
+            blockHash,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+        blockNumber,
+        blockHash,
+      );
+}
+
+class Polkadot extends NetworkId {
+  const Polkadot();
+
+  @override
+  Map<String, dynamic> toJson() => {'Polkadot': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Polkadot;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Kusama extends NetworkId {
+  const Kusama();
+
+  @override
+  Map<String, dynamic> toJson() => {'Kusama': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Kusama;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Westend extends NetworkId {
+  const Westend();
+
+  @override
+  Map<String, dynamic> toJson() => {'Westend': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Westend;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Rococo extends NetworkId {
+  const Rococo();
+
+  @override
+  Map<String, dynamic> toJson() => {'Rococo': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Rococo;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Wococo extends NetworkId {
+  const Wococo();
+
+  @override
+  Map<String, dynamic> toJson() => {'Wococo': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Wococo;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Ethereum extends NetworkId {
+  const Ethereum({required this.chainId});
+
+  factory Ethereum._decode(_i1.Input input) {
+    return Ethereum(chainId: _i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt chainId;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {
+        'Ethereum': {'chainId': chainId}
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(chainId);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      chainId,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Ethereum && other.chainId == chainId;
+
+  @override
+  int get hashCode => chainId.hashCode;
+}
+
+class BitcoinCore extends NetworkId {
+  const BitcoinCore();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCore': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCore;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BitcoinCash extends NetworkId {
+  const BitcoinCash();
+
+  @override
+  Map<String, dynamic> toJson() => {'BitcoinCash': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BitcoinCash;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class PolkadotBulletin extends NetworkId {
+  const PolkadotBulletin();
+
+  @override
+  Map<String, dynamic> toJson() => {'PolkadotBulletin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is PolkadotBulletin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junctions/junctions.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/junctions/junctions.dart
@@ -1,0 +1,1041 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../junction/junction.dart' as _i3;
+
+abstract class Junctions {
+  const Junctions();
+
+  factory Junctions.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $JunctionsCodec codec = $JunctionsCodec();
+
+  static const $Junctions values = $Junctions();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Junctions {
+  const $Junctions();
+
+  Here here() {
+    return Here();
+  }
+
+  X1 x1(_i3.Junction value0) {
+    return X1(value0);
+  }
+
+  X2 x2(
+    _i3.Junction value0,
+    _i3.Junction value1,
+  ) {
+    return X2(
+      value0,
+      value1,
+    );
+  }
+
+  X3 x3(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+  ) {
+    return X3(
+      value0,
+      value1,
+      value2,
+    );
+  }
+
+  X4 x4(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+    _i3.Junction value3,
+  ) {
+    return X4(
+      value0,
+      value1,
+      value2,
+      value3,
+    );
+  }
+
+  X5 x5(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+    _i3.Junction value3,
+    _i3.Junction value4,
+  ) {
+    return X5(
+      value0,
+      value1,
+      value2,
+      value3,
+      value4,
+    );
+  }
+
+  X6 x6(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+    _i3.Junction value3,
+    _i3.Junction value4,
+    _i3.Junction value5,
+  ) {
+    return X6(
+      value0,
+      value1,
+      value2,
+      value3,
+      value4,
+      value5,
+    );
+  }
+
+  X7 x7(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+    _i3.Junction value3,
+    _i3.Junction value4,
+    _i3.Junction value5,
+    _i3.Junction value6,
+  ) {
+    return X7(
+      value0,
+      value1,
+      value2,
+      value3,
+      value4,
+      value5,
+      value6,
+    );
+  }
+
+  X8 x8(
+    _i3.Junction value0,
+    _i3.Junction value1,
+    _i3.Junction value2,
+    _i3.Junction value3,
+    _i3.Junction value4,
+    _i3.Junction value5,
+    _i3.Junction value6,
+    _i3.Junction value7,
+  ) {
+    return X8(
+      value0,
+      value1,
+      value2,
+      value3,
+      value4,
+      value5,
+      value6,
+      value7,
+    );
+  }
+}
+
+class $JunctionsCodec with _i1.Codec<Junctions> {
+  const $JunctionsCodec();
+
+  @override
+  Junctions decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Here();
+      case 1:
+        return X1._decode(input);
+      case 2:
+        return X2._decode(input);
+      case 3:
+        return X3._decode(input);
+      case 4:
+        return X4._decode(input);
+      case 5:
+        return X5._decode(input);
+      case 6:
+        return X6._decode(input);
+      case 7:
+        return X7._decode(input);
+      case 8:
+        return X8._decode(input);
+      default:
+        throw Exception('Junctions: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Junctions value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Here:
+        (value as Here).encodeTo(output);
+        break;
+      case X1:
+        (value as X1).encodeTo(output);
+        break;
+      case X2:
+        (value as X2).encodeTo(output);
+        break;
+      case X3:
+        (value as X3).encodeTo(output);
+        break;
+      case X4:
+        (value as X4).encodeTo(output);
+        break;
+      case X5:
+        (value as X5).encodeTo(output);
+        break;
+      case X6:
+        (value as X6).encodeTo(output);
+        break;
+      case X7:
+        (value as X7).encodeTo(output);
+        break;
+      case X8:
+        (value as X8).encodeTo(output);
+        break;
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Junctions value) {
+    switch (value.runtimeType) {
+      case Here:
+        return 1;
+      case X1:
+        return (value as X1)._sizeHint();
+      case X2:
+        return (value as X2)._sizeHint();
+      case X3:
+        return (value as X3)._sizeHint();
+      case X4:
+        return (value as X4)._sizeHint();
+      case X5:
+        return (value as X5)._sizeHint();
+      case X6:
+        return (value as X6)._sizeHint();
+      case X7:
+        return (value as X7)._sizeHint();
+      case X8:
+        return (value as X8)._sizeHint();
+      default:
+        throw Exception('Junctions: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Here extends Junctions {
+  const Here();
+
+  @override
+  Map<String, dynamic> toJson() => {'Here': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Here;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class X1 extends Junctions {
+  const X1(this.value0);
+
+  factory X1._decode(_i1.Input input) {
+    return X1(_i3.Junction.codec.decode(input));
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'X1': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X1 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class X2 extends Junctions {
+  const X2(
+    this.value0,
+    this.value1,
+  );
+
+  factory X2._decode(_i1.Input input) {
+    return X2(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X2': [
+          value0.toJson(),
+          value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X2 && other.value0 == value0 && other.value1 == value1;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+      );
+}
+
+class X3 extends Junctions {
+  const X3(
+    this.value0,
+    this.value1,
+    this.value2,
+  );
+
+  factory X3._decode(_i1.Input input) {
+    return X3(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X3': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X3 && other.value0 == value0 && other.value1 == value1 && other.value2 == value2;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+      );
+}
+
+class X4 extends Junctions {
+  const X4(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+  );
+
+  factory X4._decode(_i1.Input input) {
+    return X4(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  /// Junction
+  final _i3.Junction value3;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X4': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+          value3.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    size = size + _i3.Junction.codec.sizeHint(value3);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X4 &&
+          other.value0 == value0 &&
+          other.value1 == value1 &&
+          other.value2 == value2 &&
+          other.value3 == value3;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+      );
+}
+
+class X5 extends Junctions {
+  const X5(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+    this.value4,
+  );
+
+  factory X5._decode(_i1.Input input) {
+    return X5(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  /// Junction
+  final _i3.Junction value3;
+
+  /// Junction
+  final _i3.Junction value4;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X5': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+          value3.toJson(),
+          value4.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    size = size + _i3.Junction.codec.sizeHint(value3);
+    size = size + _i3.Junction.codec.sizeHint(value4);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value3,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X5 &&
+          other.value0 == value0 &&
+          other.value1 == value1 &&
+          other.value2 == value2 &&
+          other.value3 == value3 &&
+          other.value4 == value4;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+        value4,
+      );
+}
+
+class X6 extends Junctions {
+  const X6(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+    this.value4,
+    this.value5,
+  );
+
+  factory X6._decode(_i1.Input input) {
+    return X6(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  /// Junction
+  final _i3.Junction value3;
+
+  /// Junction
+  final _i3.Junction value4;
+
+  /// Junction
+  final _i3.Junction value5;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X6': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+          value3.toJson(),
+          value4.toJson(),
+          value5.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    size = size + _i3.Junction.codec.sizeHint(value3);
+    size = size + _i3.Junction.codec.sizeHint(value4);
+    size = size + _i3.Junction.codec.sizeHint(value5);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value3,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value4,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X6 &&
+          other.value0 == value0 &&
+          other.value1 == value1 &&
+          other.value2 == value2 &&
+          other.value3 == value3 &&
+          other.value4 == value4 &&
+          other.value5 == value5;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+        value4,
+        value5,
+      );
+}
+
+class X7 extends Junctions {
+  const X7(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+    this.value4,
+    this.value5,
+    this.value6,
+  );
+
+  factory X7._decode(_i1.Input input) {
+    return X7(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  /// Junction
+  final _i3.Junction value3;
+
+  /// Junction
+  final _i3.Junction value4;
+
+  /// Junction
+  final _i3.Junction value5;
+
+  /// Junction
+  final _i3.Junction value6;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X7': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+          value3.toJson(),
+          value4.toJson(),
+          value5.toJson(),
+          value6.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    size = size + _i3.Junction.codec.sizeHint(value3);
+    size = size + _i3.Junction.codec.sizeHint(value4);
+    size = size + _i3.Junction.codec.sizeHint(value5);
+    size = size + _i3.Junction.codec.sizeHint(value6);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value3,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value4,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value5,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X7 &&
+          other.value0 == value0 &&
+          other.value1 == value1 &&
+          other.value2 == value2 &&
+          other.value3 == value3 &&
+          other.value4 == value4 &&
+          other.value5 == value5 &&
+          other.value6 == value6;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+        value4,
+        value5,
+        value6,
+      );
+}
+
+class X8 extends Junctions {
+  const X8(
+    this.value0,
+    this.value1,
+    this.value2,
+    this.value3,
+    this.value4,
+    this.value5,
+    this.value6,
+    this.value7,
+  );
+
+  factory X8._decode(_i1.Input input) {
+    return X8(
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+      _i3.Junction.codec.decode(input),
+    );
+  }
+
+  /// Junction
+  final _i3.Junction value0;
+
+  /// Junction
+  final _i3.Junction value1;
+
+  /// Junction
+  final _i3.Junction value2;
+
+  /// Junction
+  final _i3.Junction value3;
+
+  /// Junction
+  final _i3.Junction value4;
+
+  /// Junction
+  final _i3.Junction value5;
+
+  /// Junction
+  final _i3.Junction value6;
+
+  /// Junction
+  final _i3.Junction value7;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {
+        'X8': [
+          value0.toJson(),
+          value1.toJson(),
+          value2.toJson(),
+          value3.toJson(),
+          value4.toJson(),
+          value5.toJson(),
+          value6.toJson(),
+          value7.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Junction.codec.sizeHint(value0);
+    size = size + _i3.Junction.codec.sizeHint(value1);
+    size = size + _i3.Junction.codec.sizeHint(value2);
+    size = size + _i3.Junction.codec.sizeHint(value3);
+    size = size + _i3.Junction.codec.sizeHint(value4);
+    size = size + _i3.Junction.codec.sizeHint(value5);
+    size = size + _i3.Junction.codec.sizeHint(value6);
+    size = size + _i3.Junction.codec.sizeHint(value7);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value0,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value1,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value2,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value3,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value4,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value5,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value6,
+      output,
+    );
+    _i3.Junction.codec.encodeTo(
+      value7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is X8 &&
+          other.value0 == value0 &&
+          other.value1 == value1 &&
+          other.value2 == value2 &&
+          other.value3 == value3 &&
+          other.value4 == value4 &&
+          other.value5 == value5 &&
+          other.value6 == value6 &&
+          other.value7 == value7;
+
+  @override
+  int get hashCode => Object.hash(
+        value0,
+        value1,
+        value2,
+        value3,
+        value4,
+        value5,
+        value6,
+        value7,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/maybe_error_code.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/maybe_error_code.dart
@@ -1,0 +1,210 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class MaybeErrorCode {
+  const MaybeErrorCode();
+
+  factory MaybeErrorCode.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $MaybeErrorCodeCodec codec = $MaybeErrorCodeCodec();
+
+  static const $MaybeErrorCode values = $MaybeErrorCode();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $MaybeErrorCode {
+  const $MaybeErrorCode();
+
+  Success success() {
+    return Success();
+  }
+
+  Error error(List<int> value0) {
+    return Error(value0);
+  }
+
+  TruncatedError truncatedError(List<int> value0) {
+    return TruncatedError(value0);
+  }
+}
+
+class $MaybeErrorCodeCodec with _i1.Codec<MaybeErrorCode> {
+  const $MaybeErrorCodeCodec();
+
+  @override
+  MaybeErrorCode decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Success();
+      case 1:
+        return Error._decode(input);
+      case 2:
+        return TruncatedError._decode(input);
+      default:
+        throw Exception('MaybeErrorCode: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    MaybeErrorCode value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Success:
+        (value as Success).encodeTo(output);
+        break;
+      case Error:
+        (value as Error).encodeTo(output);
+        break;
+      case TruncatedError:
+        (value as TruncatedError).encodeTo(output);
+        break;
+      default:
+        throw Exception('MaybeErrorCode: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(MaybeErrorCode value) {
+    switch (value.runtimeType) {
+      case Success:
+        return 1;
+      case Error:
+        return (value as Error)._sizeHint();
+      case TruncatedError:
+        return (value as TruncatedError)._sizeHint();
+      default:
+        throw Exception('MaybeErrorCode: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Success extends MaybeErrorCode {
+  const Success();
+
+  @override
+  Map<String, dynamic> toJson() => {'Success': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Success;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Error extends MaybeErrorCode {
+  const Error(this.value0);
+
+  factory Error._decode(_i1.Input input) {
+    return Error(_i1.U8SequenceCodec.codec.decode(input));
+  }
+
+  /// BoundedVec<u8, MaxDispatchErrorLen>
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Error': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Error &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class TruncatedError extends MaybeErrorCode {
+  const TruncatedError(this.value0);
+
+  factory TruncatedError._decode(_i1.Input input) {
+    return TruncatedError(_i1.U8SequenceCodec.codec.decode(input));
+  }
+
+  /// BoundedVec<u8, MaxDispatchErrorLen>
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'TruncatedError': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is TruncatedError &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/asset_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/asset_id.dart
@@ -1,0 +1,177 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i4;
+
+import '../../../staging_xcm/v3/multilocation/multi_location.dart' as _i3;
+
+abstract class AssetId {
+  const AssetId();
+
+  factory AssetId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetIdCodec codec = $AssetIdCodec();
+
+  static const $AssetId values = $AssetId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetId {
+  const $AssetId();
+
+  Concrete concrete(_i3.MultiLocation value0) {
+    return Concrete(value0);
+  }
+
+  Abstract abstract(List<int> value0) {
+    return Abstract(value0);
+  }
+}
+
+class $AssetIdCodec with _i1.Codec<AssetId> {
+  const $AssetIdCodec();
+
+  @override
+  AssetId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Concrete._decode(input);
+      case 1:
+        return Abstract._decode(input);
+      default:
+        throw Exception('AssetId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Concrete:
+        (value as Concrete).encodeTo(output);
+        break;
+      case Abstract:
+        (value as Abstract).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetId value) {
+    switch (value.runtimeType) {
+      case Concrete:
+        return (value as Concrete)._sizeHint();
+      case Abstract:
+        return (value as Abstract)._sizeHint();
+      default:
+        throw Exception('AssetId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Concrete extends AssetId {
+  const Concrete(this.value0);
+
+  factory Concrete._decode(_i1.Input input) {
+    return Concrete(_i3.MultiLocation.codec.decode(input));
+  }
+
+  /// MultiLocation
+  final _i3.MultiLocation value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Concrete': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.MultiLocation.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i3.MultiLocation.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Concrete && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Abstract extends AssetId {
+  const Abstract(this.value0);
+
+  factory Abstract._decode(_i1.Input input) {
+    return Abstract(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Abstract': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Abstract &&
+          _i4.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/asset_instance.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/asset_instance.dart
@@ -1,0 +1,377 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+abstract class AssetInstance {
+  const AssetInstance();
+
+  factory AssetInstance.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $AssetInstanceCodec codec = $AssetInstanceCodec();
+
+  static const $AssetInstance values = $AssetInstance();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $AssetInstance {
+  const $AssetInstance();
+
+  Undefined undefined() {
+    return Undefined();
+  }
+
+  Index index(BigInt value0) {
+    return Index(value0);
+  }
+
+  Array4 array4(List<int> value0) {
+    return Array4(value0);
+  }
+
+  Array8 array8(List<int> value0) {
+    return Array8(value0);
+  }
+
+  Array16 array16(List<int> value0) {
+    return Array16(value0);
+  }
+
+  Array32 array32(List<int> value0) {
+    return Array32(value0);
+  }
+}
+
+class $AssetInstanceCodec with _i1.Codec<AssetInstance> {
+  const $AssetInstanceCodec();
+
+  @override
+  AssetInstance decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Undefined();
+      case 1:
+        return Index._decode(input);
+      case 2:
+        return Array4._decode(input);
+      case 3:
+        return Array8._decode(input);
+      case 4:
+        return Array16._decode(input);
+      case 5:
+        return Array32._decode(input);
+      default:
+        throw Exception('AssetInstance: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    AssetInstance value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Undefined:
+        (value as Undefined).encodeTo(output);
+        break;
+      case Index:
+        (value as Index).encodeTo(output);
+        break;
+      case Array4:
+        (value as Array4).encodeTo(output);
+        break;
+      case Array8:
+        (value as Array8).encodeTo(output);
+        break;
+      case Array16:
+        (value as Array16).encodeTo(output);
+        break;
+      case Array32:
+        (value as Array32).encodeTo(output);
+        break;
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(AssetInstance value) {
+    switch (value.runtimeType) {
+      case Undefined:
+        return 1;
+      case Index:
+        return (value as Index)._sizeHint();
+      case Array4:
+        return (value as Array4)._sizeHint();
+      case Array8:
+        return (value as Array8)._sizeHint();
+      case Array16:
+        return (value as Array16)._sizeHint();
+      case Array32:
+        return (value as Array32)._sizeHint();
+      default:
+        throw Exception('AssetInstance: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Undefined extends AssetInstance {
+  const Undefined();
+
+  @override
+  Map<String, dynamic> toJson() => {'Undefined': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Undefined;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Index extends AssetInstance {
+  const Index(this.value0);
+
+  factory Index._decode(_i1.Input input) {
+    return Index(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Index': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Index && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array4 extends AssetInstance {
+  const Array4(this.value0);
+
+  factory Array4._decode(_i1.Input input) {
+    return Array4(const _i1.U8ArrayCodec(4).decode(input));
+  }
+
+  /// [u8; 4]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array4': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(4).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.U8ArrayCodec(4).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array4 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array8 extends AssetInstance {
+  const Array8(this.value0);
+
+  factory Array8._decode(_i1.Input input) {
+    return Array8(const _i1.U8ArrayCodec(8).decode(input));
+  }
+
+  /// [u8; 8]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array8': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(8).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.U8ArrayCodec(8).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array8 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array16 extends AssetInstance {
+  const Array16(this.value0);
+
+  factory Array16._decode(_i1.Input input) {
+    return Array16(const _i1.U8ArrayCodec(16).decode(input));
+  }
+
+  /// [u8; 16]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array16': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(16).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.U8ArrayCodec(16).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array16 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Array32 extends AssetInstance {
+  const Array32(this.value0);
+
+  factory Array32._decode(_i1.Input input) {
+    return Array32(const _i1.U8ArrayCodec(32).decode(input));
+  }
+
+  /// [u8; 32]
+  final List<int> value0;
+
+  @override
+  Map<String, List<int>> toJson() => {'Array32': value0.toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.U8ArrayCodec(32).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.U8ArrayCodec(32).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Array32 &&
+          _i3.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/fungibility.dart
@@ -1,0 +1,172 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_instance.dart' as _i3;
+
+abstract class Fungibility {
+  const Fungibility();
+
+  factory Fungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $FungibilityCodec codec = $FungibilityCodec();
+
+  static const $Fungibility values = $Fungibility();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Fungibility {
+  const $Fungibility();
+
+  Fungible fungible(BigInt value0) {
+    return Fungible(value0);
+  }
+
+  NonFungible nonFungible(_i3.AssetInstance value0) {
+    return NonFungible(value0);
+  }
+}
+
+class $FungibilityCodec with _i1.Codec<Fungibility> {
+  const $FungibilityCodec();
+
+  @override
+  Fungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Fungible._decode(input);
+      case 1:
+        return NonFungible._decode(input);
+      default:
+        throw Exception('Fungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Fungibility value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Fungible:
+        (value as Fungible).encodeTo(output);
+        break;
+      case NonFungible:
+        (value as NonFungible).encodeTo(output);
+        break;
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Fungibility value) {
+    switch (value.runtimeType) {
+      case Fungible:
+        return (value as Fungible)._sizeHint();
+      case NonFungible:
+        return (value as NonFungible)._sizeHint();
+      default:
+        throw Exception('Fungibility: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Fungible extends Fungibility {
+  const Fungible(this.value0);
+
+  factory Fungible._decode(_i1.Input input) {
+    return Fungible(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u128
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Fungible': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Fungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class NonFungible extends Fungibility {
+  const NonFungible(this.value0);
+
+  factory NonFungible._decode(_i1.Input input) {
+    return NonFungible(_i3.AssetInstance.codec.decode(input));
+  }
+
+  /// AssetInstance
+  final _i3.AssetInstance value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'NonFungible': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetInstance.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.AssetInstance.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is NonFungible && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_asset.dart
@@ -1,0 +1,84 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_id.dart' as _i2;
+import 'fungibility.dart' as _i3;
+
+class MultiAsset {
+  const MultiAsset({
+    required this.id,
+    required this.fun,
+  });
+
+  factory MultiAsset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// AssetId
+  final _i2.AssetId id;
+
+  /// Fungibility
+  final _i3.Fungibility fun;
+
+  static const $MultiAssetCodec codec = $MultiAssetCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson() => {
+        'id': id.toJson(),
+        'fun': fun.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is MultiAsset && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class $MultiAssetCodec with _i1.Codec<MultiAsset> {
+  const $MultiAssetCodec();
+
+  @override
+  void encodeTo(
+    MultiAsset obj,
+    _i1.Output output,
+  ) {
+    _i2.AssetId.codec.encodeTo(
+      obj.id,
+      output,
+    );
+    _i3.Fungibility.codec.encodeTo(
+      obj.fun,
+      output,
+    );
+  }
+
+  @override
+  MultiAsset decode(_i1.Input input) {
+    return MultiAsset(
+      id: _i2.AssetId.codec.decode(input),
+      fun: _i3.Fungibility.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(MultiAsset obj) {
+    int size = 0;
+    size = size + _i2.AssetId.codec.sizeHint(obj.id);
+    size = size + _i3.Fungibility.codec.sizeHint(obj.fun);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_asset_filter.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_asset_filter.dart
@@ -1,0 +1,180 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i6;
+
+import 'multi_asset.dart' as _i5;
+import 'multi_assets.dart' as _i3;
+import 'wild_multi_asset.dart' as _i4;
+
+abstract class MultiAssetFilter {
+  const MultiAssetFilter();
+
+  factory MultiAssetFilter.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $MultiAssetFilterCodec codec = $MultiAssetFilterCodec();
+
+  static const $MultiAssetFilter values = $MultiAssetFilter();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $MultiAssetFilter {
+  const $MultiAssetFilter();
+
+  Definite definite(_i3.MultiAssets value0) {
+    return Definite(value0);
+  }
+
+  Wild wild(_i4.WildMultiAsset value0) {
+    return Wild(value0);
+  }
+}
+
+class $MultiAssetFilterCodec with _i1.Codec<MultiAssetFilter> {
+  const $MultiAssetFilterCodec();
+
+  @override
+  MultiAssetFilter decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return Definite._decode(input);
+      case 1:
+        return Wild._decode(input);
+      default:
+        throw Exception('MultiAssetFilter: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    MultiAssetFilter value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Definite:
+        (value as Definite).encodeTo(output);
+        break;
+      case Wild:
+        (value as Wild).encodeTo(output);
+        break;
+      default:
+        throw Exception('MultiAssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(MultiAssetFilter value) {
+    switch (value.runtimeType) {
+      case Definite:
+        return (value as Definite)._sizeHint();
+      case Wild:
+        return (value as Wild)._sizeHint();
+      default:
+        throw Exception('MultiAssetFilter: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Definite extends MultiAssetFilter {
+  const Definite(this.value0);
+
+  factory Definite._decode(_i1.Input input) {
+    return Definite(const _i1.SequenceCodec<_i5.MultiAsset>(_i5.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Definite': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+    const _i1.SequenceCodec<_i5.MultiAsset>(_i5.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Definite &&
+          _i6.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Wild extends MultiAssetFilter {
+  const Wild(this.value0);
+
+  factory Wild._decode(_i1.Input input) {
+    return Wild(_i4.WildMultiAsset.codec.decode(input));
+  }
+
+  /// WildMultiAsset
+  final _i4.WildMultiAsset value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'Wild': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.WildMultiAsset.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i4.WildMultiAsset.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Wild && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_assets.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/multi_assets.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'multi_asset.dart' as _i1;
+
+typedef MultiAssets = List<_i1.MultiAsset>;
+
+class MultiAssetsCodec with _i2.Codec<MultiAssets> {
+  const MultiAssetsCodec();
+
+  @override
+  MultiAssets decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.MultiAsset>(_i1.MultiAsset.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    MultiAssets value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.MultiAsset>(_i1.MultiAsset.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(MultiAssets value) {
+    return const _i2.SequenceCodec<_i1.MultiAsset>(_i1.MultiAsset.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/wild_fungibility.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/wild_fungibility.dart
@@ -1,0 +1,58 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+enum WildFungibility {
+  fungible('Fungible', 0),
+  nonFungible('NonFungible', 1);
+
+  const WildFungibility(
+    this.variantName,
+    this.codecIndex,
+  );
+
+  factory WildFungibility.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  final String variantName;
+
+  final int codecIndex;
+
+  static const $WildFungibilityCodec codec = $WildFungibilityCodec();
+
+  String toJson() => variantName;
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+}
+
+class $WildFungibilityCodec with _i1.Codec<WildFungibility> {
+  const $WildFungibilityCodec();
+
+  @override
+  WildFungibility decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return WildFungibility.fungible;
+      case 1:
+        return WildFungibility.nonFungible;
+      default:
+        throw Exception('WildFungibility: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildFungibility value,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      value.codecIndex,
+      output,
+    );
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/wild_multi_asset.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/multiasset/wild_multi_asset.dart
@@ -1,0 +1,327 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import 'asset_id.dart' as _i3;
+import 'wild_fungibility.dart' as _i4;
+
+abstract class WildMultiAsset {
+  const WildMultiAsset();
+
+  factory WildMultiAsset.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $WildMultiAssetCodec codec = $WildMultiAssetCodec();
+
+  static const $WildMultiAsset values = $WildMultiAsset();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $WildMultiAsset {
+  const $WildMultiAsset();
+
+  All all() {
+    return All();
+  }
+
+  AllOf allOf({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+  }) {
+    return AllOf(
+      id: id,
+      fun: fun,
+    );
+  }
+
+  AllCounted allCounted(BigInt value0) {
+    return AllCounted(value0);
+  }
+
+  AllOfCounted allOfCounted({
+    required _i3.AssetId id,
+    required _i4.WildFungibility fun,
+    required BigInt count,
+  }) {
+    return AllOfCounted(
+      id: id,
+      fun: fun,
+      count: count,
+    );
+  }
+}
+
+class $WildMultiAssetCodec with _i1.Codec<WildMultiAsset> {
+  const $WildMultiAssetCodec();
+
+  @override
+  WildMultiAsset decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const All();
+      case 1:
+        return AllOf._decode(input);
+      case 2:
+        return AllCounted._decode(input);
+      case 3:
+        return AllOfCounted._decode(input);
+      default:
+        throw Exception('WildMultiAsset: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WildMultiAsset value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case All:
+        (value as All).encodeTo(output);
+        break;
+      case AllOf:
+        (value as AllOf).encodeTo(output);
+        break;
+      case AllCounted:
+        (value as AllCounted).encodeTo(output);
+        break;
+      case AllOfCounted:
+        (value as AllOfCounted).encodeTo(output);
+        break;
+      default:
+        throw Exception('WildMultiAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(WildMultiAsset value) {
+    switch (value.runtimeType) {
+      case All:
+        return 1;
+      case AllOf:
+        return (value as AllOf)._sizeHint();
+      case AllCounted:
+        return (value as AllCounted)._sizeHint();
+      case AllOfCounted:
+        return (value as AllOfCounted)._sizeHint();
+      default:
+        throw Exception('WildMultiAsset: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class All extends WildMultiAsset {
+  const All();
+
+  @override
+  Map<String, dynamic> toJson() => {'All': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is All;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AllOf extends WildMultiAsset {
+  const AllOf({
+    required this.id,
+    required this.fun,
+  });
+
+  factory AllOf._decode(_i1.Input input) {
+    return AllOf(
+      id: _i3.AssetId.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOf': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetId.codec.sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.AssetId.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOf && other.id == id && other.fun == fun;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+      );
+}
+
+class AllCounted extends WildMultiAsset {
+  const AllCounted(this.value0);
+
+  factory AllCounted._decode(_i1.Input input) {
+    return AllCounted(_i1.CompactBigIntCodec.codec.decode(input));
+  }
+
+  /// u32
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'AllCounted': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllCounted && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class AllOfCounted extends WildMultiAsset {
+  const AllOfCounted({
+    required this.id,
+    required this.fun,
+    required this.count,
+  });
+
+  factory AllOfCounted._decode(_i1.Input input) {
+    return AllOfCounted(
+      id: _i3.AssetId.codec.decode(input),
+      fun: _i4.WildFungibility.codec.decode(input),
+      count: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  /// AssetId
+  final _i3.AssetId id;
+
+  /// WildFungibility
+  final _i4.WildFungibility fun;
+
+  /// u32
+  final BigInt count;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {
+        'AllOfCounted': {
+          'id': id.toJson(),
+          'fun': fun.toJson(),
+          'count': count,
+        }
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetId.codec.sizeHint(id);
+    size = size + _i4.WildFungibility.codec.sizeHint(fun);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(count);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.AssetId.codec.encodeTo(
+      id,
+      output,
+    );
+    _i4.WildFungibility.codec.encodeTo(
+      fun,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      count,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is AllOfCounted && other.id == id && other.fun == fun && other.count == count;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fun,
+        count,
+      );
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/origin_kind.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/origin_kind.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+enum OriginKind {
+  native('Native', 0),
+  sovereignAccount('SovereignAccount', 1),
+  superuser('Superuser', 2),
+  xcm('Xcm', 3);
+
+  const OriginKind(
+    this.variantName,
+    this.codecIndex,
+  );
+
+  factory OriginKind.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  final String variantName;
+
+  final int codecIndex;
+
+  static const $OriginKindCodec codec = $OriginKindCodec();
+
+  String toJson() => variantName;
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+}
+
+class $OriginKindCodec with _i1.Codec<OriginKind> {
+  const $OriginKindCodec();
+
+  @override
+  OriginKind decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return OriginKind.native;
+      case 1:
+        return OriginKind.sovereignAccount;
+      case 2:
+        return OriginKind.superuser;
+      case 3:
+        return OriginKind.xcm;
+      default:
+        throw Exception('OriginKind: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    OriginKind value,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      value.codecIndex,
+      output,
+    );
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/pallet_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/pallet_info.dart
@@ -1,0 +1,142 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i3;
+
+class PalletInfo {
+  const PalletInfo({
+    required this.index,
+    required this.name,
+    required this.moduleName,
+    required this.major,
+    required this.minor,
+    required this.patch,
+  });
+
+  factory PalletInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// u32
+  final BigInt index;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> name;
+
+  /// BoundedVec<u8, MaxPalletNameLen>
+  final List<int> moduleName;
+
+  /// u32
+  final BigInt major;
+
+  /// u32
+  final BigInt minor;
+
+  /// u32
+  final BigInt patch;
+
+  static const $PalletInfoCodec codec = $PalletInfoCodec();
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'name': name,
+        'moduleName': moduleName,
+        'major': major,
+        'minor': minor,
+        'patch': patch,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletInfo &&
+          other.index == index &&
+          _i3.listsEqual(
+            other.name,
+            name,
+          ) &&
+          _i3.listsEqual(
+            other.moduleName,
+            moduleName,
+          ) &&
+          other.major == major &&
+          other.minor == minor &&
+          other.patch == patch;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        name,
+        moduleName,
+        major,
+        minor,
+        patch,
+      );
+}
+
+class $PalletInfoCodec with _i1.Codec<PalletInfo> {
+  const $PalletInfoCodec();
+
+  @override
+  void encodeTo(
+    PalletInfo obj,
+    _i1.Output output,
+  ) {
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.index,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.name,
+      output,
+    );
+    _i1.U8SequenceCodec.codec.encodeTo(
+      obj.moduleName,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.major,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.minor,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.patch,
+      output,
+    );
+  }
+
+  @override
+  PalletInfo decode(_i1.Input input) {
+    return PalletInfo(
+      index: _i1.CompactBigIntCodec.codec.decode(input),
+      name: _i1.U8SequenceCodec.codec.decode(input),
+      moduleName: _i1.U8SequenceCodec.codec.decode(input),
+      major: _i1.CompactBigIntCodec.codec.decode(input),
+      minor: _i1.CompactBigIntCodec.codec.decode(input),
+      patch: _i1.CompactBigIntCodec.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(PalletInfo obj) {
+    int size = 0;
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.index);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.name);
+    size = size + _i1.U8SequenceCodec.codec.sizeHint(obj.moduleName);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.major);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.minor);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.patch);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/query_response_info.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/query_response_info.dart
@@ -1,0 +1,99 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i4;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i3;
+import '../../staging_xcm/v3/multilocation/multi_location.dart' as _i2;
+
+class QueryResponseInfo {
+  const QueryResponseInfo({
+    required this.destination,
+    required this.queryId,
+    required this.maxWeight,
+  });
+
+  factory QueryResponseInfo.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  /// MultiLocation
+  final _i2.MultiLocation destination;
+
+  /// QueryId
+  final BigInt queryId;
+
+  /// Weight
+  final _i3.Weight maxWeight;
+
+  static const $QueryResponseInfoCodec codec = $QueryResponseInfoCodec();
+
+  _i4.Uint8List encode() {
+    return codec.encode(this);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'destination': destination.toJson(),
+        'queryId': queryId,
+        'maxWeight': maxWeight.toJson(),
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is QueryResponseInfo &&
+          other.destination == destination &&
+          other.queryId == queryId &&
+          other.maxWeight == maxWeight;
+
+  @override
+  int get hashCode => Object.hash(
+        destination,
+        queryId,
+        maxWeight,
+      );
+}
+
+class $QueryResponseInfoCodec with _i1.Codec<QueryResponseInfo> {
+  const $QueryResponseInfoCodec();
+
+  @override
+  void encodeTo(
+    QueryResponseInfo obj,
+    _i1.Output output,
+  ) {
+    _i2.MultiLocation.codec.encodeTo(
+      obj.destination,
+      output,
+    );
+    _i1.CompactBigIntCodec.codec.encodeTo(
+      obj.queryId,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      obj.maxWeight,
+      output,
+    );
+  }
+
+  @override
+  QueryResponseInfo decode(_i1.Input input) {
+    return QueryResponseInfo(
+      destination: _i2.MultiLocation.codec.decode(input),
+      queryId: _i1.CompactBigIntCodec.codec.decode(input),
+      maxWeight: _i3.Weight.codec.decode(input),
+    );
+  }
+
+  @override
+  int sizeHint(QueryResponseInfo obj) {
+    int size = 0;
+    size = size + _i2.MultiLocation.codec.sizeHint(obj.destination);
+    size = size + _i1.CompactBigIntCodec.codec.sizeHint(obj.queryId);
+    size = size + _i3.Weight.codec.sizeHint(obj.maxWeight);
+    return size;
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/response.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/response.dart
@@ -1,0 +1,392 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i9;
+
+import '../../tuples.dart' as _i4;
+import 'maybe_error_code.dart' as _i7;
+import 'multiasset/multi_asset.dart' as _i8;
+import 'multiasset/multi_assets.dart' as _i3;
+import 'pallet_info.dart' as _i6;
+import 'traits/error.dart' as _i5;
+
+abstract class Response {
+  const Response();
+
+  factory Response.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $ResponseCodec codec = $ResponseCodec();
+
+  static const $Response values = $Response();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Response {
+  const $Response();
+
+  Null null_() {
+    return Null();
+  }
+
+  Assets assets(_i3.MultiAssets value0) {
+    return Assets(value0);
+  }
+
+  ExecutionResult executionResult(_i4.Tuple2<int, _i5.Error>? value0) {
+    return ExecutionResult(value0);
+  }
+
+  Version version(int value0) {
+    return Version(value0);
+  }
+
+  PalletsInfo palletsInfo(List<_i6.PalletInfo> value0) {
+    return PalletsInfo(value0);
+  }
+
+  DispatchResult dispatchResult(_i7.MaybeErrorCode value0) {
+    return DispatchResult(value0);
+  }
+}
+
+class $ResponseCodec with _i1.Codec<Response> {
+  const $ResponseCodec();
+
+  @override
+  Response decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Null();
+      case 1:
+        return Assets._decode(input);
+      case 2:
+        return ExecutionResult._decode(input);
+      case 3:
+        return Version._decode(input);
+      case 4:
+        return PalletsInfo._decode(input);
+      case 5:
+        return DispatchResult._decode(input);
+      default:
+        throw Exception('Response: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Response value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Null:
+        (value as Null).encodeTo(output);
+        break;
+      case Assets:
+        (value as Assets).encodeTo(output);
+        break;
+      case ExecutionResult:
+        (value as ExecutionResult).encodeTo(output);
+        break;
+      case Version:
+        (value as Version).encodeTo(output);
+        break;
+      case PalletsInfo:
+        (value as PalletsInfo).encodeTo(output);
+        break;
+      case DispatchResult:
+        (value as DispatchResult).encodeTo(output);
+        break;
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Response value) {
+    switch (value.runtimeType) {
+      case Null:
+        return 1;
+      case Assets:
+        return (value as Assets)._sizeHint();
+      case ExecutionResult:
+        return (value as ExecutionResult)._sizeHint();
+      case Version:
+        return (value as Version)._sizeHint();
+      case PalletsInfo:
+        return (value as PalletsInfo)._sizeHint();
+      case DispatchResult:
+        return (value as DispatchResult)._sizeHint();
+      default:
+        throw Exception('Response: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Null extends Response {
+  const Null();
+
+  @override
+  Map<String, dynamic> toJson() => {'Null': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Null;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Assets extends Response {
+  const Assets(this.value0);
+
+  factory Assets._decode(_i1.Input input) {
+    return Assets(const _i1.SequenceCodec<_i8.MultiAsset>(_i8.MultiAsset.codec).decode(input));
+  }
+
+  /// MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'Assets': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.MultiAsset>(_i8.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Assets &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExecutionResult extends Response {
+  const ExecutionResult(this.value0);
+
+  factory ExecutionResult._decode(_i1.Input input) {
+    return ExecutionResult(const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).decode(input));
+  }
+
+  /// Option<(u32, Error)>
+  final _i4.Tuple2<int, _i5.Error>? value0;
+
+  @override
+  Map<String, List<dynamic>?> toJson() => {
+        'ExecutionResult': [
+          value0?.value0,
+          value0?.value1.toJson(),
+        ]
+      };
+
+  int _sizeHint() {
+    int size = 1;
+    size = size +
+        const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+          _i1.U32Codec.codec,
+          _i5.Error.codec,
+        )).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+    const _i1.OptionCodec<_i4.Tuple2<int, _i5.Error>>(_i4.Tuple2Codec<int, _i5.Error>(
+      _i1.U32Codec.codec,
+      _i5.Error.codec,
+    )).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ExecutionResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Version extends Response {
+  const Version(this.value0);
+
+  factory Version._decode(_i1.Input input) {
+    return Version(_i1.U32Codec.codec.decode(input));
+  }
+
+  /// super::Version
+  final int value0;
+
+  @override
+  Map<String, int> toJson() => {'Version': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U32Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i1.U32Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Version && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class PalletsInfo extends Response {
+  const PalletsInfo(this.value0);
+
+  factory PalletsInfo._decode(_i1.Input input) {
+    return PalletsInfo(const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).decode(input));
+  }
+
+  /// BoundedVec<PalletInfo, MaxPalletsInfo>
+  final List<_i6.PalletInfo> value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'PalletsInfo': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.PalletInfo>(_i6.PalletInfo.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is PalletsInfo &&
+          _i9.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class DispatchResult extends Response {
+  const DispatchResult(this.value0);
+
+  factory DispatchResult._decode(_i1.Input input) {
+    return DispatchResult(_i7.MaybeErrorCode.codec.decode(input));
+  }
+
+  /// MaybeErrorCode
+  final _i7.MaybeErrorCode value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'DispatchResult': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i7.MaybeErrorCode.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i7.MaybeErrorCode.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is DispatchResult && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/traits/error.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/traits/error.dart
@@ -1,0 +1,1350 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../../sp_weights/weight_v2/weight.dart' as _i3;
+
+abstract class Error {
+  const Error();
+
+  factory Error.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $ErrorCodec codec = $ErrorCodec();
+
+  static const $Error values = $Error();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Error {
+  const $Error();
+
+  Overflow overflow() {
+    return Overflow();
+  }
+
+  Unimplemented unimplemented() {
+    return Unimplemented();
+  }
+
+  UntrustedReserveLocation untrustedReserveLocation() {
+    return UntrustedReserveLocation();
+  }
+
+  UntrustedTeleportLocation untrustedTeleportLocation() {
+    return UntrustedTeleportLocation();
+  }
+
+  LocationFull locationFull() {
+    return LocationFull();
+  }
+
+  LocationNotInvertible locationNotInvertible() {
+    return LocationNotInvertible();
+  }
+
+  BadOrigin badOrigin() {
+    return BadOrigin();
+  }
+
+  InvalidLocation invalidLocation() {
+    return InvalidLocation();
+  }
+
+  AssetNotFound assetNotFound() {
+    return AssetNotFound();
+  }
+
+  FailedToTransactAsset failedToTransactAsset() {
+    return FailedToTransactAsset();
+  }
+
+  NotWithdrawable notWithdrawable() {
+    return NotWithdrawable();
+  }
+
+  LocationCannotHold locationCannotHold() {
+    return LocationCannotHold();
+  }
+
+  ExceedsMaxMessageSize exceedsMaxMessageSize() {
+    return ExceedsMaxMessageSize();
+  }
+
+  DestinationUnsupported destinationUnsupported() {
+    return DestinationUnsupported();
+  }
+
+  Transport transport() {
+    return Transport();
+  }
+
+  Unroutable unroutable() {
+    return Unroutable();
+  }
+
+  UnknownClaim unknownClaim() {
+    return UnknownClaim();
+  }
+
+  FailedToDecode failedToDecode() {
+    return FailedToDecode();
+  }
+
+  MaxWeightInvalid maxWeightInvalid() {
+    return MaxWeightInvalid();
+  }
+
+  NotHoldingFees notHoldingFees() {
+    return NotHoldingFees();
+  }
+
+  TooExpensive tooExpensive() {
+    return TooExpensive();
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  ExpectationFalse expectationFalse() {
+    return ExpectationFalse();
+  }
+
+  PalletNotFound palletNotFound() {
+    return PalletNotFound();
+  }
+
+  NameMismatch nameMismatch() {
+    return NameMismatch();
+  }
+
+  VersionIncompatible versionIncompatible() {
+    return VersionIncompatible();
+  }
+
+  HoldingWouldOverflow holdingWouldOverflow() {
+    return HoldingWouldOverflow();
+  }
+
+  ExportError exportError() {
+    return ExportError();
+  }
+
+  ReanchorFailed reanchorFailed() {
+    return ReanchorFailed();
+  }
+
+  NoDeal noDeal() {
+    return NoDeal();
+  }
+
+  FeesNotMet feesNotMet() {
+    return FeesNotMet();
+  }
+
+  LockError lockError() {
+    return LockError();
+  }
+
+  NoPermission noPermission() {
+    return NoPermission();
+  }
+
+  Unanchored unanchored() {
+    return Unanchored();
+  }
+
+  NotDepositable notDepositable() {
+    return NotDepositable();
+  }
+
+  UnhandledXcmVersion unhandledXcmVersion() {
+    return UnhandledXcmVersion();
+  }
+
+  WeightLimitReached weightLimitReached(_i3.Weight value0) {
+    return WeightLimitReached(value0);
+  }
+
+  Barrier barrier() {
+    return Barrier();
+  }
+
+  WeightNotComputable weightNotComputable() {
+    return WeightNotComputable();
+  }
+
+  ExceedsStackLimit exceedsStackLimit() {
+    return ExceedsStackLimit();
+  }
+}
+
+class $ErrorCodec with _i1.Codec<Error> {
+  const $ErrorCodec();
+
+  @override
+  Error decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Overflow();
+      case 1:
+        return const Unimplemented();
+      case 2:
+        return const UntrustedReserveLocation();
+      case 3:
+        return const UntrustedTeleportLocation();
+      case 4:
+        return const LocationFull();
+      case 5:
+        return const LocationNotInvertible();
+      case 6:
+        return const BadOrigin();
+      case 7:
+        return const InvalidLocation();
+      case 8:
+        return const AssetNotFound();
+      case 9:
+        return const FailedToTransactAsset();
+      case 10:
+        return const NotWithdrawable();
+      case 11:
+        return const LocationCannotHold();
+      case 12:
+        return const ExceedsMaxMessageSize();
+      case 13:
+        return const DestinationUnsupported();
+      case 14:
+        return const Transport();
+      case 15:
+        return const Unroutable();
+      case 16:
+        return const UnknownClaim();
+      case 17:
+        return const FailedToDecode();
+      case 18:
+        return const MaxWeightInvalid();
+      case 19:
+        return const NotHoldingFees();
+      case 20:
+        return const TooExpensive();
+      case 21:
+        return Trap._decode(input);
+      case 22:
+        return const ExpectationFalse();
+      case 23:
+        return const PalletNotFound();
+      case 24:
+        return const NameMismatch();
+      case 25:
+        return const VersionIncompatible();
+      case 26:
+        return const HoldingWouldOverflow();
+      case 27:
+        return const ExportError();
+      case 28:
+        return const ReanchorFailed();
+      case 29:
+        return const NoDeal();
+      case 30:
+        return const FeesNotMet();
+      case 31:
+        return const LockError();
+      case 32:
+        return const NoPermission();
+      case 33:
+        return const Unanchored();
+      case 34:
+        return const NotDepositable();
+      case 35:
+        return const UnhandledXcmVersion();
+      case 36:
+        return WeightLimitReached._decode(input);
+      case 37:
+        return const Barrier();
+      case 38:
+        return const WeightNotComputable();
+      case 39:
+        return const ExceedsStackLimit();
+      default:
+        throw Exception('Error: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Error value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Overflow:
+        (value as Overflow).encodeTo(output);
+        break;
+      case Unimplemented:
+        (value as Unimplemented).encodeTo(output);
+        break;
+      case UntrustedReserveLocation:
+        (value as UntrustedReserveLocation).encodeTo(output);
+        break;
+      case UntrustedTeleportLocation:
+        (value as UntrustedTeleportLocation).encodeTo(output);
+        break;
+      case LocationFull:
+        (value as LocationFull).encodeTo(output);
+        break;
+      case LocationNotInvertible:
+        (value as LocationNotInvertible).encodeTo(output);
+        break;
+      case BadOrigin:
+        (value as BadOrigin).encodeTo(output);
+        break;
+      case InvalidLocation:
+        (value as InvalidLocation).encodeTo(output);
+        break;
+      case AssetNotFound:
+        (value as AssetNotFound).encodeTo(output);
+        break;
+      case FailedToTransactAsset:
+        (value as FailedToTransactAsset).encodeTo(output);
+        break;
+      case NotWithdrawable:
+        (value as NotWithdrawable).encodeTo(output);
+        break;
+      case LocationCannotHold:
+        (value as LocationCannotHold).encodeTo(output);
+        break;
+      case ExceedsMaxMessageSize:
+        (value as ExceedsMaxMessageSize).encodeTo(output);
+        break;
+      case DestinationUnsupported:
+        (value as DestinationUnsupported).encodeTo(output);
+        break;
+      case Transport:
+        (value as Transport).encodeTo(output);
+        break;
+      case Unroutable:
+        (value as Unroutable).encodeTo(output);
+        break;
+      case UnknownClaim:
+        (value as UnknownClaim).encodeTo(output);
+        break;
+      case FailedToDecode:
+        (value as FailedToDecode).encodeTo(output);
+        break;
+      case MaxWeightInvalid:
+        (value as MaxWeightInvalid).encodeTo(output);
+        break;
+      case NotHoldingFees:
+        (value as NotHoldingFees).encodeTo(output);
+        break;
+      case TooExpensive:
+        (value as TooExpensive).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case ExpectationFalse:
+        (value as ExpectationFalse).encodeTo(output);
+        break;
+      case PalletNotFound:
+        (value as PalletNotFound).encodeTo(output);
+        break;
+      case NameMismatch:
+        (value as NameMismatch).encodeTo(output);
+        break;
+      case VersionIncompatible:
+        (value as VersionIncompatible).encodeTo(output);
+        break;
+      case HoldingWouldOverflow:
+        (value as HoldingWouldOverflow).encodeTo(output);
+        break;
+      case ExportError:
+        (value as ExportError).encodeTo(output);
+        break;
+      case ReanchorFailed:
+        (value as ReanchorFailed).encodeTo(output);
+        break;
+      case NoDeal:
+        (value as NoDeal).encodeTo(output);
+        break;
+      case FeesNotMet:
+        (value as FeesNotMet).encodeTo(output);
+        break;
+      case LockError:
+        (value as LockError).encodeTo(output);
+        break;
+      case NoPermission:
+        (value as NoPermission).encodeTo(output);
+        break;
+      case Unanchored:
+        (value as Unanchored).encodeTo(output);
+        break;
+      case NotDepositable:
+        (value as NotDepositable).encodeTo(output);
+        break;
+      case UnhandledXcmVersion:
+        (value as UnhandledXcmVersion).encodeTo(output);
+        break;
+      case WeightLimitReached:
+        (value as WeightLimitReached).encodeTo(output);
+        break;
+      case Barrier:
+        (value as Barrier).encodeTo(output);
+        break;
+      case WeightNotComputable:
+        (value as WeightNotComputable).encodeTo(output);
+        break;
+      case ExceedsStackLimit:
+        (value as ExceedsStackLimit).encodeTo(output);
+        break;
+      default:
+        throw Exception('Error: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Error value) {
+    switch (value.runtimeType) {
+      case Overflow:
+        return 1;
+      case Unimplemented:
+        return 1;
+      case UntrustedReserveLocation:
+        return 1;
+      case UntrustedTeleportLocation:
+        return 1;
+      case LocationFull:
+        return 1;
+      case LocationNotInvertible:
+        return 1;
+      case BadOrigin:
+        return 1;
+      case InvalidLocation:
+        return 1;
+      case AssetNotFound:
+        return 1;
+      case FailedToTransactAsset:
+        return 1;
+      case NotWithdrawable:
+        return 1;
+      case LocationCannotHold:
+        return 1;
+      case ExceedsMaxMessageSize:
+        return 1;
+      case DestinationUnsupported:
+        return 1;
+      case Transport:
+        return 1;
+      case Unroutable:
+        return 1;
+      case UnknownClaim:
+        return 1;
+      case FailedToDecode:
+        return 1;
+      case MaxWeightInvalid:
+        return 1;
+      case NotHoldingFees:
+        return 1;
+      case TooExpensive:
+        return 1;
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case ExpectationFalse:
+        return 1;
+      case PalletNotFound:
+        return 1;
+      case NameMismatch:
+        return 1;
+      case VersionIncompatible:
+        return 1;
+      case HoldingWouldOverflow:
+        return 1;
+      case ExportError:
+        return 1;
+      case ReanchorFailed:
+        return 1;
+      case NoDeal:
+        return 1;
+      case FeesNotMet:
+        return 1;
+      case LockError:
+        return 1;
+      case NoPermission:
+        return 1;
+      case Unanchored:
+        return 1;
+      case NotDepositable:
+        return 1;
+      case UnhandledXcmVersion:
+        return 1;
+      case WeightLimitReached:
+        return (value as WeightLimitReached)._sizeHint();
+      case Barrier:
+        return 1;
+      case WeightNotComputable:
+        return 1;
+      case ExceedsStackLimit:
+        return 1;
+      default:
+        throw Exception('Error: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Overflow extends Error {
+  const Overflow();
+
+  @override
+  Map<String, dynamic> toJson() => {'Overflow': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Overflow;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unimplemented extends Error {
+  const Unimplemented();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unimplemented': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unimplemented;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UntrustedReserveLocation extends Error {
+  const UntrustedReserveLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'UntrustedReserveLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UntrustedReserveLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UntrustedTeleportLocation extends Error {
+  const UntrustedTeleportLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'UntrustedTeleportLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UntrustedTeleportLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationFull extends Error {
+  const LocationFull();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationFull': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationFull;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationNotInvertible extends Error {
+  const LocationNotInvertible();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationNotInvertible': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationNotInvertible;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BadOrigin extends Error {
+  const BadOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'BadOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BadOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class InvalidLocation extends Error {
+  const InvalidLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'InvalidLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is InvalidLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AssetNotFound extends Error {
+  const AssetNotFound();
+
+  @override
+  Map<String, dynamic> toJson() => {'AssetNotFound': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is AssetNotFound;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FailedToTransactAsset extends Error {
+  const FailedToTransactAsset();
+
+  @override
+  Map<String, dynamic> toJson() => {'FailedToTransactAsset': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FailedToTransactAsset;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotWithdrawable extends Error {
+  const NotWithdrawable();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotWithdrawable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotWithdrawable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationCannotHold extends Error {
+  const LocationCannotHold();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationCannotHold': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationCannotHold;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExceedsMaxMessageSize extends Error {
+  const ExceedsMaxMessageSize();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExceedsMaxMessageSize': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExceedsMaxMessageSize;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DestinationUnsupported extends Error {
+  const DestinationUnsupported();
+
+  @override
+  Map<String, dynamic> toJson() => {'DestinationUnsupported': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is DestinationUnsupported;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Transport extends Error {
+  const Transport();
+
+  @override
+  Map<String, dynamic> toJson() => {'Transport': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Transport;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unroutable extends Error {
+  const Unroutable();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unroutable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unroutable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UnknownClaim extends Error {
+  const UnknownClaim();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnknownClaim': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnknownClaim;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FailedToDecode extends Error {
+  const FailedToDecode();
+
+  @override
+  Map<String, dynamic> toJson() => {'FailedToDecode': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FailedToDecode;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class MaxWeightInvalid extends Error {
+  const MaxWeightInvalid();
+
+  @override
+  Map<String, dynamic> toJson() => {'MaxWeightInvalid': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is MaxWeightInvalid;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotHoldingFees extends Error {
+  const NotHoldingFees();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotHoldingFees': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotHoldingFees;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class TooExpensive extends Error {
+  const TooExpensive();
+
+  @override
+  Map<String, dynamic> toJson() => {'TooExpensive': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is TooExpensive;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Trap extends Error {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.U64Codec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U64Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    _i1.U64Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectationFalse extends Error {
+  const ExpectationFalse();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExpectationFalse': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExpectationFalse;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class PalletNotFound extends Error {
+  const PalletNotFound();
+
+  @override
+  Map<String, dynamic> toJson() => {'PalletNotFound': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is PalletNotFound;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NameMismatch extends Error {
+  const NameMismatch();
+
+  @override
+  Map<String, dynamic> toJson() => {'NameMismatch': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NameMismatch;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class VersionIncompatible extends Error {
+  const VersionIncompatible();
+
+  @override
+  Map<String, dynamic> toJson() => {'VersionIncompatible': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is VersionIncompatible;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class HoldingWouldOverflow extends Error {
+  const HoldingWouldOverflow();
+
+  @override
+  Map<String, dynamic> toJson() => {'HoldingWouldOverflow': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is HoldingWouldOverflow;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExportError extends Error {
+  const ExportError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExportError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExportError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ReanchorFailed extends Error {
+  const ReanchorFailed();
+
+  @override
+  Map<String, dynamic> toJson() => {'ReanchorFailed': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ReanchorFailed;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NoDeal extends Error {
+  const NoDeal();
+
+  @override
+  Map<String, dynamic> toJson() => {'NoDeal': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NoDeal;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FeesNotMet extends Error {
+  const FeesNotMet();
+
+  @override
+  Map<String, dynamic> toJson() => {'FeesNotMet': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FeesNotMet;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LockError extends Error {
+  const LockError();
+
+  @override
+  Map<String, dynamic> toJson() => {'LockError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LockError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NoPermission extends Error {
+  const NoPermission();
+
+  @override
+  Map<String, dynamic> toJson() => {'NoPermission': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NoPermission;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unanchored extends Error {
+  const Unanchored();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unanchored': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unanchored;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotDepositable extends Error {
+  const NotDepositable();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotDepositable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotDepositable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UnhandledXcmVersion extends Error {
+  const UnhandledXcmVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnhandledXcmVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnhandledXcmVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class WeightLimitReached extends Error {
+  const WeightLimitReached(this.value0);
+
+  factory WeightLimitReached._decode(_i1.Input input) {
+    return WeightLimitReached(_i3.Weight.codec.decode(input));
+  }
+
+  /// Weight
+  final _i3.Weight value0;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {'WeightLimitReached': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Weight.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WeightLimitReached && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Barrier extends Error {
+  const Barrier();
+
+  @override
+  Map<String, dynamic> toJson() => {'Barrier': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Barrier;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class WeightNotComputable extends Error {
+  const WeightNotComputable();
+
+  @override
+  Map<String, dynamic> toJson() => {'WeightNotComputable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is WeightNotComputable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExceedsStackLimit extends Error {
+  const ExceedsStackLimit();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExceedsStackLimit': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExceedsStackLimit;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/traits/send_error.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/traits/send_error.dart
@@ -1,0 +1,73 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+enum SendError {
+  notApplicable('NotApplicable', 0),
+  transport('Transport', 1),
+  unroutable('Unroutable', 2),
+  destinationUnsupported('DestinationUnsupported', 3),
+  exceedsMaxMessageSize('ExceedsMaxMessageSize', 4),
+  missingArgument('MissingArgument', 5),
+  fees('Fees', 6);
+
+  const SendError(
+    this.variantName,
+    this.codecIndex,
+  );
+
+  factory SendError.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  final String variantName;
+
+  final int codecIndex;
+
+  static const $SendErrorCodec codec = $SendErrorCodec();
+
+  String toJson() => variantName;
+
+  _i2.Uint8List encode() {
+    return codec.encode(this);
+  }
+}
+
+class $SendErrorCodec with _i1.Codec<SendError> {
+  const $SendErrorCodec();
+
+  @override
+  SendError decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return SendError.notApplicable;
+      case 1:
+        return SendError.transport;
+      case 2:
+        return SendError.unroutable;
+      case 3:
+        return SendError.destinationUnsupported;
+      case 4:
+        return SendError.exceedsMaxMessageSize;
+      case 5:
+        return SendError.missingArgument;
+      case 6:
+        return SendError.fees;
+      default:
+        throw Exception('SendError: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    SendError value,
+    _i1.Output output,
+  ) {
+    _i1.U8Codec.codec.encodeTo(
+      value.codecIndex,
+      output,
+    );
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/weight_limit.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/weight_limit.dart
@@ -1,0 +1,150 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../sp_weights/weight_v2/weight.dart' as _i3;
+
+abstract class WeightLimit {
+  const WeightLimit();
+
+  factory WeightLimit.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $WeightLimitCodec codec = $WeightLimitCodec();
+
+  static const $WeightLimit values = $WeightLimit();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $WeightLimit {
+  const $WeightLimit();
+
+  Unlimited unlimited() {
+    return Unlimited();
+  }
+
+  Limited limited(_i3.Weight value0) {
+    return Limited(value0);
+  }
+}
+
+class $WeightLimitCodec with _i1.Codec<WeightLimit> {
+  const $WeightLimitCodec();
+
+  @override
+  WeightLimit decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Unlimited();
+      case 1:
+        return Limited._decode(input);
+      default:
+        throw Exception('WeightLimit: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    WeightLimit value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Unlimited:
+        (value as Unlimited).encodeTo(output);
+        break;
+      case Limited:
+        (value as Limited).encodeTo(output);
+        break;
+      default:
+        throw Exception('WeightLimit: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(WeightLimit value) {
+    switch (value.runtimeType) {
+      case Unlimited:
+        return 1;
+      case Limited:
+        return (value as Limited)._sizeHint();
+      default:
+        throw Exception('WeightLimit: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Unlimited extends WeightLimit {
+  const Unlimited();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unlimited': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unlimited;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Limited extends WeightLimit {
+  const Limited(this.value0);
+
+  factory Limited._decode(_i1.Input input) {
+    return Limited(_i3.Weight.codec.decode(input));
+  }
+
+  /// Weight
+  final _i3.Weight value0;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {'Limited': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Weight.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Limited && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/xcm_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/xcm_1.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_1.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/xcm_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v3/xcm_2.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:polkadart/scale_codec.dart' as _i2;
+
+import 'instruction_2.dart' as _i1;
+
+typedef Xcm = List<_i1.Instruction>;
+
+class XcmCodec with _i2.Codec<Xcm> {
+  const XcmCodec();
+
+  @override
+  Xcm decode(_i2.Input input) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).decode(input);
+  }
+
+  @override
+  void encodeTo(
+    Xcm value,
+    _i2.Output output,
+  ) {
+    const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).encodeTo(
+      value,
+      output,
+    );
+  }
+
+  @override
+  int sizeHint(Xcm value) {
+    return const _i2.SequenceCodec<_i1.Instruction>(_i1.Instruction.codec).sizeHint(value);
+  }
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v5/traits/error.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/v5/traits/error.dart
@@ -1,0 +1,1381 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../../../sp_weights/weight_v2/weight.dart' as _i3;
+
+abstract class Error {
+  const Error();
+
+  factory Error.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $ErrorCodec codec = $ErrorCodec();
+
+  static const $Error values = $Error();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, dynamic> toJson();
+}
+
+class $Error {
+  const $Error();
+
+  Overflow overflow() {
+    return Overflow();
+  }
+
+  Unimplemented unimplemented() {
+    return Unimplemented();
+  }
+
+  UntrustedReserveLocation untrustedReserveLocation() {
+    return UntrustedReserveLocation();
+  }
+
+  UntrustedTeleportLocation untrustedTeleportLocation() {
+    return UntrustedTeleportLocation();
+  }
+
+  LocationFull locationFull() {
+    return LocationFull();
+  }
+
+  LocationNotInvertible locationNotInvertible() {
+    return LocationNotInvertible();
+  }
+
+  BadOrigin badOrigin() {
+    return BadOrigin();
+  }
+
+  InvalidLocation invalidLocation() {
+    return InvalidLocation();
+  }
+
+  AssetNotFound assetNotFound() {
+    return AssetNotFound();
+  }
+
+  FailedToTransactAsset failedToTransactAsset() {
+    return FailedToTransactAsset();
+  }
+
+  NotWithdrawable notWithdrawable() {
+    return NotWithdrawable();
+  }
+
+  LocationCannotHold locationCannotHold() {
+    return LocationCannotHold();
+  }
+
+  ExceedsMaxMessageSize exceedsMaxMessageSize() {
+    return ExceedsMaxMessageSize();
+  }
+
+  DestinationUnsupported destinationUnsupported() {
+    return DestinationUnsupported();
+  }
+
+  Transport transport() {
+    return Transport();
+  }
+
+  Unroutable unroutable() {
+    return Unroutable();
+  }
+
+  UnknownClaim unknownClaim() {
+    return UnknownClaim();
+  }
+
+  FailedToDecode failedToDecode() {
+    return FailedToDecode();
+  }
+
+  MaxWeightInvalid maxWeightInvalid() {
+    return MaxWeightInvalid();
+  }
+
+  NotHoldingFees notHoldingFees() {
+    return NotHoldingFees();
+  }
+
+  TooExpensive tooExpensive() {
+    return TooExpensive();
+  }
+
+  Trap trap(BigInt value0) {
+    return Trap(value0);
+  }
+
+  ExpectationFalse expectationFalse() {
+    return ExpectationFalse();
+  }
+
+  PalletNotFound palletNotFound() {
+    return PalletNotFound();
+  }
+
+  NameMismatch nameMismatch() {
+    return NameMismatch();
+  }
+
+  VersionIncompatible versionIncompatible() {
+    return VersionIncompatible();
+  }
+
+  HoldingWouldOverflow holdingWouldOverflow() {
+    return HoldingWouldOverflow();
+  }
+
+  ExportError exportError() {
+    return ExportError();
+  }
+
+  ReanchorFailed reanchorFailed() {
+    return ReanchorFailed();
+  }
+
+  NoDeal noDeal() {
+    return NoDeal();
+  }
+
+  FeesNotMet feesNotMet() {
+    return FeesNotMet();
+  }
+
+  LockError lockError() {
+    return LockError();
+  }
+
+  NoPermission noPermission() {
+    return NoPermission();
+  }
+
+  Unanchored unanchored() {
+    return Unanchored();
+  }
+
+  NotDepositable notDepositable() {
+    return NotDepositable();
+  }
+
+  TooManyAssets tooManyAssets() {
+    return TooManyAssets();
+  }
+
+  UnhandledXcmVersion unhandledXcmVersion() {
+    return UnhandledXcmVersion();
+  }
+
+  WeightLimitReached weightLimitReached(_i3.Weight value0) {
+    return WeightLimitReached(value0);
+  }
+
+  Barrier barrier() {
+    return Barrier();
+  }
+
+  WeightNotComputable weightNotComputable() {
+    return WeightNotComputable();
+  }
+
+  ExceedsStackLimit exceedsStackLimit() {
+    return ExceedsStackLimit();
+  }
+}
+
+class $ErrorCodec with _i1.Codec<Error> {
+  const $ErrorCodec();
+
+  @override
+  Error decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 0:
+        return const Overflow();
+      case 1:
+        return const Unimplemented();
+      case 2:
+        return const UntrustedReserveLocation();
+      case 3:
+        return const UntrustedTeleportLocation();
+      case 4:
+        return const LocationFull();
+      case 5:
+        return const LocationNotInvertible();
+      case 6:
+        return const BadOrigin();
+      case 7:
+        return const InvalidLocation();
+      case 8:
+        return const AssetNotFound();
+      case 9:
+        return const FailedToTransactAsset();
+      case 10:
+        return const NotWithdrawable();
+      case 11:
+        return const LocationCannotHold();
+      case 12:
+        return const ExceedsMaxMessageSize();
+      case 13:
+        return const DestinationUnsupported();
+      case 14:
+        return const Transport();
+      case 15:
+        return const Unroutable();
+      case 16:
+        return const UnknownClaim();
+      case 17:
+        return const FailedToDecode();
+      case 18:
+        return const MaxWeightInvalid();
+      case 19:
+        return const NotHoldingFees();
+      case 20:
+        return const TooExpensive();
+      case 21:
+        return Trap._decode(input);
+      case 22:
+        return const ExpectationFalse();
+      case 23:
+        return const PalletNotFound();
+      case 24:
+        return const NameMismatch();
+      case 25:
+        return const VersionIncompatible();
+      case 26:
+        return const HoldingWouldOverflow();
+      case 27:
+        return const ExportError();
+      case 28:
+        return const ReanchorFailed();
+      case 29:
+        return const NoDeal();
+      case 30:
+        return const FeesNotMet();
+      case 31:
+        return const LockError();
+      case 32:
+        return const NoPermission();
+      case 33:
+        return const Unanchored();
+      case 34:
+        return const NotDepositable();
+      case 35:
+        return const TooManyAssets();
+      case 36:
+        return const UnhandledXcmVersion();
+      case 37:
+        return WeightLimitReached._decode(input);
+      case 38:
+        return const Barrier();
+      case 39:
+        return const WeightNotComputable();
+      case 40:
+        return const ExceedsStackLimit();
+      default:
+        throw Exception('Error: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    Error value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case Overflow:
+        (value as Overflow).encodeTo(output);
+        break;
+      case Unimplemented:
+        (value as Unimplemented).encodeTo(output);
+        break;
+      case UntrustedReserveLocation:
+        (value as UntrustedReserveLocation).encodeTo(output);
+        break;
+      case UntrustedTeleportLocation:
+        (value as UntrustedTeleportLocation).encodeTo(output);
+        break;
+      case LocationFull:
+        (value as LocationFull).encodeTo(output);
+        break;
+      case LocationNotInvertible:
+        (value as LocationNotInvertible).encodeTo(output);
+        break;
+      case BadOrigin:
+        (value as BadOrigin).encodeTo(output);
+        break;
+      case InvalidLocation:
+        (value as InvalidLocation).encodeTo(output);
+        break;
+      case AssetNotFound:
+        (value as AssetNotFound).encodeTo(output);
+        break;
+      case FailedToTransactAsset:
+        (value as FailedToTransactAsset).encodeTo(output);
+        break;
+      case NotWithdrawable:
+        (value as NotWithdrawable).encodeTo(output);
+        break;
+      case LocationCannotHold:
+        (value as LocationCannotHold).encodeTo(output);
+        break;
+      case ExceedsMaxMessageSize:
+        (value as ExceedsMaxMessageSize).encodeTo(output);
+        break;
+      case DestinationUnsupported:
+        (value as DestinationUnsupported).encodeTo(output);
+        break;
+      case Transport:
+        (value as Transport).encodeTo(output);
+        break;
+      case Unroutable:
+        (value as Unroutable).encodeTo(output);
+        break;
+      case UnknownClaim:
+        (value as UnknownClaim).encodeTo(output);
+        break;
+      case FailedToDecode:
+        (value as FailedToDecode).encodeTo(output);
+        break;
+      case MaxWeightInvalid:
+        (value as MaxWeightInvalid).encodeTo(output);
+        break;
+      case NotHoldingFees:
+        (value as NotHoldingFees).encodeTo(output);
+        break;
+      case TooExpensive:
+        (value as TooExpensive).encodeTo(output);
+        break;
+      case Trap:
+        (value as Trap).encodeTo(output);
+        break;
+      case ExpectationFalse:
+        (value as ExpectationFalse).encodeTo(output);
+        break;
+      case PalletNotFound:
+        (value as PalletNotFound).encodeTo(output);
+        break;
+      case NameMismatch:
+        (value as NameMismatch).encodeTo(output);
+        break;
+      case VersionIncompatible:
+        (value as VersionIncompatible).encodeTo(output);
+        break;
+      case HoldingWouldOverflow:
+        (value as HoldingWouldOverflow).encodeTo(output);
+        break;
+      case ExportError:
+        (value as ExportError).encodeTo(output);
+        break;
+      case ReanchorFailed:
+        (value as ReanchorFailed).encodeTo(output);
+        break;
+      case NoDeal:
+        (value as NoDeal).encodeTo(output);
+        break;
+      case FeesNotMet:
+        (value as FeesNotMet).encodeTo(output);
+        break;
+      case LockError:
+        (value as LockError).encodeTo(output);
+        break;
+      case NoPermission:
+        (value as NoPermission).encodeTo(output);
+        break;
+      case Unanchored:
+        (value as Unanchored).encodeTo(output);
+        break;
+      case NotDepositable:
+        (value as NotDepositable).encodeTo(output);
+        break;
+      case TooManyAssets:
+        (value as TooManyAssets).encodeTo(output);
+        break;
+      case UnhandledXcmVersion:
+        (value as UnhandledXcmVersion).encodeTo(output);
+        break;
+      case WeightLimitReached:
+        (value as WeightLimitReached).encodeTo(output);
+        break;
+      case Barrier:
+        (value as Barrier).encodeTo(output);
+        break;
+      case WeightNotComputable:
+        (value as WeightNotComputable).encodeTo(output);
+        break;
+      case ExceedsStackLimit:
+        (value as ExceedsStackLimit).encodeTo(output);
+        break;
+      default:
+        throw Exception('Error: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(Error value) {
+    switch (value.runtimeType) {
+      case Overflow:
+        return 1;
+      case Unimplemented:
+        return 1;
+      case UntrustedReserveLocation:
+        return 1;
+      case UntrustedTeleportLocation:
+        return 1;
+      case LocationFull:
+        return 1;
+      case LocationNotInvertible:
+        return 1;
+      case BadOrigin:
+        return 1;
+      case InvalidLocation:
+        return 1;
+      case AssetNotFound:
+        return 1;
+      case FailedToTransactAsset:
+        return 1;
+      case NotWithdrawable:
+        return 1;
+      case LocationCannotHold:
+        return 1;
+      case ExceedsMaxMessageSize:
+        return 1;
+      case DestinationUnsupported:
+        return 1;
+      case Transport:
+        return 1;
+      case Unroutable:
+        return 1;
+      case UnknownClaim:
+        return 1;
+      case FailedToDecode:
+        return 1;
+      case MaxWeightInvalid:
+        return 1;
+      case NotHoldingFees:
+        return 1;
+      case TooExpensive:
+        return 1;
+      case Trap:
+        return (value as Trap)._sizeHint();
+      case ExpectationFalse:
+        return 1;
+      case PalletNotFound:
+        return 1;
+      case NameMismatch:
+        return 1;
+      case VersionIncompatible:
+        return 1;
+      case HoldingWouldOverflow:
+        return 1;
+      case ExportError:
+        return 1;
+      case ReanchorFailed:
+        return 1;
+      case NoDeal:
+        return 1;
+      case FeesNotMet:
+        return 1;
+      case LockError:
+        return 1;
+      case NoPermission:
+        return 1;
+      case Unanchored:
+        return 1;
+      case NotDepositable:
+        return 1;
+      case TooManyAssets:
+        return 1;
+      case UnhandledXcmVersion:
+        return 1;
+      case WeightLimitReached:
+        return (value as WeightLimitReached)._sizeHint();
+      case Barrier:
+        return 1;
+      case WeightNotComputable:
+        return 1;
+      case ExceedsStackLimit:
+        return 1;
+      default:
+        throw Exception('Error: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class Overflow extends Error {
+  const Overflow();
+
+  @override
+  Map<String, dynamic> toJson() => {'Overflow': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Overflow;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unimplemented extends Error {
+  const Unimplemented();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unimplemented': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      1,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unimplemented;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UntrustedReserveLocation extends Error {
+  const UntrustedReserveLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'UntrustedReserveLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      2,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UntrustedReserveLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UntrustedTeleportLocation extends Error {
+  const UntrustedTeleportLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'UntrustedTeleportLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UntrustedTeleportLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationFull extends Error {
+  const LocationFull();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationFull': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationFull;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationNotInvertible extends Error {
+  const LocationNotInvertible();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationNotInvertible': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationNotInvertible;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class BadOrigin extends Error {
+  const BadOrigin();
+
+  @override
+  Map<String, dynamic> toJson() => {'BadOrigin': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      6,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is BadOrigin;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class InvalidLocation extends Error {
+  const InvalidLocation();
+
+  @override
+  Map<String, dynamic> toJson() => {'InvalidLocation': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      7,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is InvalidLocation;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class AssetNotFound extends Error {
+  const AssetNotFound();
+
+  @override
+  Map<String, dynamic> toJson() => {'AssetNotFound': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      8,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is AssetNotFound;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FailedToTransactAsset extends Error {
+  const FailedToTransactAsset();
+
+  @override
+  Map<String, dynamic> toJson() => {'FailedToTransactAsset': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      9,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FailedToTransactAsset;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotWithdrawable extends Error {
+  const NotWithdrawable();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotWithdrawable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      10,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotWithdrawable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LocationCannotHold extends Error {
+  const LocationCannotHold();
+
+  @override
+  Map<String, dynamic> toJson() => {'LocationCannotHold': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      11,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LocationCannotHold;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExceedsMaxMessageSize extends Error {
+  const ExceedsMaxMessageSize();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExceedsMaxMessageSize': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      12,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExceedsMaxMessageSize;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class DestinationUnsupported extends Error {
+  const DestinationUnsupported();
+
+  @override
+  Map<String, dynamic> toJson() => {'DestinationUnsupported': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      13,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is DestinationUnsupported;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Transport extends Error {
+  const Transport();
+
+  @override
+  Map<String, dynamic> toJson() => {'Transport': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      14,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Transport;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unroutable extends Error {
+  const Unroutable();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unroutable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      15,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unroutable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UnknownClaim extends Error {
+  const UnknownClaim();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnknownClaim': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      16,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnknownClaim;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FailedToDecode extends Error {
+  const FailedToDecode();
+
+  @override
+  Map<String, dynamic> toJson() => {'FailedToDecode': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      17,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FailedToDecode;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class MaxWeightInvalid extends Error {
+  const MaxWeightInvalid();
+
+  @override
+  Map<String, dynamic> toJson() => {'MaxWeightInvalid': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      18,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is MaxWeightInvalid;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotHoldingFees extends Error {
+  const NotHoldingFees();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotHoldingFees': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      19,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotHoldingFees;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class TooExpensive extends Error {
+  const TooExpensive();
+
+  @override
+  Map<String, dynamic> toJson() => {'TooExpensive': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      20,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is TooExpensive;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Trap extends Error {
+  const Trap(this.value0);
+
+  factory Trap._decode(_i1.Input input) {
+    return Trap(_i1.U64Codec.codec.decode(input));
+  }
+
+  /// u64
+  final BigInt value0;
+
+  @override
+  Map<String, BigInt> toJson() => {'Trap': value0};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i1.U64Codec.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      21,
+      output,
+    );
+    _i1.U64Codec.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is Trap && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class ExpectationFalse extends Error {
+  const ExpectationFalse();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExpectationFalse': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      22,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExpectationFalse;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class PalletNotFound extends Error {
+  const PalletNotFound();
+
+  @override
+  Map<String, dynamic> toJson() => {'PalletNotFound': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      23,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is PalletNotFound;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NameMismatch extends Error {
+  const NameMismatch();
+
+  @override
+  Map<String, dynamic> toJson() => {'NameMismatch': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      24,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NameMismatch;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class VersionIncompatible extends Error {
+  const VersionIncompatible();
+
+  @override
+  Map<String, dynamic> toJson() => {'VersionIncompatible': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      25,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is VersionIncompatible;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class HoldingWouldOverflow extends Error {
+  const HoldingWouldOverflow();
+
+  @override
+  Map<String, dynamic> toJson() => {'HoldingWouldOverflow': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      26,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is HoldingWouldOverflow;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExportError extends Error {
+  const ExportError();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExportError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      27,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExportError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ReanchorFailed extends Error {
+  const ReanchorFailed();
+
+  @override
+  Map<String, dynamic> toJson() => {'ReanchorFailed': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      28,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ReanchorFailed;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NoDeal extends Error {
+  const NoDeal();
+
+  @override
+  Map<String, dynamic> toJson() => {'NoDeal': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      29,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NoDeal;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class FeesNotMet extends Error {
+  const FeesNotMet();
+
+  @override
+  Map<String, dynamic> toJson() => {'FeesNotMet': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      30,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is FeesNotMet;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class LockError extends Error {
+  const LockError();
+
+  @override
+  Map<String, dynamic> toJson() => {'LockError': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      31,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is LockError;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NoPermission extends Error {
+  const NoPermission();
+
+  @override
+  Map<String, dynamic> toJson() => {'NoPermission': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      32,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NoPermission;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class Unanchored extends Error {
+  const Unanchored();
+
+  @override
+  Map<String, dynamic> toJson() => {'Unanchored': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      33,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Unanchored;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class NotDepositable extends Error {
+  const NotDepositable();
+
+  @override
+  Map<String, dynamic> toJson() => {'NotDepositable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      34,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is NotDepositable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class TooManyAssets extends Error {
+  const TooManyAssets();
+
+  @override
+  Map<String, dynamic> toJson() => {'TooManyAssets': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      35,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is TooManyAssets;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class UnhandledXcmVersion extends Error {
+  const UnhandledXcmVersion();
+
+  @override
+  Map<String, dynamic> toJson() => {'UnhandledXcmVersion': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      36,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is UnhandledXcmVersion;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class WeightLimitReached extends Error {
+  const WeightLimitReached(this.value0);
+
+  factory WeightLimitReached._decode(_i1.Input input) {
+    return WeightLimitReached(_i3.Weight.codec.decode(input));
+  }
+
+  /// Weight
+  final _i3.Weight value0;
+
+  @override
+  Map<String, Map<String, BigInt>> toJson() => {'WeightLimitReached': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Weight.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      37,
+      output,
+    );
+    _i3.Weight.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is WeightLimitReached && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class Barrier extends Error {
+  const Barrier();
+
+  @override
+  Map<String, dynamic> toJson() => {'Barrier': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      38,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is Barrier;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class WeightNotComputable extends Error {
+  const WeightNotComputable();
+
+  @override
+  Map<String, dynamic> toJson() => {'WeightNotComputable': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      39,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is WeightNotComputable;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class ExceedsStackLimit extends Error {
+  const ExceedsStackLimit();
+
+  @override
+  Map<String, dynamic> toJson() => {'ExceedsStackLimit': null};
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      40,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is ExceedsStackLimit;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_asset_id.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_asset_id.dart
@@ -1,0 +1,229 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../staging_xcm/v4/asset/asset_id.dart' as _i4;
+import '../staging_xcm/v4/location/location.dart' as _i6;
+import '../staging_xcm/v5/asset/asset_id.dart' as _i5;
+import '../staging_xcm/v5/location/location.dart' as _i7;
+import 'v3/multiasset/asset_id.dart' as _i3;
+
+abstract class VersionedAssetId {
+  const VersionedAssetId();
+
+  factory VersionedAssetId.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedAssetIdCodec codec = $VersionedAssetIdCodec();
+
+  static const $VersionedAssetId values = $VersionedAssetId();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson();
+}
+
+class $VersionedAssetId {
+  const $VersionedAssetId();
+
+  V3 v3(_i3.AssetId value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.AssetId value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.AssetId value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedAssetIdCodec with _i1.Codec<VersionedAssetId> {
+  const $VersionedAssetIdCodec();
+
+  @override
+  VersionedAssetId decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedAssetId: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedAssetId value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedAssetId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedAssetId value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedAssetId: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedAssetId {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(_i3.AssetId.codec.decode(input));
+  }
+
+  /// v3::AssetId
+  final _i3.AssetId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V3': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.AssetId.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.AssetId.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedAssetId {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(_i6.Location.codec.decode(input));
+  }
+
+  /// v4::AssetId
+  final _i4.AssetId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V4': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i4.AssetIdCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i6.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedAssetId {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(_i7.Location.codec.decode(input));
+  }
+
+  /// v5::AssetId
+  final _i5.AssetId value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V5': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i5.AssetIdCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i7.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_assets.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_assets.dart
@@ -1,0 +1,246 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i7;
+
+import '../staging_xcm/v4/asset/asset.dart' as _i8;
+import '../staging_xcm/v4/asset/assets.dart' as _i4;
+import '../staging_xcm/v5/asset/asset.dart' as _i9;
+import '../staging_xcm/v5/asset/assets.dart' as _i5;
+import 'v3/multiasset/multi_asset.dart' as _i6;
+import 'v3/multiasset/multi_assets.dart' as _i3;
+
+abstract class VersionedAssets {
+  const VersionedAssets();
+
+  factory VersionedAssets.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedAssetsCodec codec = $VersionedAssetsCodec();
+
+  static const $VersionedAssets values = $VersionedAssets();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson();
+}
+
+class $VersionedAssets {
+  const $VersionedAssets();
+
+  V3 v3(_i3.MultiAssets value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.Assets value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.Assets value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedAssetsCodec with _i1.Codec<VersionedAssets> {
+  const $VersionedAssetsCodec();
+
+  @override
+  VersionedAssets decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedAssets: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedAssets value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedAssets: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedAssets value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedAssets: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedAssets {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(const _i1.SequenceCodec<_i6.MultiAsset>(_i6.MultiAsset.codec).decode(input));
+  }
+
+  /// v3::MultiAssets
+  final _i3.MultiAssets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'V3': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.MultiAssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.MultiAsset>(_i6.MultiAsset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedAssets {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).decode(input));
+  }
+
+  /// v4::Assets
+  final _i4.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'V4': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i4.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.Asset>(_i8.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedAssets {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(const _i1.SequenceCodec<_i9.Asset>(_i9.Asset.codec).decode(input));
+  }
+
+  /// v5::Assets
+  final _i5.Assets value0;
+
+  @override
+  Map<String, List<Map<String, Map<String, dynamic>>>> toJson() =>
+      {'V5': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i5.AssetsCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i9.Asset>(_i9.Asset.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_location.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_location.dart
@@ -1,0 +1,227 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../staging_xcm/v3/multilocation/multi_location.dart' as _i3;
+import '../staging_xcm/v4/location/location.dart' as _i4;
+import '../staging_xcm/v5/location/location.dart' as _i5;
+
+abstract class VersionedLocation {
+  const VersionedLocation();
+
+  factory VersionedLocation.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedLocationCodec codec = $VersionedLocationCodec();
+
+  static const $VersionedLocation values = $VersionedLocation();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson();
+}
+
+class $VersionedLocation {
+  const $VersionedLocation();
+
+  V3 v3(_i3.MultiLocation value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.Location value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.Location value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedLocationCodec with _i1.Codec<VersionedLocation> {
+  const $VersionedLocationCodec();
+
+  @override
+  VersionedLocation decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedLocation: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedLocation value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedLocation: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedLocation value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedLocation: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedLocation {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(_i3.MultiLocation.codec.decode(input));
+  }
+
+  /// v3::MultiLocation
+  final _i3.MultiLocation value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V3': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.MultiLocation.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.MultiLocation.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedLocation {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(_i4.Location.codec.decode(input));
+  }
+
+  /// v4::Location
+  final _i4.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V4': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i4.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedLocation {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(_i5.Location.codec.decode(input));
+  }
+
+  /// v5::Location
+  final _i5.Location value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V5': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i5.Location.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i5.Location.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_response.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_response.dart
@@ -1,0 +1,227 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+
+import '../staging_xcm/v4/response.dart' as _i4;
+import '../staging_xcm/v5/response.dart' as _i5;
+import 'v3/response.dart' as _i3;
+
+abstract class VersionedResponse {
+  const VersionedResponse();
+
+  factory VersionedResponse.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedResponseCodec codec = $VersionedResponseCodec();
+
+  static const $VersionedResponse values = $VersionedResponse();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, Map<String, dynamic>> toJson();
+}
+
+class $VersionedResponse {
+  const $VersionedResponse();
+
+  V3 v3(_i3.Response value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.Response value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.Response value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedResponseCodec with _i1.Codec<VersionedResponse> {
+  const $VersionedResponseCodec();
+
+  @override
+  VersionedResponse decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedResponse: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedResponse value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedResponse: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedResponse value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedResponse: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedResponse {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(_i3.Response.codec.decode(input));
+  }
+
+  /// v3::Response
+  final _i3.Response value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V3': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i3.Response.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    _i3.Response.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedResponse {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(_i4.Response.codec.decode(input));
+  }
+
+  /// v4::Response
+  final _i4.Response value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V4': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i4.Response.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    _i4.Response.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedResponse {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(_i5.Response.codec.decode(input));
+  }
+
+  /// v5::Response
+  final _i5.Response value0;
+
+  @override
+  Map<String, Map<String, dynamic>> toJson() => {'V5': value0.toJson()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + _i5.Response.codec.sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    _i5.Response.codec.encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 && other.value0 == value0;
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_xcm_1.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_xcm_1.dart
@@ -1,0 +1,243 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i7;
+
+import '../staging_xcm/v4/instruction_1.dart' as _i8;
+import '../staging_xcm/v4/xcm_1.dart' as _i4;
+import '../staging_xcm/v5/instruction_1.dart' as _i9;
+import '../staging_xcm/v5/xcm_1.dart' as _i5;
+import 'v3/instruction_1.dart' as _i6;
+import 'v3/xcm_1.dart' as _i3;
+
+abstract class VersionedXcm {
+  const VersionedXcm();
+
+  factory VersionedXcm.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedXcmCodec codec = $VersionedXcmCodec();
+
+  static const $VersionedXcm values = $VersionedXcm();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, List<Map<String, dynamic>>> toJson();
+}
+
+class $VersionedXcm {
+  const $VersionedXcm();
+
+  V3 v3(_i3.Xcm value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.Xcm value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.Xcm value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedXcmCodec with _i1.Codec<VersionedXcm> {
+  const $VersionedXcmCodec();
+
+  @override
+  VersionedXcm decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedXcm: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedXcm value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedXcm: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedXcm value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedXcm: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedXcm {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(const _i1.SequenceCodec<_i6.Instruction>(_i6.Instruction.codec).decode(input));
+  }
+
+  /// v3::Xcm<RuntimeCall>
+  final _i3.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V3': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.Instruction>(_i6.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedXcm {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(const _i1.SequenceCodec<_i8.Instruction>(_i8.Instruction.codec).decode(input));
+  }
+
+  /// v4::Xcm<RuntimeCall>
+  final _i4.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V4': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i4.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.Instruction>(_i8.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedXcm {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(const _i1.SequenceCodec<_i9.Instruction>(_i9.Instruction.codec).decode(input));
+  }
+
+  /// v5::Xcm<RuntimeCall>
+  final _i5.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V5': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i5.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i9.Instruction>(_i9.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}

--- a/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_xcm_2.dart
+++ b/packages/ew_polkadart/lib/generated/encointer_kusama/types/xcm/versioned_xcm_2.dart
@@ -1,0 +1,243 @@
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:typed_data' as _i2;
+
+import 'package:polkadart/scale_codec.dart' as _i1;
+import 'package:quiver/collection.dart' as _i7;
+
+import '../staging_xcm/v4/instruction_2.dart' as _i8;
+import '../staging_xcm/v4/xcm_2.dart' as _i4;
+import '../staging_xcm/v5/instruction_2.dart' as _i9;
+import '../staging_xcm/v5/xcm_2.dart' as _i5;
+import 'v3/instruction_2.dart' as _i6;
+import 'v3/xcm_2.dart' as _i3;
+
+abstract class VersionedXcm {
+  const VersionedXcm();
+
+  factory VersionedXcm.decode(_i1.Input input) {
+    return codec.decode(input);
+  }
+
+  static const $VersionedXcmCodec codec = $VersionedXcmCodec();
+
+  static const $VersionedXcm values = $VersionedXcm();
+
+  _i2.Uint8List encode() {
+    final output = _i1.ByteOutput(codec.sizeHint(this));
+    codec.encodeTo(this, output);
+    return output.toBytes();
+  }
+
+  int sizeHint() {
+    return codec.sizeHint(this);
+  }
+
+  Map<String, List<Map<String, dynamic>>> toJson();
+}
+
+class $VersionedXcm {
+  const $VersionedXcm();
+
+  V3 v3(_i3.Xcm value0) {
+    return V3(value0);
+  }
+
+  V4 v4(_i4.Xcm value0) {
+    return V4(value0);
+  }
+
+  V5 v5(_i5.Xcm value0) {
+    return V5(value0);
+  }
+}
+
+class $VersionedXcmCodec with _i1.Codec<VersionedXcm> {
+  const $VersionedXcmCodec();
+
+  @override
+  VersionedXcm decode(_i1.Input input) {
+    final index = _i1.U8Codec.codec.decode(input);
+    switch (index) {
+      case 3:
+        return V3._decode(input);
+      case 4:
+        return V4._decode(input);
+      case 5:
+        return V5._decode(input);
+      default:
+        throw Exception('VersionedXcm: Invalid variant index: "$index"');
+    }
+  }
+
+  @override
+  void encodeTo(
+    VersionedXcm value,
+    _i1.Output output,
+  ) {
+    switch (value.runtimeType) {
+      case V3:
+        (value as V3).encodeTo(output);
+        break;
+      case V4:
+        (value as V4).encodeTo(output);
+        break;
+      case V5:
+        (value as V5).encodeTo(output);
+        break;
+      default:
+        throw Exception('VersionedXcm: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+
+  @override
+  int sizeHint(VersionedXcm value) {
+    switch (value.runtimeType) {
+      case V3:
+        return (value as V3)._sizeHint();
+      case V4:
+        return (value as V4)._sizeHint();
+      case V5:
+        return (value as V5)._sizeHint();
+      default:
+        throw Exception('VersionedXcm: Unsupported "$value" of type "${value.runtimeType}"');
+    }
+  }
+}
+
+class V3 extends VersionedXcm {
+  const V3(this.value0);
+
+  factory V3._decode(_i1.Input input) {
+    return V3(const _i1.SequenceCodec<_i6.Instruction>(_i6.Instruction.codec).decode(input));
+  }
+
+  /// v3::Xcm<RuntimeCall>
+  final _i3.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V3': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i3.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      3,
+      output,
+    );
+    const _i1.SequenceCodec<_i6.Instruction>(_i6.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V3 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V4 extends VersionedXcm {
+  const V4(this.value0);
+
+  factory V4._decode(_i1.Input input) {
+    return V4(const _i1.SequenceCodec<_i8.Instruction>(_i8.Instruction.codec).decode(input));
+  }
+
+  /// v4::Xcm<RuntimeCall>
+  final _i4.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V4': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i4.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      4,
+      output,
+    );
+    const _i1.SequenceCodec<_i8.Instruction>(_i8.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V4 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}
+
+class V5 extends VersionedXcm {
+  const V5(this.value0);
+
+  factory V5._decode(_i1.Input input) {
+    return V5(const _i1.SequenceCodec<_i9.Instruction>(_i9.Instruction.codec).decode(input));
+  }
+
+  /// v5::Xcm<RuntimeCall>
+  final _i5.Xcm value0;
+
+  @override
+  Map<String, List<Map<String, dynamic>>> toJson() => {'V5': value0.map((value) => value.toJson()).toList()};
+
+  int _sizeHint() {
+    int size = 1;
+    size = size + const _i5.XcmCodec().sizeHint(value0);
+    return size;
+  }
+
+  void encodeTo(_i1.Output output) {
+    _i1.U8Codec.codec.encodeTo(
+      5,
+      output,
+    );
+    const _i1.SequenceCodec<_i9.Instruction>(_i9.Instruction.codec).encodeTo(
+      value0,
+      output,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is V5 &&
+          _i7.listsEqual(
+            other.value0,
+            value0,
+          );
+
+  @override
+  int get hashCode => value0.hashCode;
+}


### PR DESCRIPTION
This adds the new SwapAsset stuff needed for the treasury payment on AssetHub Kusama. This is a preparation task for #1805.

Steps done:
1. In `ew_polkadart/pubspec.yaml` replace `wss://gesell.encointer.org` with `wss://kusama.api.encointer.org`
1.1. If files generated on windows, run: `./scripts/replace_backslash_in_dart_files.sh ./packages/ew_polkadart/
`
3. run ` .\.flutter\bin\dart run melos run-polkadart-generate`
4. format generated code: `.flutter/bin/dart format . --line-length 120`
5. fix generated code `.flutter/bin/dart fix . --apply`
6. This generated a lot of code for many pallets that we do not use. From the diff we only take encointer_pallets related changes. In this case, this means that we also need to add some XCM stuff.

This process is kind of manual, which sucks a bit, but the solution to this is not straightforward https://github.com/encointer/encointer-wallet-flutter/issues/1825.