### PR TITLE
Set mock swap options via dev options

### DIFF
--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -74,7 +74,9 @@ class _AssetsViewState extends State<AssetsView> {
   NativeSwap? nativeSwap;
   AssetSwap? assetSwap;
 
-  final devSwap = true;
+  // UI mocks that can be enabled via the dev options
+  NativeSwap? nativeSwapMock;
+  AssetSwap? assetSwapMock;
 
   @override
   void initState() {
@@ -113,13 +115,18 @@ class _AssetsViewState extends State<AssetsView> {
 
     final accountId = AddressUtils.addressToPubKey(widget.store.account.currentAddress).toList();
 
-    if (devSwap) {
-      Log.d('DEV: Getting Swap Options', _logTarget);
+    if (widget.store.settings.ksmMockSwapEnabled) {
+      Log.d('DEV: Getting KSM Swap Options', _logTarget);
       setState(() {
-        // nativeSwap = mockNativeSwap(cid);
-        assetSwap = mockAssetSwap(cid);
+        nativeSwapMock = mockNativeSwap(cid);
       });
-      return;
+    }
+
+    if (widget.store.settings.usdcMockSwapEnabled) {
+      Log.d('DEV: Getting USDC Swap Options', _logTarget);
+      setState(() {
+        assetSwapMock = mockAssetSwap(cid);
+      });
     }
 
     Log.d('Getting Swap Options', _logTarget);
@@ -322,6 +329,18 @@ class _AssetsViewState extends State<AssetsView> {
                   ),
                   onPressed: () => Navigator.pushNamed(context, ExerciseSwapPage.route, arguments: assetSwap),
                 ),
+              if (assetSwapMock != null)
+                ElevatedButton(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Iconsax.trade),
+                      const SizedBox(width: 4),
+                      Text(l10n.exerciseSwapAssetOptionAvailable(assetSwapMock!.symbol)),
+                    ],
+                  ),
+                  onPressed: () => Navigator.pushNamed(context, ExerciseSwapPage.route, arguments: assetSwapMock),
+                ),
               if (nativeSwap != null)
                 ElevatedButton(
                   child: Row(
@@ -336,6 +355,22 @@ class _AssetsViewState extends State<AssetsView> {
                     context,
                     ExerciseSwapPage.route,
                     arguments: nativeSwap,
+                  ),
+                ),
+              if (nativeSwapMock != null)
+                ElevatedButton(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Iconsax.trade),
+                      const SizedBox(width: 4),
+                      Text(l10n.exerciseSwapNativeOptionAvailable),
+                    ],
+                  ),
+                  onPressed: () => Navigator.pushNamed(
+                    context,
+                    ExerciseSwapPage.route,
+                    arguments: nativeSwapMock,
                   ),
                 ),
               Observer(builder: (_) {

--- a/app/lib/page/profile/index.dart
+++ b/app/lib/page/profile/index.dart
@@ -228,6 +228,20 @@ class _ProfileState extends State<Profile> {
                             : const CupertinoActivityIndicator(),
                       ),
                     ),
+                    ListTile(
+                      title: Text('Enable KSM Mock Swap', style: h3Grey),
+                      trailing: Checkbox(
+                        value: store.settings.ksmMockSwapEnabled,
+                        onChanged: (_) => store.settings.toggleKsmMockSwapEnabled(),
+                      ),
+                    ),
+                    ListTile(
+                      title: Text('Enable USDC Mock Swap', style: h3Grey),
+                      trailing: Checkbox(
+                        value: store.settings.usdcMockSwapEnabled,
+                        onChanged: (_) => store.settings.toggleUsdcMockSwapEnabled(),
+                      ),
+                    ),
                     Padding(
                       padding: const EdgeInsets.all(8),
                       child: SubmitButton(

--- a/app/lib/store/settings.dart
+++ b/app/lib/store/settings.dart
@@ -29,6 +29,12 @@ abstract class _SettingsStore with Store {
   Network currentNetwork = Network.encointerKusama;
 
   @observable
+  bool ksmMockSwapEnabled = false;
+
+  @observable
+  bool usdcMockSwapEnabled = false;
+
+  @observable
   ObservableList<AccountData> contactList = ObservableList<AccountData>();
 
   @computed
@@ -56,6 +62,16 @@ abstract class _SettingsStore with Store {
     await Future.wait([
       loadContacts(),
     ]);
+  }
+
+  @action
+  void toggleKsmMockSwapEnabled() {
+    ksmMockSwapEnabled = !ksmMockSwapEnabled;
+  }
+
+  @action
+  void toggleUsdcMockSwapEnabled() {
+    usdcMockSwapEnabled = !usdcMockSwapEnabled;
   }
 
   @action

--- a/app/lib/store/settings.g.dart
+++ b/app/lib/store/settings.g.dart
@@ -77,6 +77,36 @@ mixin _$SettingsStore on _SettingsStore, Store {
     });
   }
 
+  late final _$ksmMockSwapEnabledAtom = Atom(name: '_SettingsStore.ksmMockSwapEnabled', context: context);
+
+  @override
+  bool get ksmMockSwapEnabled {
+    _$ksmMockSwapEnabledAtom.reportRead();
+    return super.ksmMockSwapEnabled;
+  }
+
+  @override
+  set ksmMockSwapEnabled(bool value) {
+    _$ksmMockSwapEnabledAtom.reportWrite(value, super.ksmMockSwapEnabled, () {
+      super.ksmMockSwapEnabled = value;
+    });
+  }
+
+  late final _$usdcMockSwapEnabledAtom = Atom(name: '_SettingsStore.usdcMockSwapEnabled', context: context);
+
+  @override
+  bool get usdcMockSwapEnabled {
+    _$usdcMockSwapEnabledAtom.reportRead();
+    return super.usdcMockSwapEnabled;
+  }
+
+  @override
+  set usdcMockSwapEnabled(bool value) {
+    _$usdcMockSwapEnabledAtom.reportWrite(value, super.usdcMockSwapEnabled, () {
+      super.usdcMockSwapEnabled = value;
+    });
+  }
+
   late final _$contactListAtom = Atom(name: '_SettingsStore.contactList', context: context);
 
   @override
@@ -151,6 +181,26 @@ mixin _$SettingsStore on _SettingsStore, Store {
   late final _$_SettingsStoreActionController = ActionController(name: '_SettingsStore', context: context);
 
   @override
+  void toggleKsmMockSwapEnabled() {
+    final _$actionInfo = _$_SettingsStoreActionController.startAction(name: '_SettingsStore.toggleKsmMockSwapEnabled');
+    try {
+      return super.toggleKsmMockSwapEnabled();
+    } finally {
+      _$_SettingsStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  void toggleUsdcMockSwapEnabled() {
+    final _$actionInfo = _$_SettingsStoreActionController.startAction(name: '_SettingsStore.toggleUsdcMockSwapEnabled');
+    try {
+      return super.toggleUsdcMockSwapEnabled();
+    } finally {
+      _$_SettingsStoreActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
   void setNetworkLoading(bool isLoading) {
     final _$actionInfo = _$_SettingsStoreActionController.startAction(name: '_SettingsStore.setNetworkLoading');
     try {
@@ -176,6 +226,8 @@ mixin _$SettingsStore on _SettingsStore, Store {
 loading: ${loading},
 localeCode: ${localeCode},
 currentNetwork: ${currentNetwork},
+ksmMockSwapEnabled: ${ksmMockSwapEnabled},
+usdcMockSwapEnabled: ${usdcMockSwapEnabled},
 contactList: ${contactList},
 endpointIsNoTee: ${endpointIsNoTee},
 ipfsGateway: ${ipfsGateway},


### PR DESCRIPTION
Before, this was hardcoded, and I had to enable it by setting a flag to true. It has been shown that this is error prone as in the last release, I have accidentally committed the wrong flag, such that the mock swap is shown in the production release.

Now the mock flags can be set from the profile page.