### PR TITLE
[CI] run encointer-node in separate linux workflow and expose is to device tests

### DIFF
--- a/.github/workflows/ios_integration_test.yml
+++ b/.github/workflows/ios_integration_test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   ios_device_test:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     strategy:
       matrix:
@@ -85,19 +85,7 @@ jobs:
       - name: Melos Bootstrap
         run: .flutter/bin/dart run melos bootstrap
 
-      - name: Start colima a docker runtime for MacOs
-        # The brew install returns exit code 1 for a non-fatal dependency linker error.
-        # We don't care, the subsequent steps will work still.
-        run: |
-          brew install docker || true
-          brew install colima || true
-          colima start
-
-      - name: Run encointer-node
-        run: ./scripts/docker_run_encointer_node_notee.sh ${{ matrix.docker_tag }} &
-
-      - name: Bootstrap Demo Community
-        run: ./scripts/docker_run_encointer_client_bootstrap_demo_community.sh --docker-tag=${{ matrix.docker_tag }}
+      - uses: ./.github/workflows/encointer-node.yml
 
       - name: "Start Simulator"
         working-directory: ./scripts

--- a/.github/workflows/run-encointer-node.yml
+++ b/.github/workflows/run-encointer-node.yml
@@ -1,0 +1,35 @@
+on:
+  workflow_call:
+    inputs:
+      docker_tag:
+        required: true
+        type: string
+    outputs:
+      ws_endpoint:
+        value: ${{ jobs.node.outputs.ws }}
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    outputs:
+      ws: ${{ steps.export.outputs.ws }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run encointer-node
+        run: ./scripts/docker_run_encointer_node_notee.sh ${{ matrix.docker_tag }} &
+
+      - run: ./scripts/docker_run_encointer_client_bootstrap_demo_community.sh \
+             --docker-tag=${{ inputs.docker_tag }}
+
+      - run: |
+          curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+            -o cloudflared
+          chmod +x cloudflared
+          ./cloudflared tunnel --url http://localhost:9944 > tunnel.log 2>&1 &
+          sleep 10
+
+      - id: export
+        run: |
+          URL=$(grep -o 'https://[^ ]*trycloudflare.com' tunnel.log | head -n1)
+          echo "ws=${URL/https:/wss:}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This should fix our long-lasting issue of broken docker in MacOs workflows. Closes #1901.