### PR TITLE
[txHistory] Fix: use 24h format in Fmt.dateTime()

### DIFF
--- a/app/lib/utils/format.dart
+++ b/app/lib/utils/format.dart
@@ -18,7 +18,7 @@ class Fmt {
   }
 
   static String dateTime(DateTime time) {
-    return DateFormat('yyyy-MM-dd hh:mm').format(time);
+    return DateFormat('yyyy-MM-dd HH:mm').format(time);
   }
 
   static String hhmmss(int seconds) {

--- a/app/test/utils/format_test.dart
+++ b/app/test/utils/format_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:encointer_wallet/utils/format.dart';
+
+void main() {
+  group('Fmt.dateTime', () {
+    test('formats afternoon time in 24h format', () {
+      final dt = DateTime(2024, 3, 30, 15, 13);
+      expect(Fmt.dateTime(dt), '2024-03-30 15:13');
+    });
+
+    test('formats morning time with leading zero', () {
+      final dt = DateTime(2024, 3, 30, 9, 5);
+      expect(Fmt.dateTime(dt), '2024-03-30 09:05');
+    });
+
+    test('formats midnight correctly', () {
+      final dt = DateTime(2024, 3, 30);
+      expect(Fmt.dateTime(dt), '2024-03-30 00:00');
+    });
+  });
+}


### PR DESCRIPTION
  ## Summary
  - `Fmt.dateTime()` used `hh` (12-hour) without am/pm, so PM times like 15:13 rendered as "03:13"
  - Switch to `HH` (24-hour, 00–23)
  - Add unit tests for afternoon, morning, and midnight formatting

Closes #1950