### PR TITLE
[Homepage] mockswaps are explicitly enabled from the developer settings

### DIFF
--- a/app/lib/page/assets/index.dart
+++ b/app/lib/page/assets/index.dart
@@ -318,10 +318,12 @@ class _AssetsViewState extends State<AssetsView> {
                     children: [
                       const Icon(Iconsax.trade),
                       const SizedBox(width: 4),
-                      Text(l10n.exerciseSwapAssetOptionAvailable(mockAssetSwap(widget.store.encointer.chosenCid!).symbol)),
+                      Text(l10n
+                          .exerciseSwapAssetOptionAvailable(mockAssetSwap(widget.store.encointer.chosenCid!).symbol)),
                     ],
                   ),
-                  onPressed: () => Navigator.pushNamed(context, ExerciseSwapPage.route, arguments: mockAssetSwap(widget.store.encointer.chosenCid!)),
+                  onPressed: () => Navigator.pushNamed(context, ExerciseSwapPage.route,
+                      arguments: mockAssetSwap(widget.store.encointer.chosenCid!)),
                 ),
               if (nativeSwap != null)
                 ElevatedButton(


### PR DESCRIPTION
The mock swaps are no longer using the same state as the real swaps. They are simply additional buttons shown if they are enabled.