### PR TITLE
fix: fetch balance immediately after first account import (#1978)

### DIFF
--- a/app/lib/store/encointer/encointer.dart
+++ b/app/lib/store/encointer/encointer.dart
@@ -280,6 +280,8 @@ abstract class _EncointerStore with Store {
     // update depending values without awaiting
     if (!_rootStore.settings.loading) {
       webApi.encointer.getCommunityData();
+      unawaited(getEncointerBalance());
+      unawaited(updateAggregatedAccountData());
     }
   }
 
@@ -378,6 +380,7 @@ abstract class _EncointerStore with Store {
 
     if (currentAddress.isEmpty || chosenCid == null) {
       Log.d('[getEncointerBalance] address empty or chosenCid == null', 'EncointerStore');
+      return;
     }
 
     final balanceEntry = await webApi.encointer.getEncointerBalance(currentAddress, chosenCid!);


### PR DESCRIPTION
During first-time import, setCurrentAccount() calls setInvalidated() before chosenCid is set. The reaction fires updateState() which crashes on chosenCid! null assertion, then resets invalidated=false. When setChosenCid() runs later it never re-triggers a balance fetch, so the user waits 2 minutes for the next periodic update.

Fix: add early return in getEncointerBalance() when chosenCid is null, and fetch balance + aggregated account data in setChosenCid().


Closes #1978 