### PR TITLE
fix(ci): poll for Cloudflare tunnel URL instead of fixed sleep

### DIFF
--- a/.github/workflows/device_ci_proxy.yml
+++ b/.github/workflows/device_ci_proxy.yml
@@ -46,7 +46,22 @@ jobs:
           curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o cloudflared
           chmod +x cloudflared
           ./cloudflared tunnel --url http://localhost:9944 > tunnel.log 2>&1 &
-          sleep 5
+
+          echo "Waiting for WS tunnel URL (up to 60s)..."
+          for i in $(seq 1 60); do
+            WS_URL=$(grep -o 'https://[^ ]*trycloudflare.com' tunnel.log 2>/dev/null | head -n1 || true)
+            if [ -n "$WS_URL" ]; then
+              echo "WS tunnel ready after ${i}s: $WS_URL"
+              break
+            fi
+            sleep 1
+          done
+
+          if [ -z "$WS_URL" ]; then
+            echo "::error::WS tunnel not ready after 60s"
+            cat tunnel.log
+            exit 1
+          fi
 
       - name: Verify Cloudflare tunnel health
         run: ./scripts/check_cloudflare_tunnel.sh
@@ -82,7 +97,7 @@ jobs:
           INTERVAL=30
           ELAPSED=0
 
-          while [ $ELAPSED -lt $((MAX_MINUTES * 45)) ]; do
+          while [ $ELAPSED -lt $((MAX_MINUTES * 60)) ]; do
             if ./scripts/check_cloudflare_tunnel.sh; then
               echo "✅ Tunnel is healthy (checked at $ELAPSED seconds)"
             else

--- a/scripts/check_cloudflare_tunnel.sh
+++ b/scripts/check_cloudflare_tunnel.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
-# Extract the tunnel host
-HTTP_URL=$(grep -o 'https://[^ ]*trycloudflare.com' tunnel.log | head -n1)
+# Extract the tunnel host (retry for up to 30s in case log is still being written)
+HTTP_URL=""
+for i in $(seq 1 30); do
+  HTTP_URL=$(grep -o 'https://[^ ]*trycloudflare.com' tunnel.log 2>/dev/null | head -n1 || true)
+  if [ -n "$HTTP_URL" ]; then
+    break
+  fi
+  sleep 1
+done
 if [ -z "$HTTP_URL" ]; then
-  echo "❌ ERROR: Could not find tunnel URL in log"
+  echo "❌ ERROR: Could not find tunnel URL in log after 30s"
   exit 1
 fi
 
@@ -13,8 +20,10 @@ HOST=$(echo "$HTTP_URL" | sed -E 's|https://([^/]+).*|\1|')
 echo "🌍 Tunnel URL: $HTTP_URL"
 echo "🔎 Verifying tunnel is reachable…"
 
-echo "Installing deps"
-sudo apt-get install -y dnsutils
+if ! command -v getent &>/dev/null || ! command -v nc &>/dev/null; then
+  echo "Installing deps"
+  sudo apt-get install -y dnsutils
+fi
 
 # Retry helper
 retry_command() {


### PR DESCRIPTION
  ## Summary
  - Replace `sleep 5` with 60s polling loop for WS tunnel URL in `device_ci_proxy.yml`, matching the IPFS tunnel pattern
  - Add 30s retry to URL extraction in `check_cloudflare_tunnel.sh` for resilience during log writes
  - Fix monitoring loop duration bug (`MAX_MINUTES * 45` → `* 60`)
  - Guard `apt-get install` behind command existence check (avoids ~110 redundant apt calls in monitoring loop)

  ## Test plan
  - [x] Observe next Device CI run — tunnel should connect within seconds instead of failing at 5s
  - [ ] Verify infra-logs artifact captures tunnel.log for debugging any remaining issues

  Closes #1907