### PR TITLE
feat: show owner/delegate indicator on bazaar business cards (#1930)

### DIFF
--- a/app/lib/page-encointer/bazaar/bazaar_main.dart
+++ b/app/lib/page-encointer/bazaar/bazaar_main.dart
@@ -32,9 +32,10 @@ class _BazaarPageState extends State<BazaarPage> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final cid = context.read<AppStore>().encointer.community?.cid;
+      final store = context.read<AppStore>();
+      final cid = store.encointer.community?.cid;
       if (cid != null) {
-        await context.read<BusinessesStore>().getBusinesses(cid);
+        await context.read<BusinessesStore>().getBusinesses(cid, store.account.currentAddress);
       } else {
         AppAlert.showErrorDialog(
           context,

--- a/app/lib/page-encointer/bazaar/businesses/logic/businesses_store.g.dart
+++ b/app/lib/page-encointer/bazaar/businesses/logic/businesses_store.g.dart
@@ -69,11 +69,26 @@ mixin _$BusinessesStore on _BusinessesStoreBase, Store {
     });
   }
 
+  late final _$delegateOfControllersAtom = Atom(name: '_BusinessesStoreBase.delegateOfControllers', context: context);
+
+  @override
+  Set<String> get delegateOfControllers {
+    _$delegateOfControllersAtom.reportRead();
+    return super.delegateOfControllers;
+  }
+
+  @override
+  set delegateOfControllers(Set<String> value) {
+    _$delegateOfControllersAtom.reportWrite(value, super.delegateOfControllers, () {
+      super.delegateOfControllers = value;
+    });
+  }
+
   late final _$getBusinessesAsyncAction = AsyncAction('_BusinessesStoreBase.getBusinesses', context: context);
 
   @override
-  Future<void> getBusinesses(CommunityIdentifier cid) {
-    return _$getBusinessesAsyncAction.run(() => super.getBusinesses(cid));
+  Future<void> getBusinesses(CommunityIdentifier cid, String currentAddress) {
+    return _$getBusinessesAsyncAction.run(() => super.getBusinesses(cid, currentAddress));
   }
 
   late final _$_BusinessesStoreBaseActionController = ActionController(name: '_BusinessesStoreBase', context: context);
@@ -95,7 +110,8 @@ mixin _$BusinessesStore on _BusinessesStoreBase, Store {
 businesses: ${businesses},
 sortedBusinesses: ${sortedBusinesses},
 fetchStatus: ${fetchStatus},
-error: ${error}
+error: ${error},
+delegateOfControllers: ${delegateOfControllers}
     ''';
   }
 }

--- a/app/lib/page-encointer/bazaar/businesses/widgets/business_card.dart
+++ b/app/lib/page-encointer/bazaar/businesses/widgets/business_card.dart
@@ -1,4 +1,5 @@
 import 'package:encointer_wallet/page-encointer/bazaar/businesses/view/ipfs_image.dart';
+import 'package:encointer_wallet/page-encointer/bazaar/businesses/logic/businesses_store.dart';
 import 'package:encointer_wallet/page-encointer/democracy/proposal_page/helpers.dart';
 import 'package:encointer_wallet/page-encointer/democracy/proposal_page/propose_page.dart';
 import 'package:encointer_wallet/service/service.dart';
@@ -22,7 +23,11 @@ class BusinessCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final store = context.read<AppStore>();
     final currentAddress = store.account.currentAddress;
+    final businessesStore = context.read<BusinessesStore>();
     // const currentAddress = '5C6xA6UDoGYnYM5o4wAfWMUHLL2dZLEDwAAFep11kcU9oiQK';
+
+    final isOwner = AddressUtils.areEqual(business.controller!, currentAddress);
+    final isDelegate = !isOwner && businessesStore.delegateOfControllers.contains(business.controller);
 
     return InkWell(
       borderRadius: BorderRadius.circular(16),
@@ -66,7 +71,7 @@ class BusinessCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Category + Status
+                    // Category + Status + Role
                     Row(
                       children: [
                         Expanded(
@@ -76,6 +81,13 @@ class BusinessCard extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                        if (isOwner || isDelegate)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 6),
+                            child: _RoleChip(
+                              label: isOwner ? context.l10n.businessOwner : context.l10n.businessDelegate,
+                            ),
+                          ),
                         Text(
                           business.status?.name ?? '',
                           style: context.bodySmall.copyWith(
@@ -106,7 +118,7 @@ class BusinessCard extends StatelessWidget {
                     ),
 
                     // Button (compact)
-                    if (AddressUtils.areEqual(business.controller!, currentAddress))
+                    if (isOwner || isDelegate)
                       Padding(
                         padding: const EdgeInsets.only(top: 10),
                         child: Align(
@@ -133,6 +145,30 @@ class BusinessCard extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoleChip extends StatelessWidget {
+  const _RoleChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: context.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: context.bodySmall.copyWith(
+          color: context.colorScheme.onPrimaryContainer,
+          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/app/test/mock/api/mock_encointer_api.dart
+++ b/app/test/mock/api/mock_encointer_api.dart
@@ -8,6 +8,8 @@ import 'package:encointer_wallet/models/encointer_balance_data/balance_entry.dar
 import 'package:ew_log/ew_log.dart';
 import 'package:encointer_wallet/service/substrate_api/encointer/encointer_api.dart';
 import 'package:ew_polkadart/ew_polkadart.dart' show BlockHash;
+import 'package:ew_polkadart/encointer_types.dart' as et;
+import 'package:ew_polkadart/generated/encointer_kusama/types/sp_core/crypto/account_id32.dart';
 
 import '../data/mock_encointer_data.dart';
 import 'mock_substrate_dart_api.dart';
@@ -137,6 +139,11 @@ class MockEncointerApi extends EncointerApi {
   @override
   Future<int> getNumberOfNewbieTicketsForReputable({BlockHash? at}) {
     return Future.value(0);
+  }
+
+  @override
+  Future<List<et.ProxyDefinition>> getProxyAccounts(AccountId32 accountId, {BlockHash? at}) async {
+    return [];
   }
 
   @override

--- a/app/test/store/bazaar/businesses_store_test.dart
+++ b/app/test/store/bazaar/businesses_store_test.dart
@@ -25,7 +25,7 @@ void main() {
       expect(businessesStore.fetchStatus, FetchStatus.loading);
       expect(businessesStore.sortedBusinesses, isEmpty);
 
-      await businessesStore.getBusinesses(cid);
+      await businessesStore.getBusinesses(cid, '');
 
       expect(businessesStore.fetchStatus, FetchStatus.success);
       expect(businessesStore.sortedBusinesses, isNotEmpty);
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('`getBusinesses()` should filter businesses by category', () async {
-      await businessesStore.getBusinesses(cid);
+      await businessesStore.getBusinesses(cid, '');
 
       expect(businessesStore.sortedBusinesses, isNotNull);
       expect(businessesStore.sortedBusinesses.every((business) => business.category == Category.food), isTrue);

--- a/l10n/lib/src/arb/app_de.arb
+++ b/l10n/lib/src/arb/app_de.arb
@@ -15,6 +15,8 @@
     "accountShare": "Konto teilen",
     "addAccount": "Konto hinzufügen",
     "addBusiness": "Geschäft hinzufügen",
+    "businessDelegate": "Delegierter",
+    "businessOwner": "Inhaber",
     "addContact": "Kontakt hinzufügen",
     "addInvoiceQrToAddress": "QR-Rechnung zu Adresse hinzufügen",
     "address": "Adresse",

--- a/l10n/lib/src/arb/app_en.arb
+++ b/l10n/lib/src/arb/app_en.arb
@@ -15,6 +15,8 @@
     "accountShare": "Share Account",
     "addAccount": "Add account",
     "addBusiness": "Add business",
+    "businessDelegate": "Delegate",
+    "businessOwner": "Owner",
     "addContact": "Add contact",
     "addInvoiceQrToAddress": "Add QR-invoice to Address",
     "address": "Address",

--- a/l10n/lib/src/arb/app_fr.arb
+++ b/l10n/lib/src/arb/app_fr.arb
@@ -15,6 +15,8 @@
     "accountShare": "Partager son compte",
     "addAccount": "Ajouter un compte",
     "addBusiness": "Ajouter une entreprise",
+    "businessDelegate": "Délégué",
+    "businessOwner": "Propriétaire",
     "addContact": "ajouter un contact",
     "addInvoiceQrToAddress": "Ajouter le code QR de la facture à l'adresse",
     "address": "Adresse",

--- a/l10n/lib/src/arb/app_ru.arb
+++ b/l10n/lib/src/arb/app_ru.arb
@@ -15,6 +15,8 @@
     "accountShare": "Поделиться аккаунтом",
     "addAccount": "Добавить аккаунт",
     "addBusiness": "Добавить бизнес",
+    "businessDelegate": "Делегат",
+    "businessOwner": "Владелец",
     "addContact": "Добавить контакт",
     "addInvoiceQrToAddress": "Добавить QR-инвойс к адресу",
     "address": "Адрес",

--- a/l10n/lib/src/arb/app_sw.arb
+++ b/l10n/lib/src/arb/app_sw.arb
@@ -15,6 +15,8 @@
     "accountShare": "Shea akaunti",
     "addAccount": "Ongeza akaunti",
     "addBusiness": "Ongeza biashara",
+    "businessDelegate": "Mjumbe",
+    "businessOwner": "Mmiliki",
     "addContact": "Ongeza mawasiliano",
     "addInvoiceQrToAddress": "Ongeza QR-invoice kwenye anuani",
     "address": "Anuani",

--- a/l10n/lib/src/gen/app_localizations.dart
+++ b/l10n/lib/src/gen/app_localizations.dart
@@ -194,6 +194,18 @@ abstract class AppLocalizations {
   /// **'Add business'**
   String get addBusiness;
 
+  /// No description provided for @businessDelegate.
+  ///
+  /// In en, this message translates to:
+  /// **'Delegate'**
+  String get businessDelegate;
+
+  /// No description provided for @businessOwner.
+  ///
+  /// In en, this message translates to:
+  /// **'Owner'**
+  String get businessOwner;
+
   /// No description provided for @addContact.
   ///
   /// In en, this message translates to:

--- a/l10n/lib/src/gen/app_localizations_de.dart
+++ b/l10n/lib/src/gen/app_localizations_de.dart
@@ -57,6 +57,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get addBusiness => 'Geschäft hinzufügen';
 
   @override
+  String get businessDelegate => 'Delegierter';
+
+  @override
+  String get businessOwner => 'Inhaber';
+
+  @override
   String get addContact => 'Kontakt hinzufügen';
 
   @override

--- a/l10n/lib/src/gen/app_localizations_en.dart
+++ b/l10n/lib/src/gen/app_localizations_en.dart
@@ -55,6 +55,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get addBusiness => 'Add business';
 
   @override
+  String get businessDelegate => 'Delegate';
+
+  @override
+  String get businessOwner => 'Owner';
+
+  @override
   String get addContact => 'Add contact';
 
   @override

--- a/l10n/lib/src/gen/app_localizations_fr.dart
+++ b/l10n/lib/src/gen/app_localizations_fr.dart
@@ -56,6 +56,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addBusiness => 'Ajouter une entreprise';
 
   @override
+  String get businessDelegate => 'Délégué';
+
+  @override
+  String get businessOwner => 'Propriétaire';
+
+  @override
   String get addContact => 'ajouter un contact';
 
   @override

--- a/l10n/lib/src/gen/app_localizations_ru.dart
+++ b/l10n/lib/src/gen/app_localizations_ru.dart
@@ -55,6 +55,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get addBusiness => 'Добавить бизнес';
 
   @override
+  String get businessDelegate => 'Делегат';
+
+  @override
+  String get businessOwner => 'Владелец';
+
+  @override
   String get addContact => 'Добавить контакт';
 
   @override

--- a/l10n/lib/src/gen/app_localizations_sw.dart
+++ b/l10n/lib/src/gen/app_localizations_sw.dart
@@ -55,6 +55,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get addBusiness => 'Ongeza biashara';
 
   @override
+  String get businessDelegate => 'Mjumbe';
+
+  @override
+  String get businessOwner => 'Mmiliki';
+
+  @override
   String get addContact => 'Ongeza mawasiliano';
 
   @override


### PR DESCRIPTION
Precompute per-controller delegate status via proxy queries in BusinessesStore, then display a role chip (Owner/Delegate) on each business card. Also extends the Swap Option button to delegates.

Tested with a LEU test account and it works: 
<img width="482" height="1028" alt="image" src="https://github.com/user-attachments/assets/bcc6e464-f768-43d7-a76a-c183d5567372" />
