### PR TITLE
propagate update to flutter 3.38

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 
 ## Architecture
 
-**Monorepo** managed by Melos. Flutter 3.35.0, Dart >=3.6.0. Flutter SDK lives in `.flutter/` git submodule.
+**Monorepo** managed by Melos. Flutter 3.38.5, Dart >=3.6.0. Flutter SDK lives in `.flutter/` git submodule.
 
 ### Workspace layout
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -22,7 +22,7 @@ resolution: workspace
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: "3.35.0"
+  flutter: "3.38.5"
 
 dependencies:
   collection: ^1.19.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2302,4 +2302,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ workspace:
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: "3.35.0"
+  flutter: "3.38.5"
 
 dev_dependencies:
   build_runner: ^2.4.7


### PR DESCRIPTION
We implicitly upgrade the `.flutter` submodule to 3.38 a while ago, but this was incorrectly propagated to the version constraints, which means that the CI and the release process were still done with 3.35.